### PR TITLE
docs: 上游链接指向官方 deepseek-ai/deepseek-harness，plugin-upgrade 明确面向 0.1.1 → 0.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 DSH 插件生态的 **skill 合集仓库**，社区共建。
 
-[DSH（DeepSeek Harness）](https://github.com/LaplaceYoung/oh-my-dsh) 是"一切皆插件"的 agent harness。本仓库收集与 DSH 插件相关的各种 agent skill——升级、审计、迁移、开发脚手架……欢迎贡献。
+[DSH（DeepSeek Harness）](https://github.com/deepseek-ai/deepseek-harness) 是"一切皆插件"的 agent harness。本仓库收集与 DSH 插件相关的各种 agent skill——升级、审计、迁移、开发脚手架……欢迎贡献。官方也在这里征集定点升级类 skill（如 0.1.1 → 0.1.2），见 [discussions/5120](https://github.com/deepseek-ai/deepseek-harness/discussions/5120)。
 
 ## 目录结构
 
@@ -19,7 +19,7 @@ DSH 插件生态的 **skill 合集仓库**，社区共建。
 
 | Skill | 说明 |
 | --- | --- |
-| [plugin-upgrade](skills/plugin-upgrade/) | 升级 DSH 插件：盘点版本 → 评估 changelog → 迁移 cordis.yml → 执行升级 → 验证 |
+| [plugin-upgrade](skills/plugin-upgrade/) | 升级 DSH 插件（当前面向 0.1.1 → 0.1.2）：盘点版本 → 评估 changelog → 迁移 cordis.yml → 执行升级 → 验证 |
 
 ## 如何贡献
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -37,4 +37,4 @@ description: 一句话说明这个 skill 做什么、什么时候触发。agent 
 
 | Skill | 说明 | 作者 |
 | --- | --- | --- |
-| [plugin-upgrade](plugin-upgrade/) | 升级 DSH 插件：盘点版本 → 评估 changelog → 迁移 cordis.yml → 执行升级 → 验证 | [@oh-my-dsh](https://github.com/oh-my-dsh) |
+| [plugin-upgrade](plugin-upgrade/) | 升级 DSH 插件（当前面向 0.1.1 → 0.1.2）：盘点版本 → 评估 changelog → 迁移 cordis.yml → 执行升级 → 验证 | [@oh-my-dsh](https://github.com/oh-my-dsh) |

--- a/skills/plugin-upgrade/SKILL.md
+++ b/skills/plugin-upgrade/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: plugin-upgrade
-description: 升级 DSH（DeepSeek Harness）插件的 skill。当用户想检查已安装插件的更新、升级某个插件到新版、或处理插件升级带来的 breaking changes 时使用。
+description: 升级 DSH（DeepSeek Harness）插件的 skill，当前主要面向 0.1.1 → 0.1.2 这次升级。当用户想检查已安装插件的更新、升级某个插件到新版、或处理插件升级带来的 breaking changes 时使用。
 ---
 
 # plugin-upgrade
@@ -10,7 +10,7 @@ description: 升级 DSH（DeepSeek Harness）插件的 skill。当用户想检�
 ## 流程
 
 1. **盘点**：读取 `cordis.yml`，列出已挂载插件与本地版本，对照上游 registry / git 仓库找出可升级项
-2. **评估**：拉取目标版本的 changelog 与 release notes，总结 breaking changes，判断升级影响面
+2. **评估**：拉取目标版本的 changelog 与 release notes，总结 breaking changes，判断升级影响面；跨度超过一个版本时逐版本过 changelog，不要跳版
 3. **迁移**：manifest（`cordis.yml`）有变更时改写；配置项重命名/废弃时给出迁移建议
 4. **升级**：git pull / 包管理器升级；必要时按 changelog 指导修复接缝（seam）层面的 breaking changes
 5. **验证**：运行插件自带的测试 / typecheck / e2e 注册检查，确认插件在 DSH 中正常挂载
@@ -22,5 +22,6 @@ description: 升级 DSH（DeepSeek Harness）插件的 skill。当用户想检�
 
 ## 背景
 
-- 上游生态：[oh-my-dsh](https://github.com/LaplaceYoung/oh-my-dsh) —— DSH 的能力插件库
+- 上游生态：[deepseek-ai/deepseek-harness](https://github.com/deepseek-ai/deepseek-harness) —— DSH 官方仓库，版本相关的 breaking changes 与迁移指引以此处 release notes 为准
 - DSH 插件约定：ESM 包，经 `cordis.yml` 挂载，遵循 interface / implementation / consumer 三段式接缝
+- 本 skill 主要面向 0.1.1 → 0.1.2 这次升级，背景与出处见官方 [discussions/5120](https://github.com/deepseek-ai/deepseek-harness/discussions/5120)


### PR DESCRIPTION
## 背景

官方正在 [deepseek-ai/deepseek-harness discussions/5120](https://github.com/deepseek-ai/deepseek-harness/discussions/5120) 征集"插件从 0.1.1 升级到 0.1.2"方向的 skill，本 PR 对仓库现有内容做了对应的对齐。

## 改动

- **README.md / skills/plugin-upgrade/SKILL.md**：DSH 与上游生态的链接由 `LaplaceYoung/oh-my-dsh` 更新为官方仓库 `deepseek-ai/deepseek-harness`，breaking changes 与迁移指引以官方 release notes 为准
- **skill 定位收紧**：`plugin-upgrade` 的说明（含 frontmatter `description`）明确当前主要面向 **0.1.1 → 0.1.2** 这次升级，并在背景中链接官方征集帖
- **SKILL.md 评估步骤**：补充跨版本升级时逐版本过 changelog、不要跳版的指引

## 未改动

- skill 的五步流程（盘点 → 评估 → 迁移 → 升级 → 验证）、编写规范与贡献流程均保持原样
