### PR TITLE
fix(plugin-upgrade): harden workflows and migration validation

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,18 @@
+name: validate
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: node scripts/validate.mjs

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 oh-my-dsh contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,33 +1,56 @@
 # dsh-plugin-upgrade-skill
 
-DSH 插件生态的 **skill 合集仓库**，社区共建。
+DSH 插件生态的 **Skill 合集仓库**，社区共建。
 
-[DSH（DeepSeek Harness）](https://github.com/LaplaceYoung/oh-my-dsh) 是"一切皆插件"的 agent harness。本仓库收集与 DSH 插件相关的各种 agent skill——升级、审计、迁移、开发脚手架……欢迎贡献。
-
-## 目录结构
-
-```
-.
-├── README.md          # 本文件：仓库总览与贡献指南
-└── skills/            # 所有 skill 都在这个目录下
-    ├── README.md      # skill 编写规范与收录清单
-    └── <skill-name>/  # 一个 skill 一个文件夹
-        └── SKILL.md   # skill 主体（必须）
-```
+[DSH（DeepSeek Harness）](https://github.com/deepseek-ai/deepseek-harness) 是
+“Everything is a Plugin”的 agent harness；[oh-my-dsh](https://github.com/LaplaceYoung/oh-my-dsh)
+是面向 DSH 的社区插件生态。本仓库收集插件升级、审计、迁移和开发相关 Skill。
 
 ## Skill 索引
 
 | Skill | 说明 |
-| --- | --- |
-| [plugin-upgrade](skills/plugin-upgrade/) | 升级 DSH 插件：盘点版本 → 评估 changelog → 迁移 cordis.yml → 执行升级 → 验证；含宿主版本迁移分支（触点自查 + 版本变更卡片，见 references/） |
+|---|---|
+| [plugin-upgrade](skills/plugin-upgrade/) | 三模式安全升级：只读检查、已安装插件升级、DSH 宿主兼容迁移；含七类触点、版本卡片与回滚约束 |
 
-## 如何贡献
+## 安装与触发
 
-1. 在 `skills/` 下新建文件夹，kebab-case 命名（如 `plugin-audit`）
-2. 按 [skills/README.md](skills/README.md) 的规范编写 `SKILL.md`
-3. 在 `skills/README.md` 的清单表格里登记你的 skill
-4. 提 PR
+项目级使用可把 `skills/plugin-upgrade/` 复制到：
+
+```text
+<your-project>/.agents/skills/plugin-upgrade/
+```
+
+也可以让 DSH 本地 Skill provider 直接加载本仓库的 `skills/` 根目录。确认目录中保留
+`SKILL.md` 与 `references/`，不要只复制主文件。
+
+示例请求：
+
+- `只读检查这个 DSH 插件有没有新版本，不要修改任何文件。`
+- `把已安装插件升级到 1.4.0，先给计划，确认后再执行。`
+- `把这个插件从 dsh-v0.1.1-rc.2 适配到 dsh-v0.1.2-alpha.2。`
+
+## 目录
+
+```text
+skills/<skill-name>/
+├── SKILL.md
+├── references/     # 按需加载的版本事实与清单
+└── examples/       # 静态夹具，不默认执行
+scripts/validate.mjs
+```
+
+## 贡献与验证
+
+1. 按 [skills/README.md](skills/README.md) 编写或更新 Skill；
+2. 版本卡遵循 [card schema](skills/plugin-upgrade/references/README.md)；
+3. 运行：
+
+```sh
+node scripts/validate.mjs
+```
+
+4. 提 PR，并说明已运行的验证。
 
 ## License
 
-MIT
+[MIT](LICENSE)

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "dsh-plugin-upgrade-skill",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node scripts/validate.mjs",
+    "validate": "node scripts/validate.mjs"
+  }
+}

--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -1,0 +1,186 @@
+import { existsSync } from 'node:fs'
+import { readFile, readdir } from 'node:fs/promises'
+import { basename, dirname, join, relative, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const failures = []
+const fail = (file, message) => failures.push(`${relative(root, file).replaceAll('\\', '/')}: ${message}`)
+
+async function walk(directory) {
+  const files = []
+  for (const entry of await readdir(directory, { withFileTypes: true })) {
+    if (entry.name === '.git' || entry.name === 'node_modules') continue
+    const path = join(directory, entry.name)
+    if (entry.isDirectory()) files.push(...(await walk(path)))
+    else files.push(path)
+  }
+  return files
+}
+
+function parseFrontmatter(text, file, required = true) {
+  const normalized = text.replaceAll('\r\n', '\n')
+  if (!normalized.startsWith('---\n')) {
+    if (required) fail(file, 'missing YAML frontmatter')
+    return { meta: {}, body: normalized }
+  }
+  const end = normalized.indexOf('\n---\n', 4)
+  if (end < 0) {
+    fail(file, 'unterminated YAML frontmatter')
+    return { meta: {}, body: normalized }
+  }
+  const meta = {}
+  for (const line of normalized.slice(4, end).split('\n')) {
+    if (!line.trim()) continue
+    const match = /^([A-Za-z][A-Za-z0-9-]*):\s*(.*)$/.exec(line)
+    if (!match) {
+      fail(file, `unsupported frontmatter line: ${line}`)
+      continue
+    }
+    const [, key, raw] = match
+    const value = raw.replace(/^['"]|['"]$/g, '')
+    meta[key] = /^\d+$/.test(value) ? Number(value) : value
+  }
+  return { meta, body: normalized.slice(end + 5) }
+}
+
+const allFiles = await walk(root)
+const markdownFiles = allFiles.filter((file) => file.endsWith('.md'))
+
+// Skill frontmatter and directory ownership.
+const skillsRoot = join(root, 'skills')
+const skillEntries = (await readdir(skillsRoot, { withFileTypes: true })).filter((entry) => entry.isDirectory())
+for (const entry of skillEntries) {
+  const file = join(skillsRoot, entry.name, 'SKILL.md')
+  if (!existsSync(file)) {
+    fail(file, 'missing SKILL.md')
+    continue
+  }
+  const { meta } = parseFrontmatter(await readFile(file, 'utf8'), file)
+  if (meta.name !== entry.name) fail(file, `name must equal directory (${entry.name})`)
+  if (typeof meta.description !== 'string' || meta.description.trim().length < 20) {
+    fail(file, 'description must state a concrete trigger')
+  }
+}
+
+// Repository-relative Markdown links; external links are deliberately not network-gated.
+for (const file of markdownFiles) {
+  const text = await readFile(file, 'utf8')
+  const links = text.matchAll(/\[[^\]]*\]\(([^)]+)\)/g)
+  for (const match of links) {
+    let target = match[1].trim().replace(/^<|>$/g, '')
+    if (/^(https?:|mailto:|#)/.test(target)) continue
+    target = target.split('#', 1)[0].split('?', 1)[0]
+    if (!target) continue
+    if (!existsSync(resolve(dirname(file), target))) fail(file, `broken relative link: ${match[1]}`)
+  }
+}
+
+// Version-card schema, IDs and directed corridor metadata.
+const referencesDir = join(root, 'skills', 'plugin-upgrade', 'references')
+const cardFiles = (await readdir(referencesDir))
+  .filter((name) => /^v.*\.md$/.test(name))
+  .map((name) => join(referencesDir, name))
+const requiredMeta = ['kind', 'schema', 'from', 'to', 'status', 'coverage', 'cardCount', 'idPrefix', 'verifiedAt']
+const requiredFields = ['类型', '适用对象', '影响触点', '操作级别', '症状', '迁移配方', '验证', '来源']
+const allowedTypes = new Set(['breaking', 'behavior', 'capability', 'fix', 'security', 'privacy'])
+const allowedActions = /^(required|conditional|optional|informational|required-if-[A-Za-z0-9.-]+)$/
+const tag = /^dsh-v\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/
+const allCardIds = new Set()
+const edges = new Map()
+let totalCards = 0
+const indexText = await readFile(join(referencesDir, 'README.md'), 'utf8')
+
+for (const file of cardFiles) {
+  const text = await readFile(file, 'utf8')
+  const { meta, body } = parseFrontmatter(text, file)
+  for (const key of requiredMeta) if (meta[key] === undefined || meta[key] === '') fail(file, `missing metadata: ${key}`)
+  if (meta.kind !== 'dsh-version-card-set') fail(file, 'kind must be dsh-version-card-set')
+  if (meta.schema !== 1) fail(file, 'schema must be 1')
+  if (!tag.test(String(meta.from))) fail(file, `invalid from tag: ${meta.from}`)
+  if (!tag.test(String(meta.to))) fail(file, `invalid to tag: ${meta.to}`)
+  if (meta.from === meta.to) fail(file, 'from and to must differ')
+  if (!['draft', 'reviewed'].includes(meta.status)) fail(file, `invalid status: ${meta.status}`)
+  if (!['curated', 'complete'].includes(meta.coverage)) fail(file, `invalid coverage: ${meta.coverage}`)
+  if (edges.has(meta.from)) fail(file, `duplicate corridor edge from ${meta.from}`)
+  edges.set(meta.from, meta.to)
+
+  const headings = [...body.matchAll(/^###\s+([A-Za-z0-9.-]+)\s+·\s+.+$/gm)]
+  if (headings.length !== meta.cardCount) fail(file, `cardCount=${meta.cardCount}, found ${headings.length}`)
+  if (!indexText.includes(`](${basename(file)})`) || !indexText.includes(`| ${meta.cardCount} |`)) {
+    fail(file, 'version index is missing this file or its card count')
+  }
+
+  for (let index = 0; index < headings.length; index += 1) {
+    const heading = headings[index]
+    const id = heading[1]
+    const end = headings[index + 1]?.index ?? body.length
+    const card = body.slice(heading.index, end)
+    if (!id.startsWith(`${meta.idPrefix}-`)) fail(file, `${id} does not match idPrefix ${meta.idPrefix}`)
+    if (allCardIds.has(id)) fail(file, `duplicate card ID: ${id}`)
+    allCardIds.add(id)
+    totalCards += 1
+
+    for (const field of requiredFields) {
+      if (!new RegExp(`^- \\*\\*${field}\\*\\*:`, 'm').test(card)) fail(file, `${id} missing field: ${field}`)
+    }
+    const type = /^- \*\*类型\*\*:\s*([^\r\n]+)/m.exec(card)?.[1]?.trim()
+    const action = /^- \*\*操作级别\*\*:\s*([^\r\n]+)/m.exec(card)?.[1]?.trim()
+    if (!allowedTypes.has(type)) fail(file, `${id} invalid type: ${type}`)
+    if (!allowedActions.test(action ?? '')) fail(file, `${id} invalid action: ${action}`)
+    if (!/^- \*\*来源\*\*:[\s\S]*?https:\/\//m.test(card)) fail(file, `${id} must cite a primary URL`)
+  }
+}
+
+// Corridor edges must not cycle.
+for (const start of edges.keys()) {
+  const seen = new Set()
+  let cursor = start
+  while (edges.has(cursor)) {
+    if (seen.has(cursor)) {
+      fail(join(referencesDir, 'README.md'), `version corridor cycle at ${cursor}`)
+      break
+    }
+    seen.add(cursor)
+    cursor = edges.get(cursor)
+  }
+}
+
+// Every full card reference in Markdown must resolve to a defined ID.
+for (const file of markdownFiles) {
+  const text = await readFile(file, 'utf8')
+  for (const match of text.matchAll(/\bDSH-\d+\.\d+\.\d+-A\d+-\d{2}\b/g)) {
+    if (!allCardIds.has(match[0])) fail(file, `unknown card reference: ${match[0]}`)
+  }
+}
+
+// Executable pre-flight patterns must be valid and hit the static fixture.
+const patternFile = join(referencesDir, 'pre-flight-patterns.json')
+const patternData = JSON.parse(await readFile(patternFile, 'utf8'))
+if (patternData.schema !== 1) fail(patternFile, 'schema must be 1')
+const ids = patternData.classes.map((entry) => entry.id)
+if (new Set(ids).size !== 7 || ![1, 2, 3, 4, 5, 6, 7].every((id) => ids.includes(id))) {
+  fail(patternFile, 'touchpoint IDs must be exactly 1..7')
+}
+const fixtureRoot = join(root, 'skills', 'plugin-upgrade', 'examples', 'legacy-plugin')
+const fixtureFiles = (await walk(fixtureRoot)).filter((file) => basename(file) !== 'README.md')
+const fixtureText = (await Promise.all(fixtureFiles.map((file) => readFile(file, 'utf8')))).join('\n')
+for (const entry of patternData.classes) {
+  let hit = false
+  for (const source of entry.patterns) {
+    try {
+      if (new RegExp(source, 'm').test(fixtureText)) hit = true
+    } catch (error) {
+      fail(patternFile, `#${entry.id} invalid regex ${source}: ${error.message}`)
+    }
+  }
+  if (!hit) fail(patternFile, `#${entry.id} has no fixture hit`)
+}
+
+if (failures.length) {
+  console.error(`Validation failed (${failures.length}):`)
+  for (const failure of failures) console.error(`- ${failure}`)
+  process.exit(1)
+}
+
+console.log(`Validation OK: ${skillEntries.length} skill, ${cardFiles.length} card sets, ${totalCards} cards, ${markdownFiles.length} Markdown files, 7 touchpoint fixtures`)

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,40 +1,37 @@
 # skills/
 
-所有 skill 都放这里。**一个 skill 一个文件夹**，文件夹名用 kebab-case，见名知意。
+所有 Skill 都放在这里。**一个 Skill 一个文件夹**，文件夹名使用 kebab-case。
 
 ## 编写规范
 
-每个 skill 文件夹至少包含一个 `SKILL.md`：
-
-```
+```text
 skills/<skill-name>/
-├── SKILL.md          # 必须。skill 主体
-├── scripts/          # 可选。skill 可调用的脚本
-├── references/       # 可选。参考文档，按需加载
-└── examples/         # 可选。示例
+├── SKILL.md          # 必需：触发描述与决策流程
+├── scripts/          # 可选：Skill 自有脚本
+├── references/       # 可选：按需加载的详细事实
+└── examples/         # 可选：静态示例/夹具
 ```
 
-`SKILL.md` 格式：
+`SKILL.md` 至少包含：
 
 ```markdown
 ---
-name: skill-name          # 与文件夹名一致
-description: 一句话说明这个 skill 做什么、什么时候触发。agent 靠它决定何时加载，写清楚触发场景。
+name: skill-name
+description: 一句话说明做什么、何时触发，以及重要的只读/写入边界。
 ---
-
-# 标题
-
-（正文：skill 的具体指令、流程、注意事项）
 ```
 
-注意：
+要求：
 
-- `description` 是最重要的字段——它决定 agent 什么时候会用到这个 skill，务必写清触发场景
-- 正文保持精简，详细参考材料放 `references/` 按需引用，不要一次性全塞进 `SKILL.md`
-- skill 聚焦单一职责；一个 skill 做太多事就拆成多个
+- `name` 与文件夹名一致；
+- `description` 同时说明操作和触发场景；
+- 主文件只保留决策流程，详细材料放 `references/`；
+- 一个 Skill 聚焦一项用户目标；同一目标有只读/写入模式时先显式分流；
+- 写操作必须先展示计划并取得确认；
+- 新增/修改后运行根目录 `node scripts/validate.mjs`。
 
 ## 收录清单
 
 | Skill | 说明 | 作者 |
-| --- | --- | --- |
-| [plugin-upgrade](plugin-upgrade/) | 升级 DSH 插件：盘点版本 → 评估 changelog → 迁移 cordis.yml → 执行升级 → 验证；含宿主版本迁移分支（触点自查 + 版本变更卡片） | [@oh-my-dsh](https://github.com/oh-my-dsh) |
+|---|---|---|
+| [plugin-upgrade](plugin-upgrade/) | 只读检查、已安装插件升级、宿主兼容迁移；七类触点 + 版本卡片 + 安全回滚 | [@oh-my-dsh](https://github.com/oh-my-dsh) |

--- a/skills/plugin-upgrade/SKILL.md
+++ b/skills/plugin-upgrade/SKILL.md
@@ -1,52 +1,107 @@
 ---
 name: plugin-upgrade
-description: 升级 DSH（DeepSeek Harness）插件的 skill。当用户想检查已安装插件的更新、升级某个插件到新版、处理插件升级带来的 breaking changes，或 DSH 宿主升级后需要适配插件源码时使用。
+description: 检查或升级已安装的 DSH（DeepSeek Harness）插件，或让插件源码适配新的 DSH 宿主版本。仅检查时保持只读；任何配置、依赖或源码写入前必须先展示计划并获得确认。
 ---
 
 # plugin-upgrade
 
-把已安装的 DSH 插件安全地升级到新版本：从检查更新、阅读 changelog，到迁移配置、验证升级结果。也覆盖「DSH 宿主升级后插件挂掉」的场景——用 [references/](references/) 里的版本变更卡片做源码级迁移。
+安全完成三类任务：只读更新检查、已安装插件升级、DSH 宿主版本兼容迁移。若用户意图
+不明确，先确认模式；不要从“帮我看看更新”自行滑入安装或改代码。
 
-## 流程
+## 第 0 步：选择模式
 
-1. **盘点**：读取 `cordis.yml`，列出已挂载插件与本地版本，对照上游 registry / git 仓库找出可升级项
-2. **评估**：拉取目标版本的 changelog 与 release notes，总结 breaking changes，判断升级影响面
-3. **迁移**：manifest（`cordis.yml`）有变更时改写；配置项重命名/废弃时给出迁移建议
-4. **升级**：git pull / 包管理器升级；必要时按 changelog 指导修复接缝（seam）层面的 breaking changes
-5. **验证**：运行插件自带的测试 / typecheck / e2e 注册检查，确认插件在 DSH 中正常挂载
+| 模式 | 用户意图 | 允许的默认动作 |
+|---|---|---|
+| A · inspect | 检查更新、判断是否受某版 DSH 影响 | 只读调查与报告；完成后停止 |
+| B · update | 把已安装插件升级到明确版本 | 先计划和确认，再改 composition/依赖 |
+| C · host-migrate | DSH 宿主升级后适配插件源码 | 先建版本走廊和触点清单，再计划和确认 |
 
-### 宿主版本迁移（插件随 DSH 升级适配）
+本 skill 不负责“只升级 DSH core 且不处理插件”；也不允许修改 DSH core 来掩盖插件兼容
+问题。
 
-当升级的是 **DSH 宿主本身**（如 0.1.1 → 0.1.2），或插件因宿主升级而挂载失败时，第 2–4 步改走本节：
+## 通用只读准备
 
-1. **定走廊**：确认 from → to 版本区间，按序取 `references/` 下的版本卡片；区间内有版本缺卡片时，先按 [references/README.md](references/README.md) 的格式补卡，**不要凭记忆猜变更**
-2. **测触点**：按 [pre-flight 清单](references/pre-flight.md) 把插件与宿主的接触面分成六类（源码 patch / 内部事件名 / 服务探测 / 文件读写 / UI·命令注册 / 子进程·stdout 解析）；六类全零命中 → 插件只经公共契约耦合，跑一遍烟测即可收工
-3. **套卡片**：只应用命中触点的卡片，一次迁一类；卡片没写的 API 不臆造，查不到的调用点标「待确认」；跨 alpha 版本存在字段波动（删了又恢复），走廊读完再删防御代码；`capability` 类卡片是机会不是义务，向用户建议、不自动应用
-4. **分层验证**：typecheck / build → 卡片级单测（如错误码分支）→ 真实冷启动 + 完整一轮对话（发消息 → 工具调用 → 回复）；headless 包装要比对 stdout/stderr 内容分类
-5. **报告**：已迁移（触点类 → 卡片 → 验证结果）/ 跳过（未命中及原因）/ 待确认 / 建议采纳的新能力，四档列清
+1. 阅读目标仓库的 `AGENTS.md` / `CLAUDE.md` 等规则；检查 branch、HEAD、working tree、
+   submodule。发现陌生修改或未跟踪文件就停止并报告，不自动 stash/reset/clean/checkout。
+2. 识别安装轨：registry 包、Git checkout、workspace/junction 或复制安装；记录 declared
+   版本、resolved 版本、Git SHA 与当前 DSH/Node 版本。
+3. 区分文件所有权：
+   - `package.json` / lockfile：包与依赖；
+   - `dsh-plugin.json`：社区标准 manifest（若采用）；
+   - `cordis.patch.yml` / `agent.cordis.yml` / 历史 `cordis.yml`：profile composition；
+   - resolved config：运行时组合结果，只用于核对，不整对象回写。
+4. 核对目标版本来源、tag/包名、兼容范围、release notes、安装脚本与已知 breaking changes。
+   不读取、打印或提交 token、`.npmrc` 内容、凭据或会话日志。
+5. 记录回滚基线：当前 HEAD/包版本、lockfile 与将改配置的 hash/路径；说明失败后如何恢复
+   **本次明确路径**，不要承诺回滚第三方安装脚本的任意副作用。
 
-## 原则
+## 模式 A · inspect（只读）
 
-- 有 breaking change 必须停下来向用户说明影响并等待确认，不要直接升级
-- 重点检查接缝（seam）API 变更：DSH 插件通过 `ctx.tools` / `ctx.effect()` / `ctx.on()` 注册，接口变更最容易导致挂载失败
-- 诚实优先：未知标「待确认」，不编造迁移配方；卡片与实际行为冲突时信实际行为，并把差异回馈到卡片的「实战批注」
-- 在独立分支上迁移，不把迁移改动和功能改动混在一个提交里
+输出：当前/可用版本、来源、兼容范围、breaking changes、建议目标、风险与验证计划。不得
+改文件、安装依赖、执行 lifecycle script、`git pull` 或切换版本。用户若决定执行，再进入
+模式 B 或 C 并单独确认。
 
-## 背景
+## 模式 B · update（升级已安装插件）
 
-- 上游生态：[oh-my-dsh](https://github.com/LaplaceYoung/oh-my-dsh) —— DSH 的能力插件库
-- DSH 插件约定：ESM 包，经 `cordis.yml` 挂载，遵循 interface / implementation / consumer 三段式接缝
-- 插件规范：[dsh-community-standard](https://github.com/oh-my-dsh/dsh-community-standard) —— manifest / 契约坐标 / 协商；本 skill 的触点分类与其迁移指南对齐，引用其概念、不重复定义
+1. 按安装轨选择唯一更新方式；有 lockfile 时只使用对应包管理器，不混用 npm/pnpm/bun。
+2. 生成变更计划：精确目标版本、将执行的命令、会改的文件、可能执行的生命周期脚本、
+   配置迁移和回滚步骤。
+3. **任何写入或安装前取得用户明确确认**；即使没有 breaking change 也一样。
+4. 在独立 branch/worktree 中做最小修改；配置用路径级 patch，保留未知字段。Git 来源先
+   fetch/比较明确 tag 或 commit，不对脏工作区直接 `git pull`。
+5. 按“验证与报告”执行；失败时只恢复本次拥有的路径并报告残留副作用。
 
-## references/
+## 模式 C · host-migrate（插件随 DSH 升级）
+
+1. 用精确 tag 确认 from/to；按 [references/README.md](references/README.md) 的
+   `from → to` 元数据连接版本走廊，禁止按文件名字典序。
+2. 先读完整走廊并计算最终净状态。字段在中间版本删除、目标版又恢复时，不先删再加。
+3. 按 [pre-flight.md](references/pre-flight.md) 扫描七类触点：源码 patch、事件、服务/
+   Remote、宿主文件系统、UI/命令/工具、自建通道、子进程/输出。零命中只是启发式结果，
+   仍须检查依赖/导入并跑 build 与真实挂载。
+4. 只保留与命中触点和实际 face（Host/Web Client/普通 plugin）相交的卡片。卡片是 curated
+   清单，不是完整 API diff；缺走廊边或 API 坐标时标 unsupported/待确认，不凭记忆改。
+5. 生成按 seam 分组的源码迁移计划，列命中文件、卡片、目标行为与测试；取得确认后再在
+   独立 branch/worktree 实施。`capability` 卡仅建议，不自动采用。
+
+## 安全边界
+
+- 所有写文件、安装、拉取/切换版本、运行包脚本的动作都要先展示并确认；
+- 不自动 stash/reset/clean/强制更新，不覆盖用户或其他 Agent 的工作；
+- 不泄露凭据；诊断只报告是否配置及非敏感版本/来源；
+- 不把未知 `gateway/internal` 或其他失败默认重试；仅在错误可重试、操作幂等且策略允许时重试；
+- 迁移方式不能由一手来源或可复现行为高置信确定时，停止自动修改并标「待确认」；
+- 本地观察与一手来源冲突时并列记录、复现并上报，不静默选择一方。
+
+## 验证与报告
+
+至少按适用层级验证：
+
+1. 安装/解析：对应包管理器、lockfile 与依赖图只发生预期变化；
+2. 静态：build、typecheck、插件测试；
+3. 运行时：真实 DSH profile 冷启动、entry activate、依赖/提供的 Cordis service 不停在
+   pending；
+4. 行为：执行一条插件核心路径；宿主迁移至少完成一次消息→工具→回复，或等价专用流程；
+5. 包装器：核对退出码、stdout、stderr、取消与 teardown。
+
+报告固定分为：
+
+- **已完成**：版本、文件、卡片与验证；
+- **跳过**：未命中或不适用及依据；
+- **待确认/残留风险**：缺来源、未跑平台、生命周期脚本副作用；
+- **回滚**：已记录基线与可恢复路径；
+- **建议**：可选 capability 和迁到公开 seam 的后续工作。
+
+## 参考材料
 
 | 文件 | 内容 |
-| --- | --- |
-| [README.md](references/README.md) | 卡片索引 + 新增一版卡片的格式规范 |
-| [pre-flight.md](references/pre-flight.md) | 六类触点自查清单（含 ripgrep 检出模式与汇总模板） |
-| [v0.1.2-alpha.1.md](references/v0.1.2-alpha.1.md) | 0.1.1 → alpha.1：12 张卡（含 APIProxy→`@Remote` 17 条操作映射表） |
-| [v0.1.2-alpha.2.md](references/v0.1.2-alpha.2.md) | alpha.1 → alpha.2：4 张卡（`ignorable` 恢复、`RemoteError` 封装等） |
+|---|---|
+| [references/README.md](references/README.md) | 版本走廊、卡片 schema 与维护规则 |
+| [references/pre-flight.md](references/pre-flight.md) | 七类触点自查与汇总模板 |
+| [references/v0.1.2-alpha.1.md](references/v0.1.2-alpha.1.md) | rc.2→alpha.1：13 张 curated 卡 |
+| [references/v0.1.2-alpha.2.md](references/v0.1.2-alpha.2.md) | alpha.1→alpha.2：4 张 curated 卡 |
+| [examples/legacy-plugin/](examples/legacy-plugin/) | 七类触点静态夹具（不得执行） |
 
-自测夹具：[examples/legacy-plugin/](examples/legacy-plugin/) —— 一个停留在 0.1.1 写法的
-最小插件，覆盖六类触点；在上面跑 pre-flight 检出应六类全命中，再走一遍
-「套卡片 → 分层验证」即可验证本 skill 是否好使。
+规范背景：[dsh-community-standard](https://github.com/oh-my-dsh/dsh-community-standard)
+负责 manifest、契约坐标与协商；本 skill 处理现有插件的实际升级，引用其分类而不重定义
+规范语义。

--- a/skills/plugin-upgrade/examples/legacy-plugin/README.md
+++ b/skills/plugin-upgrade/examples/legacy-plugin/README.md
@@ -1,23 +1,22 @@
-# legacy-plugin · 六类触点测试夹具
+# legacy-plugin · 七类触点静态夹具
 
-一个**故意停留在 0.1.1 时代写法**的最小插件，覆盖 pre-flight 清单的六类触点，
-供 plugin-upgrade skill 自测与演示：
+这是一个**故意包含旧耦合与错误假设**的静态夹具，用来验证
+[pre-flight.md](../../references/pre-flight.md) 能检出七类触点。它不是可安装插件，
+**不得执行、不得发布、不能编译是设计使然**。
 
-- 在 `examples/legacy-plugin/` 上跑 [pre-flight.md](../../references/pre-flight.md) 的
-  六类 ripgrep 检出，应当**六类全命中**；
-- 再按 [references/](../../references/) 的版本卡片走一遍「套卡片 → 分层验证」流程，
-  每类触点都有对应卡片可套（ALPHA1-01/03/04/05、ALPHA2-01/02 等）。
+运行仓库 `node scripts/validate.mjs` 时，校验器会使用
+[pre-flight-patterns.json](../../references/pre-flight-patterns.json) 扫描本目录（排除本
+README），七类都必须至少命中一次。
 
-> ⚠️ 代码为示意复原：API 按 0.1.1 → 0.1.2 迁移知识库（#1）中的旧写法编写，
-> **不能编译是设计使然**——它存在的意义就是"被检出、被迁移"。
+| 触点 | 命中位置 |
+|---|---|
+| #1 源码 patch | [cordis.patch.yml](cordis.patch.yml) · [patch.yml](patch.yml) · [apply-patch.mjs](scripts/apply-patch.mjs) |
+| #2 内部/持久事件 | [src/index.ts](src/index.ts) · 外部 informational SessionEvent producer |
+| #3 内部服务/Remote | [src/index.ts](src/index.ts) · `ctx.get('apiProxy')` |
+| #4 宿主文件系统 | [src/index.ts](src/index.ts) · 固定 `~/.dsh/profiles/default` |
+| #5 内部 UI/命令 | [src/index.ts](src/index.ts) · internal import + `registerCommand` |
+| #6 自建通道 | [src/index.ts](src/index.ts) · loopback HTTP `/api/legacy` |
+| #7 子进程/输出 | [src/index.ts](src/index.ts) · [apply-patch.mjs](scripts/apply-patch.mjs) · 错误假设 stdout 是 JSONL |
 
-## 触点对照
-
-| 触点类 | 命中位置 |
-| --- | --- |
-| #1 源码 patch | [cordis.yml](cordis.yml) · [patch.yml](patch.yml) · [scripts/apply-patch.mjs](scripts/apply-patch.mjs) |
-| #2 内部事件名 | [src/index.ts](src/index.ts) · `session/event` 订阅 + `SessionEvent.ignorable` |
-| #3 内部服务探测 | [src/index.ts](src/index.ts) · `ctx.get('apiProxy')` |
-| #4 直接读写宿主目录 | [src/index.ts](src/index.ts) · `~/.dsh/profiles/default` |
-| #5 内部 UI / 命令注册 | [src/index.ts](src/index.ts) · 内部路径 import + `registerCommand` |
-| #6 子进程 / stdout 解析 | [src/index.ts](src/index.ts) · [scripts/apply-patch.mjs](scripts/apply-patch.mjs) · spawn `dsh headless` 解析 stdout |
+相关卡使用完整 ID（如 `DSH-0.1.2-A1-01`、`DSH-0.1.2-A2-02`）。该夹具只证明扫描
+模式有已知正样本，不证明扫描零命中时没有宿主耦合。

--- a/skills/plugin-upgrade/examples/legacy-plugin/cordis.patch.yml
+++ b/skills/plugin-upgrade/examples/legacy-plugin/cordis.patch.yml
@@ -1,0 +1,6 @@
+# Static fixture only: profile composition plus source patch declaration (#1).
+- id: legacy-plugin
+  name: legacy-plugin
+  config: {}
+  patch:
+    - patch.yml

--- a/skills/plugin-upgrade/examples/legacy-plugin/cordis.yml
+++ b/skills/plugin-upgrade/examples/legacy-plugin/cordis.yml
@@ -1,7 +1,0 @@
-# 触点 #1: 0.1.1 时代的挂载 + patch 面声明
-# 0.1.2-alpha.1 会话视图工程拆分后，patch 目标文件可能移动/失效（见 ALPHA1-03）
-- id: legacy-plugin
-  name: legacy-plugin
-  config: {}
-  patch:
-    - patch.yml

--- a/skills/plugin-upgrade/examples/legacy-plugin/patch.yml
+++ b/skills/plugin-upgrade/examples/legacy-plugin/patch.yml
@@ -1,6 +1,4 @@
-# patch 面清单（触点 #1）
-# patch-surface 记录插件要合成的宿主文件与替换片段；
-# 0.1.2-alpha.1 起会话视图工程拆分，本清单中的宿主路径需逐一核对新分层（ALPHA1-03）
+# Static patch-surface fixture (#1).
 surface:
   - target: src/session/view/SessionView.ts
     replacements:

--- a/skills/plugin-upgrade/examples/legacy-plugin/scripts/apply-patch.mjs
+++ b/skills/plugin-upgrade/examples/legacy-plugin/scripts/apply-patch.mjs
@@ -1,25 +1,19 @@
-// 触点 #1 + #6: patch 面合成脚本（0.1.1 时代做法的示意复原）
-// 实战参照 dsh-tui 的适配流程：DSH_HARNESS_SOURCE_ROOT 指向上游源码 → patch-surface 合成
-// 0.1.2-alpha.1 会话视图工程拆分后，patch 目标路径需逐一核对（ALPHA1-03）
-import { readFileSync, writeFileSync } from 'node:fs'
-import { join } from 'node:path'
-import { execFileSync, spawn } from 'node:child_process'
+// Static fixture for touchpoints #1 and #7. Do not execute.
+import { readFileSync } from 'node:fs'
+import { execFileSync } from 'node:child_process'
 
-const sourceRoot = process.env.DSH_HARNESS_SOURCE_ROOT // 触点 #1: 依赖宿主源码 checkout
+const sourceRoot = process.env.DSH_HARNESS_SOURCE_ROOT
 if (!sourceRoot) throw new Error('DSH_HARNESS_SOURCE_ROOT is required')
 
-const surface = readFileSync('patch.yml', 'utf8') // 触点 #1: patch-surface 清单
+const surface = readFileSync('patch.yml', 'utf8')
 console.log('[legacy] applying patch surface:\n', surface)
 
-// 触点 #6: 升级后自检——跑一次 headless 并解析 stdout（0.1.2 起应改解析 stderr → ALPHA1-05）
-const out = execFileSync('dsh', ['headless', '--profile', 'default', '-p', 'ping'], {
+// Deliberately wrong expectation: target headless stdout is final text, not JSONL.
+const output = execFileSync('dsh', ['--profile', 'headless', 'ping'], {
   encoding: 'utf8',
 })
-for (const line of out.split('\n')) {
+for (const line of output.split('\n')) {
   if (!line.trim()) continue
-  const evt = JSON.parse(line)
-  if (evt.type === 'final') console.log('[legacy] headless ok:', evt.text)
+  const event = JSON.parse(line)
+  if (event.type === 'final') console.log('[legacy] headless ok:', event.text)
 }
-
-const child = spawn('dsh', ['headless', '--profile', 'default'])
-child.stdout.on('data', (l) => writeFileSync(1, l))

--- a/skills/plugin-upgrade/examples/legacy-plugin/src/index.ts
+++ b/skills/plugin-upgrade/examples/legacy-plugin/src/index.ts
@@ -1,26 +1,27 @@
-// legacy-plugin · 0.1.1 时代写法的示意复原，覆盖触点 #2–#6
-// 对应迁移卡片见 references/（ALPHA1-01/02/03/04/05、ALPHA2-01/02）
-// ⚠️ 故意不编译：它存在的意义是"被 pre-flight 检出、被卡片迁移"
+// legacy-plugin: static fixture only. Do not execute or publish.
+// It deliberately contains legacy coupling and incorrect wrapper assumptions.
 
+import { createServer } from 'node:http'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
 import { writeFileSync } from 'node:fs'
 import { spawn } from 'node:child_process'
-// 触点 #5: 从会话视图工程内部路径导入（alpha.1 工程拆分后此路径失效 → ALPHA1-03）
+// Touchpoint #5: private Host/Web Client path removed by UI decomposition.
 import { SessionView } from '@deepseek-ai/dsh-session-view/internal'
 
 export function activate(ctx: any) {
-  // ── 触点 #2: 内部事件名 ─────────────────────────────
-  // 硬编码订阅宿主内部事件；0.1.2-alpha.1 移除 SessionEvent.ignorable、alpha.2 恢复
-  // → ALPHA1-02 / ALPHA2-01（跨 alpha 的字段波动，走廊读完再删防御代码）
-  ctx.on('session/event', (ev: any /* SessionEvent */) => {
-    if (ev.ignorable) return
-    console.log('[legacy] session event:', ev.type)
+  // #2 Producer of an external informational durable event.
+  // alpha.1 removed the ignorable marker; alpha.2 restored its producer/persistence contract.
+  ctx.emit('session/event', {
+    type: 'legacy/informational-note',
+    ignorable: true,
+    payload: { text: 'fixture' },
+  })
+  ctx.on('session/event', (event: any /* SessionEvent */) => {
+    console.log('[legacy] session event:', event.type)
   })
 
-  // ── 触点 #3: 内部服务探测 ────────────────────────────
-  // 经 APIProxy 调宿主能力；0.1.2-alpha.1 APIProxy 整体移除，须按 17 条映射表改 @Remote
-  // → ALPHA1-01；Remote 错误处理 → ALPHA2-02
+  // #3 Legacy Host APIProxy calls.
   ctx.register('rename-session', async ({ id, title }: any) => {
     const apiProxy = await ctx.get('apiProxy')
     await apiProxy.invoke('session.rename', { id, title })
@@ -30,30 +31,36 @@ export function activate(ctx: any) {
     return apiProxy.invoke('llm.providers')
   })
 
-  // ── 触点 #4: 直接读写宿主目录 ────────────────────────
-  // 假设默认 profile 固定路径；0.1.2 统一经 Profile 启动后目录解析假设可能失配
-  // → ALPHA1-04
+  // #4 Hard-coded Host/profile path.
   ctx.register('write-note', async ({ text }: any) => {
     const profileDir = join(homedir(), '.dsh', 'profiles', 'default')
     writeFileSync(join(profileDir, 'legacy-note.txt'), text)
   })
 
-  // ── 触点 #5: 内部 UI / 命令注册 ─────────────────────
-  // 注册命令到宿主内部结构；UI 工程拆分后注册路径失效 → ALPHA1-03
+  // #5 Private UI/command registration.
   ctx.contributes.registerCommand('legacy.openView', () => {
     return new SessionView({ enhanced: true })
   })
 
-  // ── 触点 #6: 子进程 / stdout 解析 ───────────────────
-  // spawn headless 并解析 stdout；0.1.2-alpha.1 起进度流改走 stderr、stdout 只出最终结果
-  // → ALPHA1-05；--profile 启动语义 → ALPHA1-04
+  // #6 Private loopback HTTP bridge that bypasses the Host Gateway authentication model.
+  // The function is never invoked; the fixture must remain static-only.
+  function startLegacyBridge() {
+    const server = createServer((_request, response) => {
+      response.end('legacy')
+    })
+    server.listen(43121, '127.0.0.1') // http://localhost:43121/api/legacy
+    return server
+  }
+  void startLegacyBridge
+
+  // #7 Deliberately wrong wrapper assumption: treats headless stdout as JSONL.
   ctx.register('headless-ask', ({ prompt }: any) =>
     new Promise((resolve) => {
-      const child = spawn('dsh', ['headless', '--profile', 'default', '-p', prompt])
+      const child = spawn('dsh', ['--profile', 'headless', prompt])
       let result = ''
       child.stdout.on('data', (line: Buffer) => {
-        const evt = JSON.parse(line.toString()) // 0.1.1: stdout 每行一个 JSON 事件
-        if (evt.type === 'final') result = evt.text
+        const event = JSON.parse(line.toString())
+        if (event.type === 'final') result = event.text
       })
       child.on('close', () => resolve(result))
     })

--- a/skills/plugin-upgrade/references/README.md
+++ b/skills/plugin-upgrade/references/README.md
@@ -1,38 +1,68 @@
 # references/ · 按需加载的参考材料
 
-> SKILL.md 保持精简，详细材料都在这里按需引用（见
-> [skills/README.md](../../README.md) 编写规范）。
+> `SKILL.md` 只保留决策流程，版本事实与扫描模式放在这里按需加载。
 
-## 版本卡片索引
+## 版本走廊索引
 
-| 卡片文件 | 版本区间 | 卡数 | 要点 |
-|---|---|---|---|
-| [v0.1.2-alpha.1.md](v0.1.2-alpha.1.md) | 0.1.1(-rc.2) → alpha.1 | 12 | APIProxy→`@Remote`（17 条操作映射表）、`SessionEvent.ignorable` 移除、会话视图拆分、headless 输出语义、Profile 统一启动、WebFetch 默认开、4 张新能力卡 |
-| [v0.1.2-alpha.2.md](v0.1.2-alpha.2.md) | alpha.1 → alpha.2 | 4 | `ignorable` 恢复（与 alpha.1 卡交叉引用）、`RemoteError` 统一封装、peer deps 裁剪、Node 24 修复 |
+按表中 `from → to` 的有向边构造走廊，**不要按文件名排序**；`alpha.10` 的字典序会早于
+`alpha.2`。目标跨多版时先读完整走廊并计算最终净状态，再修改源码——例如字段在
+alpha.1 删除、alpha.2 恢复时，不应先删再加。
 
-配套：[pre-flight.md](pre-flight.md)（升级前六类触点自查，含 ripgrep 检出模式）。
+| 顺序 | 卡片文件 | from | to | 卡数 | 状态 / 覆盖 |
+|---|---|---|---|---:|---|
+| 1 | [v0.1.2-alpha.1.md](v0.1.2-alpha.1.md) | `dsh-v0.1.1-rc.2` | `dsh-v0.1.2-alpha.1` | 13 | reviewed / curated |
+| 2 | [v0.1.2-alpha.2.md](v0.1.2-alpha.2.md) | `dsh-v0.1.2-alpha.1` | `dsh-v0.1.2-alpha.2` | 4 | reviewed / curated |
 
-## 新增一版卡片的格式
+`curated` 表示只收录已识别的插件相关变化，**不表示完整 API diff**。走廊缺边时停止
+自动迁移，向用户报告缺口；为当前任务做临时上游调研与给本仓库补卡是两件事，后者
+不应成为修改用户插件的隐式副作用。
 
-DSH 每发一个版本，这里就需要一份新卡片（`vX.Y.Z-<suffix>.md`）：
+配套材料：
 
-1. 从官方 release notes + 上游架构笔记（`.agents/notes/`）提炼**插件相关**变更；
-   对插件无触点的宿主内部变化收进文件尾注，不建卡，控制信噪比；
-2. 每条变更一张卡，字段如下：
+- [pre-flight.md](pre-flight.md)：七类触点自查与迁移任务汇总；
+- [pre-flight-patterns.json](pre-flight-patterns.json)：可执行校验使用的正则真源；
+- [examples/legacy-plugin/](../examples/legacy-plugin/)：七类触点静态夹具。
 
-```markdown
-### <RELEASE>-NN · 标题
-- **类型**: breaking | behavior | capability | fix
-- **影响触点**: #<触点编号，对应 pre-flight.md 的六类>
-- **症状**: 升级后什么会坏/变
-- **迁移配方**: 具体步骤；旧→新映射表（如适用）
-- **验证**: 怎么确认迁移成功
-- **来源**: 上游 release notes / 架构笔记链接
-- **实战批注**（可选）: 真实迁移中观察到的与笔记不符的行为，注明日期与插件名
+## 卡片文件元数据
+
+每个 `vX.Y.Z-<suffix>.md` 以 frontmatter 声明：
+
+```yaml
+---
+kind: dsh-version-card-set
+schema: 1
+from: dsh-v0.1.2-alpha.1
+to: dsh-v0.1.2-alpha.2
+status: reviewed
+coverage: curated
+cardCount: 4
+idPrefix: DSH-0.1.2-A2
+verifiedAt: 2026-08-30
+---
 ```
 
-3. 规则：
-   - ID 为 `<RELEASE>-NN` 顺序编号，不复用；
-   - 每张卡至少一条一手来源；
-   - 跨版本的波动（如字段删了又恢复）用卡片交叉引用记录；
-   - 提 PR 时标题带版本号。
+版本顺序由 `from/to` 决定；`cardCount`、ID 前缀与必需字段由仓库校验脚本检查。
+
+## 单张卡片格式
+
+```markdown
+### DSH-0.1.2-A2-01 · 标题
+
+- **类型**: breaking | behavior | capability | fix | security | privacy
+- **适用对象**: client / server plugin / profile wrapper / packaging 等
+- **影响触点**: #1…#7，或“无（打包/隐私面）”
+- **操作级别**: required | required-if-hit | required-if-target-is-… | conditional | optional | informational
+- **症状**: 升级后什么会坏或变化
+- **迁移配方**: 可核对的步骤；旧→新 ledger（如适用）
+- **验证**: 如何证明最终行为，而不是只证明安装成功
+- **来源**: 固定 release tag / commit 的一手来源
+- **实战批注**（可选）: 可复现的真实迁移差异，注明日期、插件、平台与版本
+```
+
+规则：
+
+1. ID 必须包含完整宿主版本并在仓库内唯一；
+2. 每张卡至少引用一条一手来源，同版本材料存在时优先钉在同一个 tag；
+3. release notes 只给出方向、没有 API 坐标时，配方必须要求再查目标 tag 类型，不能自造接口；
+4. 跨版本回滚/恢复用完整 ID 交叉引用；
+5. 本地观察与一手来源冲突时，先复现并并列记录差异，不静默覆盖任何一方。

--- a/skills/plugin-upgrade/references/pre-flight-patterns.json
+++ b/skills/plugin-upgrade/references/pre-flight-patterns.json
@@ -1,0 +1,69 @@
+{
+  "schema": 1,
+  "scope": "heuristic",
+  "classes": [
+    {
+      "id": 1,
+      "slug": "source-patch",
+      "name": "源码 patch / monkey patch",
+      "patterns": [
+        "cordis\\.patch\\.yml|patch\\.yml|patchedDependencies|patch-package",
+        "DSH_HARNESS_SOURCE_ROOT|patch-surface|monkeypatch|monkey-patch"
+      ]
+    },
+    {
+      "id": 2,
+      "slug": "internal-events",
+      "name": "内部事件名与持久事件",
+      "patterns": [
+        "SessionEvent|session/event|ctx\\.on\\(|subscribe\\(",
+        "tool/code-dispatch|tools-code-mode|connection/reset"
+      ]
+    },
+    {
+      "id": 3,
+      "slug": "internal-services",
+      "name": "内部服务探测 / Remote",
+      "patterns": [
+        "APIProxy|apiProxy|ctx\\.get\\(|ctx\\.remote|@Remote",
+        "@deepseek-ai/dsh-api-.+/client|/internal"
+      ]
+    },
+    {
+      "id": 4,
+      "slug": "host-filesystem",
+      "name": "直接读写宿主目录",
+      "patterns": [
+        "DSH_HOME|\\.dsh[/\\\\]|profiles[/\\\\]|homedir\\(",
+        "readFile|writeFile|mkdir|openPath"
+      ]
+    },
+    {
+      "id": 5,
+      "slug": "internal-ui-commands",
+      "name": "内部 UI / 命令 / 工具注册",
+      "patterns": [
+        "registerCommand|registerView|contributes|ctx\\.tools",
+        "ctx\\.effect\\(|/internal"
+      ]
+    },
+    {
+      "id": 6,
+      "slug": "custom-channel",
+      "name": "自建 HTTP / WS / RPC / DOM / CSS 通道",
+      "patterns": [
+        "createServer\\(|WebSocket|MutationObserver|insertRule",
+        "127\\.0\\.0\\.1|localhost|router\\.(get|post|put|delete)\\(|/api/"
+      ]
+    },
+    {
+      "id": 7,
+      "slug": "subprocess-output",
+      "name": "子进程 / stdout / stderr 解析",
+      "patterns": [
+        "node:child_process|spawn\\(|exec(File)?Sync\\(|execa|Bun\\.spawn",
+        "headless|--profile"
+      ]
+    }
+  ]
+}

--- a/skills/plugin-upgrade/references/pre-flight.md
+++ b/skills/plugin-upgrade/references/pre-flight.md
@@ -1,132 +1,135 @@
-# Pre-flight 清单 · 升级前触点自查
+# Pre-flight · 宿主升级前触点自查
 
-> 用途：升级 DSH 宿主版本前，先弄清插件与宿主的接触面有多大。
-> 六类触点与 [dsh-community-standard 迁移指南](https://github.com/oh-my-dsh/dsh-community-standard/blob/main/guides/migration.md)
-> 的调研分类对齐。检出模式以 ripgrep 示意，等效 grep 即可。
+> 这是启发式扫描，不是兼容性证明。七类零命中只表示“未被当前模式发现”，仍须检查
+> 依赖/配置并执行 build、真实挂载和功能烟测。
 
-## 使用方法
+前六类沿用 [dsh-community-standard 迁移指南](https://github.com/oh-my-dsh/dsh-community-standard/blob/main/guides/migration.md)
+的分类；本 skill 另加 #7 子进程/输出解析。机器校验读取
+[pre-flight-patterns.json](pre-flight-patterns.json)。下列 `rg` 仅为示例；Agent 应优先
+使用当前环境提供的内容搜索工具。
 
-1. 先确定版本区间（from → to），到本目录（references/）按文件名序取版本卡片；
-2. 对插件源码逐类跑检出，记录命中（文件 + 行）；
-3. 按每类末尾的「去查哪张卡」索引，把命中的卡片集合汇总成迁移任务清单；
-4. 六类全零命中 → 插件只经公共契约耦合，跑一遍烟测即可收工。
+## 0. 先做配置与依赖盘点
 
----
+扫描全部受跟踪的源码、测试、脚本、CI 和根配置，排除生成物、vendor 与
+`node_modules`。至少记录：
+
+- `package.json` 的插件版本、`peerDependencies`、`engines` 与 `@deepseek-ai/*` 导入；
+- resolved 版本与 lockfile（只认仓库正在使用的包管理器）；
+- 标准 manifest `dsh-plugin.json`（若存在）；
+- profile composition：`cordis.patch.yml`、`agent.cordis.yml`、历史 `cordis.yml`；
+- 实际安装轨：registry 包、Git checkout、workspace/junction 或复制安装。
+
+这些文件所有权不同，不能统一称为 manifest，也不能整对象重写未知字段。
+
+## 1. 构造版本走廊
+
+1. 用精确 tag 确认 from/to；
+2. 按 [版本走廊索引](README.md#版本走廊索引) 的 `from → to` 边连接，禁止按文件名字典序；
+3. 先读完整走廊并折叠“移除后又恢复”等净变化，再生成修改计划；
+4. 缺卡时报告 unsupported gap，先做一手来源调研，不凭记忆自动改插件。
 
 ## #1 源码 patch / monkey patch
 
-**查什么**: 改写宿主文件或函数的一切手段。
-
 ```sh
-rg -n "cordis\.patch|patch\.yml|monkeypatch|monkey-patch" .
-rg -n "DSH_HARNESS_SOURCE_ROOT|patch-surface" .
+rg -n "cordis\.patch\.yml|patch\.yml|patchedDependencies|patch-package" .
+rg -n "DSH_HARNESS_SOURCE_ROOT|patch-surface|monkeypatch|monkey-patch" .
 ```
 
-**命中意味着**: 宿主文件一旦移动/拆分/重命名，patch 直接失效——通常是最痛的
-一类。
+命中后逐个记录宿主目标路径与替换意图；目标 tag 中找不到等价 owning 模块时标
+「待确认」，不猜路径。
 
-**去查哪张卡**: ALPHA1-03（会话视图拆分）；每版 release notes 的「其他变更」
-节里出现「工程拆分/迁移」字样时必有新卡。
+**关联卡**: `DSH-0.1.2-A1-03`
 
----
-
-## #2 内部事件名
-
-**查什么**: 硬编码订阅宿主内部事件字符串。
+## #2 内部事件名与持久事件
 
 ```sh
-rg -n "SessionEvent|session/event|\.on\(['\"]|subscribe\(" src/
+rg -n "SessionEvent|session/event|ctx\.on\(|subscribe\(" .
+rg -n "tool/code-dispatch|tools-code-mode|connection/reset" .
 ```
 
-**命中意味着**: 事件字段增删波动会直接改变插件行为。
+区分 producer、persistence、reload、transport 与普通 observer；未知 required 事件不能
+因白名单而被放过。
 
-**去查哪张卡**: ALPHA1-02 / ALPHA2-01（`ignorable` 一删一复）。
+**关联卡**: `DSH-0.1.2-A1-02`、`DSH-0.1.2-A1-06`、`DSH-0.1.2-A2-01`
 
----
-
-## #3 内部服务探测（APIProxy / Remote / ctx.get）
-
-**查什么**: 反射、结构探测、旧代理接口调用。
+## #3 内部服务探测 / Remote
 
 ```sh
-rg -n "APIProxy|apiProxy" .
-rg -n "ctx\.get\(|ctx\.remote" src/
+rg -n "APIProxy|apiProxy|ctx\.get\(|ctx\.remote|@Remote" .
+rg -n "@deepseek-ai/dsh-api-.+/client|/internal" .
 ```
 
-**命中意味着**: APIProxy 已整体移除（ALPHA1-01），这是 0.1.1 → 0.1.2 最大的
-一个坑；Remote 调用则要按 RemoteError 重写错误处理（ALPHA2-02）。
+同时记录调用所在 face（Host、Web Client、普通 Cordis plugin）与包入口；内部架构迁移
+不能直接当成所有插件的公开 API 建议。
 
-**去查哪张卡**: ALPHA1-01（含 17 条操作映射表）、ALPHA2-02。
-
----
+**关联卡**: `DSH-0.1.2-A1-01`、`DSH-0.1.2-A1-06`、`DSH-0.1.2-A1-11`、`DSH-0.1.2-A2-02`
 
 ## #4 直接读写宿主目录
 
-**查什么**: 往 profile、工作区、宿主配置目录写文件或读内部结构。
-
 ```sh
-rg -n "DSH_HOME|\.dsh|profiles[/\\\\]" src/ scripts/
-rg -n "(readFile|writeFile|mkdir).*profile" src/
+rg -n "DSH_HOME|\.dsh[/\\]|profiles[/\\]|homedir\(" .
+rg -n "readFile|writeFile|mkdir|openPath" .
 ```
 
-**命中意味着**: 启动链路统一经 Profile 后（ALPHA1-04），目录解析假设可能
-失配。
+同一行搜索无法发现数据流；命中路径构造函数后继续追踪变量来源与写入目标。不得打印
+配置内容、token、`.npmrc` 或会话日志。
 
-**去查哪张卡**: ALPHA1-04。
+**关联卡**: `DSH-0.1.2-A1-04`、`DSH-0.1.2-A1-13`
 
----
-
-## #5 内部 UI / 命令注册
-
-**查什么**: 注册视图、组件、命令到宿主内部结构。
+## #5 内部 UI / 命令 / 工具注册
 
 ```sh
-rg -n "registerCommand|registerView|contributes" src/
+rg -n "registerCommand|registerView|contributes|ctx\.tools" .
+rg -n "ctx\.effect\(|/internal" .
 ```
 
-**命中意味着**: 宿主 UI 工程拆分时注册路径失效；同时也是新能力的接入点
-（提供方登录控件、第三方语言、子代理参数）。
+将公开 seam 与内部路径分开；机会型 capability 只建议、不自动采用。
 
-**去查哪张卡**: ALPHA1-03（破坏面）、ALPHA1-08/09/10（机会面）。
+**关联卡**: `DSH-0.1.2-A1-03`、`DSH-0.1.2-A1-06`、`DSH-0.1.2-A1-09`、`DSH-0.1.2-A1-10`、`DSH-0.1.2-A1-11`
 
----
-
-## #6 子进程 / stdout 解析
-
-**查什么**: spawn 宿主进程、解析其输出、包装启动。
+## #6 自建 HTTP / WS / RPC / DOM / CSS 通道
 
 ```sh
-rg -n "spawn|execFile|fork\(" src/
-rg -n "headless|--profile" src/ scripts/
+rg -n "createServer\(|WebSocket|MutationObserver|insertRule" .
+rg -n "127\.0\.0\.1|localhost|router\.(get|post|put|delete)\(|/api/" .
 ```
 
-**命中意味着**: headless 输出语义变了（ALPHA1-05）、启动统一走 Profile
-（ALPHA1-04）、平台级 workaround 可能过期（ALPHA1-12、ALPHA2-04）。
+检查认证、Host/Origin、端口生命周期和 teardown；不能因“只监听 loopback”就跳过认证。
 
-**去查哪张卡**: ALPHA1-04 / 05 / 06 / 12、ALPHA2-04。
+**关联卡**: `DSH-0.1.2-A1-08`
 
----
+## #7 子进程 / stdout / stderr 解析
 
-## 特殊类别
+```sh
+rg -n "node:child_process|spawn\(|exec(File)?Sync\(|execa|Bun\.spawn" .
+rg -n "headless|--profile" .
+```
 
-**权限/审批类插件**（挂钩子到审批流的，跨 #2/#3）: 另查 ALPHA1-07——公网
-WebFetch 默认开启后审批钩子的触发集合会变。
+记录 argv、cwd、env、取消、退出码、stdout/stderr 所有权；不要只验证进程能启动。
 
----
+**关联卡**: `DSH-0.1.2-A1-04`、`DSH-0.1.2-A1-05`、`DSH-0.1.2-A1-06`、`DSH-0.1.2-A1-13`、`DSH-0.1.2-A2-04`
+
+## 特殊面
+
+- 权限/审批：另查 `DSH-0.1.2-A1-07`；
+- 打包/依赖：另查 `DSH-0.1.2-A2-03`；
+- 隐私披露：另查 `DSH-0.1.2-A1-12`。
 
 ## 汇总模板
 
 ```markdown
-## 触点体检结果（<插件名>，<from> → <to>）
+## 触点体检（<插件>，<from> → <to>）
 
-| 触点类 | 命中数 | 代表文件 | 待查卡片 |
-|---|---|---|---|
-| #1 patch | | | |
-| #2 事件名 | | | |
-| #3 服务探测 | | | |
-| #4 文件读写 | | | |
-| #5 UI/命令 | | | |
-| #6 子进程 | | | |
+| 触点 | 命中 | 文件/行 | 适用卡 | 置信说明 |
+|---|---:|---|---|---|
+| #1 patch | | | | |
+| #2 事件 | | | | |
+| #3 服务/Remote | | | | |
+| #4 文件系统 | | | | |
+| #5 UI/命令/工具 | | | | |
+| #6 自建通道 | | | | |
+| #7 子进程/输出 | | | | |
 
-结论：迁移工作量预估 = <零命中=烟测 / 1-2 类=点改 / ≥3 类或含 #1=分支单独迁>
+未命中说明：<扫描范围、排除目录、依赖/配置另行检查结果>
+必须验证：<build/typecheck、真实 profile 挂载、功能路径>
 ```

--- a/skills/plugin-upgrade/references/v0.1.2-alpha.1.md
+++ b/skills/plugin-upgrade/references/v0.1.2-alpha.1.md
@@ -1,197 +1,231 @@
+---
+kind: dsh-version-card-set
+schema: 1
+from: dsh-v0.1.1-rc.2
+to: dsh-v0.1.2-alpha.1
+status: reviewed
+coverage: curated
+cardCount: 13
+idPrefix: DSH-0.1.2-A1
+verifiedAt: 2026-08-30
+---
+
 # 变更卡片 · 0.1.2-alpha.1
 
-> **相对基线**: `dsh-v0.1.1-rc.2`（0.1.1 线尾点）
+> 本文件是**插件相关变更的精选清单，不是完整 API diff**。迁移前仍须检查目标插件的
+> 依赖、导入、配置和实际运行路径。
+>
 > **上游比较**: [dsh-v0.1.1-rc.2...dsh-v0.1.2-alpha.1](https://github.com/deepseek-ai/deepseek-harness/compare/dsh-v0.1.1-rc.2...dsh-v0.1.2-alpha.1)
-> **Release Notes**: [中文](https://github.com/deepseek-ai/deepseek-harness/releases/tag/dsh-v0.1.2-alpha.1)
-> 卡片格式见 [references/README.md](README.md)。触点编号对应 [pre-flight 清单](pre-flight.md)。
+> · **Release Notes**: [dsh-v0.1.2-alpha.1](https://github.com/deepseek-ai/deepseek-harness/releases/tag/dsh-v0.1.2-alpha.1)
+> · 卡片格式见 [references/README.md](README.md)
+> · 触点编号见 [pre-flight.md](pre-flight.md)
 
 ---
 
-### ALPHA1-01 · APIProxy 整体移除，统一走 `@Remote` 网关
+### DSH-0.1.2-A1-01 · APIProxy 移除，Host/Web Client 调用迁到 `@Remote`
 
 - **类型**: breaking
-- **影响触点**: #3（内部服务探测）；间接 #1（patch 脚本若代理了 APIProxy）
-- **症状**: 升级后所有经 APIProxy 的调用直接报错——接口不存在；插件的功能按钮、
-  设置读写、会话操作全部失效。
-- **迁移配方**: 按下表把旧操作替换为对应 Remote 方法；客户端侧统一经
-  `@deepseek-ai/dsh-api-remotes/client` 选择生成的 contribution。
+- **适用对象**: 直接使用 Host APIProxy 的 Web Client、宿主集成插件；普通 Cordis 服务端插件只有命中旧 APIProxy 时才适用
+- **影响触点**: #3；间接 #1
+- **操作级别**: required-if-hit
+- **症状**: 旧 APIProxy 接口消失；会话、设置、凭据、模型目录等调用无法工作。
+- **迁移配方**: 先确认调用点确属旧 Host APIProxy，不要因为看到本卡就让普通插件导入宿主内部 client 包。命中时按下表迁移；Remote unary 调用返回 `RemoteResult<T>`，错误控制流见 [DSH-0.1.2-A2-02](v0.1.2-alpha.2.md)。
 
 | 旧 APIProxy 操作 | 新 Remote 方法 | 备注 |
 |---|---|---|
 | `session.rename` | `sessionTitle/rename` | 返回标题事件序列 |
 | `command.list` / `command.execute` | `commands/list` / `commands/execute` | 保留 Agent 查找与调用方取消 |
-| `llm.providers` | `llm/listProviders` + `llm/listConfigurableProviders` | 一个拆两个，注意合并展示逻辑 |
+| `llm.providers` | `llm/listProviders` + `llm/listConfigurableProviders` | 一个拆为两个结果 |
 | `llm.discoverModels` | `llm/discoverModels` | |
-| `llm.models` | `session/modelCatalog` | 从 LLM 域挪到 Session 域 |
+| `llm.models` | `session/modelCatalog` | 从 LLM 域移到 Session 域 |
 | `credentials.describe/set/unset` | `credentials/describe/set/unset` | |
-| `settings.describe/update/replace/mutate` | `settings/*` 同名方法 | 保留脱敏与修订检查 |
+| `settings.describe/update/replace/mutate` | `settings/*` 同名方法 | 保留脱敏与 revision 检查 |
 | `settings.openDocument` | `settings/openSettingsDocument` | |
 | `agentPreset.read/copy/remove` | `agentPresets/*` | |
-| `agentPreset.openDocument` | `settings/openAgentPresetDirectory` | 挪到 settings 域 |
-| `subagent.interrupt` | `subagents/interruptByParent` | 保留父权威、不激活 Agent |
+| `agentPreset.openDocument` | `settings/openAgentPresetDirectory` | 移到 Settings 域 |
+| `subagent.interrupt` | `subagents/interruptByParent` | 保留父 Agent 权威 |
 | `workspace.list/insertSessionBefore/archiveSession` | `workspace/*` | |
-| `skill.list` | `skills/list` | 列举不再激活 Agent（行为更懒） |
-| `fileReferences/list` | `fileReferences/list` | 冷查找行为不变 |
-| `host.openPath` | `session/openWorkspacePath` | Client 侧先解析工作区相对路径 |
-| `host.describe` | `$events` ready 帧 + 按页能力查询 | 改读 `ctx.remote.$host.home` |
-| `session.export` | `GET/HEAD /api/session.export` | 走 Fetch 流式 ZIP，**无 JSON 信封** |
+| `skill.list` | `skills/list` | 列举不激活冷 Agent |
+| `fileReferences/list` | `fileReferences/list` | |
+| `host.openPath` | `session/openWorkspacePath` | Client 先解析工作区相对路径 |
+| `host.describe` | `$events` ready 帧 + 按域查询 | Host home 读 `ctx.remote.$host.home` |
+| `session.export` | `GET/HEAD /api/session.export` | Fetch 流式 ZIP，不走 JSON Remote 信封；认证见 A1-08 |
 
-- **验证**: 逐调用点写错误码分支单测（错误码见下方）；至少一个真实调用走通。
-- **来源**: [release notes](https://github.com/deepseek-ai/deepseek-harness/releases/tag/dsh-v0.1.2-alpha.1) ·
-  架构笔记 [unary-apiproxy-remote-migration](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/.agents/notes/implemented/architecture/2026-08-10-unary-apiproxy-remote-migration.md)
-- **实战批注**（2026-08-30，dsh-tui 适配）: 业务失败会以带自身错误码的
-  `RemoteError` 上抛（如 `session/not-found`、`session/agent-bus`），与
-  `gateway/internal` 可区分；旧客户端超时已被移除，依赖超时语义的调用方需自查。
-  RemoteError 的统一封装细节见 [ALPHA2-02](v0.1.2-alpha.2.md)。
+  调用插件在 `inject` 声明所需 Remote contribution，经
+  `@deepseek-ai/dsh-api-remotes/client` 获得生成的类型挂载，再调用
+  `ctx.remote.<namespace>.<method>(...)`。不要手写 wire 中转对象或方法签名。
+- **验证**: 每个命中调用至少覆盖成功分支、一个业务失败码及取消；对
+  `session.export` 验证无会话认证被拒、合法浏览器会话能下载。
+- **来源**: [APIProxy→Remote 架构笔记（alpha.1）](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/.agents/notes/implemented/architecture/2026-08-10-unary-apiproxy-remote-migration.md)
 
 ---
 
-### ALPHA1-02 · `SessionEvent.ignorable` 字段移除
+### DSH-0.1.2-A1-02 · `SessionEvent.ignorable` 暂时移除
 
 - **类型**: breaking
-- **影响触点**: #2（内部事件名）
-- **症状**: 订阅会话事件的插件读取 `ignorable` 字段得到 `undefined`；依赖它做
-  过滤/降噪的逻辑失效。
-- **迁移配方**: alpha.1 下移除对 `ignorable` 的依赖，改用事件类型白名单做降噪。
-  **注意**: 该字段在 alpha.2 已恢复（见
-  [ALPHA2-01](v0.1.2-alpha.2.md)）——若目标版本 ≥ alpha.2，可保留原逻辑，
-  仅需确认字段语义未变。
-- **验证**: 事件回放夹具下断言过滤行为不变。
-- **来源**: 由 [alpha.2 release notes](https://github.com/deepseek-ai/deepseek-harness/releases/tag/dsh-v0.1.2-alpha.2)
-  「恢复 0.1.2-alpha.1 中移除的 `SessionEvent.ignorable`」反推；alpha.1 notes
-  未单列此条。
+- **适用对象**: 生产第三方持久 SessionEvent 的插件，以及负责持久化/reload/transport 的集成层
+- **影响触点**: #2
+- **操作级别**: required-if-target-is-alpha.1
+- **症状**: alpha.1 无法保留第三方 informational event 的 `ignorable: true` 标记；第一方 reader 遇到未知持久事件时会按 required 事件拒绝 reload。
+- **迁移配方**: 若目标**恰好是 alpha.1**，不要把未知持久事件改成消费者白名单——那会错误放过 required 事件。应暂时停止写入该未知持久事件，或改用目标版本已知的公开事件词汇。若最终目标是 alpha.2 或更高，先读 [DSH-0.1.2-A2-01](v0.1.2-alpha.2.md) 计算走廊净状态，不要先删再恢复 producer marker。
+- **验证**: 未知 required 事件必须 fail closed；目标 alpha.1 不应写出无法被该版本安全 reload 的未知事件。
+- **来源**: [alpha.2 恢复决策对 alpha.1 移除的说明](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/.agents/notes/implemented/architecture/2026-08-30-retain-ignorable-external-session-events.md)
 
 ---
 
-### ALPHA1-03 · 会话视图工程大幅拆分
+### DSH-0.1.2-A1-03 · 会话视图工程大幅拆分
 
 - **类型**: breaking
-- **影响触点**: #1（源码 patch）、#5（内部 UI / 命令注册）
-- **症状**: patch 目标文件路径失效、内部导入路径 404、UI 注册找不到旧组件。
-- **迁移配方**: 上游要求「面向诉求分层导入合适模块」——逐一核对 patch 脚本与
-  import 语句引用的宿主文件：已移动的按新分层改路径，已拆分的按功能改从
-  owning 模块导入。没有自动映射表，需对照上游 compare 逐文件确认。
-- **验证**: patch-surface 映射逐一核对（参考 dsh-tui 的
-  `verify:alpha-source` 做法：`DSH_HARNESS_SOURCE_ROOT` 指向目标版本源码做
-  合成验证）。
-- **来源**: [release notes](https://github.com/deepseek-ai/deepseek-harness/releases/tag/dsh-v0.1.2-alpha.1) 「其他变更」节。
-- **实战批注**（2026-08-30，dsh-tui 适配）: 重度 UI 集成插件此卡工作量最大
-  （dsh-tui 适配约 44 文件中大部分源于此类），建议独立分支单独迁移。
+- **适用对象**: patch 宿主源码或从会话视图内部路径导入的 Host/Web Client 集成
+- **影响触点**: #1、#5
+- **操作级别**: required-if-hit
+- **症状**: patch 目标路径、内部 import 或 UI 注册点失效。
+- **迁移配方**: 对照精确 tag compare 逐一核对宿主路径；按 owning 模块重建导入。没有稳定公开 seam 的能力标记「待确认」，不要猜新路径。普通插件优先迁到公开 facet/service，避免继续增加内部导入。
+- **验证**: 用目标 tag 源码做 patch-surface 合成；每个旧目标都必须映射到目标版本文件或明确删除原因。
+- **来源**: [alpha.1 release notes「其他变更」](https://github.com/deepseek-ai/deepseek-harness/releases/tag/dsh-v0.1.2-alpha.1)
+- **实战批注**: dsh-tui 使用 `DSH_HARNESS_SOURCE_ROOT` 指向目标 tag，并对 patch-surface 路径逐项合成验证。
 
 ---
 
-### ALPHA1-04 · 应用统一经 `dsh` Profile 启动（含 Python SDK、ACP 模式）
+### DSH-0.1.2-A1-04 · 应用统一经 `dsh` Profile 启动
 
 - **类型**: behavior
-- **影响触点**: #4（直接读写宿主目录）、#6（子进程启动包装）
-- **症状**: 假设了旧启动链路的路径探测、环境变量注入、进程树结构可能失配。
-- **迁移配方**: 检查插件对启动链路的所有假设：profile 目录解析（以 `DSH_HOME`
-  与官方脚本为准，勿硬编码）、子进程 spawn 的参数与 cwd、SDK/ACP 场景下的
-  环境变量传递。
-- **验证**: 冷启动 + 升级启动（保留旧 profile 数据）各跑一次，比对插件
-  探测到的路径集合。
-- **来源**: [release notes](https://github.com/deepseek-ai/deepseek-harness/releases/tag/dsh-v0.1.2-alpha.1) 「其他变更」节。
+- **适用对象**: 启动包装器、Python SDK/ACP 集成、直接读取 profile 文件的插件
+- **影响触点**: #4、#7
+- **操作级别**: required-if-hit
+- **症状**: 旧进程树、cwd、环境变量或固定 profile 路径假设失配。
+- **迁移配方**: 以运行时 `DSH_HOME`、目标 profile 和官方启动器为事实源；区分 profile composition（如 `cordis.patch.yml` / `agent.cordis.yml`）、包清单和 resolved config，不硬编码用户目录。
+- **验证**: 新 profile 冷启动与旧 profile 升级启动各一次；核对 cwd、环境变量、插件挂载与 resolved config。
+- **来源**: [alpha.1 release notes「其他变更」](https://github.com/deepseek-ai/deepseek-harness/releases/tag/dsh-v0.1.2-alpha.1)
 
 ---
 
-### ALPHA1-05 · Headless：进度改走 stderr，stdout 只出最终结果
+### DSH-0.1.2-A1-05 · Headless：stderr 输出 reasoning/错误，stdout 输出最终文本
 
 - **类型**: behavior
-- **影响触点**: #6（stdout 解析）
-- **症状**: 解析 stdout 的包装器/脚本把进度文本当结果，或因 stdout 迟迟不
-  flush 而超时。
-- **迁移配方**: 解析端只读 stdout 的最终 JSON；进度展示改订阅 stderr 流。
-  若插件把 stdout 当日志收，需整体换管道。
-- **验证**: 真实 headless 跑一遍，diff 迁移前后两个管道的内容分类。
-- **来源**: [release notes](https://github.com/deepseek-ai/deepseek-harness/releases/tag/dsh-v0.1.2-alpha.1) 「其他变更」节。
+- **适用对象**: headless 包装器、进程监督器、stdout/stderr 解析器
+- **影响触点**: #7
+- **操作级别**: required-if-hit
+- **症状**: 把 stdout 当 JSONL 事件流会解析失败；忽略 stderr 会丢 reasoning 与错误；只看输出文本会误判失败。
+- **迁移配方**: 将 stdout 作为最终 assistant **文本**通道（除非具体入口另有结构化契约）；stderr 接收 `dsh: reasoning:` 段或 `dsh: <code>: <message>`；以退出码判定成功（完成为 0，失败/中止/无完成回合为 1）。不要对 stdout 默认 `JSON.parse`。
+- **验证**: 覆盖纯文本成功、带 reasoning、空最终文本、直接启动失败与非零退出；确认敏感 reasoning 被送到受控 stderr sink。
+- **来源**: [alpha.1 headless README](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/packages/bundle/headless/README.md)
 
 ---
 
-### ALPHA1-06 · Code Mode 更名 PTC mode
+### DSH-0.1.2-A1-06 · Code Mode 精确更名为 PTC mode
 
-- **类型**: behavior
-- **影响触点**: #5、#6；文档/UI 文案里的字符串引用
-- **症状**: 按旧名 `Code Mode` 匹配的模式串、配置键、文案失效（旧会话记录
-  仍可读，仅命名变化）。
-- **迁移配方**: 全局替换模式串与配置键为新名 `PTC mode`；对外文案同步。
-- **验证**: grep 无残留旧名；功能路径 smoke。
-- **来源**: [release notes](https://github.com/deepseek-ai/deepseek-harness/releases/tag/dsh-v0.1.2-alpha.1) 「其他变更」节。
+- **类型**: breaking
+- **适用对象**: 使用工具呈现模式、PTC preset、dispatch waterfall 或相关类型的插件
+- **影响触点**: #2、#3、#5、#7
+- **操作级别**: required-if-hit
+- **症状**: `tools.mode: code`、preset id `code`、旧 dispatch 名称与 prompt rule 不再受支持。
+- **迁移配方**: **禁止全局替换 `code`**。只按 ledger 改：
+  - `tools.mode: 'code'` → `'ptc'`
+  - preset id/目录 `code` → `ptc`
+  - `tools/code-dispatch-log` → `tools/ptc-dispatch-log`
+  - `CodeDispatch*` → `PtcDispatch*`
+  - `tools:code-only` → `tools:ptc-only`
+  - 用户文案 `Code Mode` → `PTC mode` / `PTC 模式`
 
----
-
-### ALPHA1-07 · 公网 WebFetch 默认开启（内置 SSRF 防护，不再逐次审批）
-
-- **类型**: behavior
-- **影响触点**: 权限/审批类插件（跨 #2/#3）
-- **症状**: 依赖「WebFetch 逐次审批」默认行为的权限类插件，其审批钩子不再
-  被触发；用户侧感知为插件"失明"。
-- **迁移配方**: 审批插件改为感知新的默认策略（公网直通 + SSRF 防护内置），
-  把自己的规则挂到剩余仍需审批的类别上；或向用户提供恢复逐次审批的配置指引。
-- **验证**: 公网/内网各发一次 WebFetch，断言插件钩子的触发集合符合预期。
-- **来源**: [release notes](https://github.com/deepseek-ai/deepseek-harness/releases/tag/dsh-v0.1.2-alpha.1) 「其他变更」节。
+  保持不变：`run_code`、它的 `code` 参数、`CodeSdkLanguage`、`CodeRunFailedError`、
+  `dsh-code-runtime*` 包族，以及持久事件 `tool/code-dispatch*`、插件名
+  `tools-code-mode`、sub-call id 中的 `:code:`。
+- **验证**: 新配置/preset 可启动；旧 Session 日志仍能加载；保留标识未被误改。
+- **来源**: [PTC rename ledger](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/.agents/notes/implemented/architecture/2026-08-25-rename-code-mode-to-ptc.md)
 
 ---
 
-### ALPHA1-08 · 新能力：插件可在模型设置页添加提供方登录配置
+### DSH-0.1.2-A1-07 · 公网 WebFetch 默认开启且不再逐次审批
+
+- **类型**: security
+- **适用对象**: 权限、审批、WebFetch 策略与审计插件
+- **影响触点**: #2、#3
+- **操作级别**: conditional
+- **症状**: 依赖旧默认审批路径的插件**可能**观察到不同的授权事件集合；release notes 未保证具体插件钩子形状。
+- **迁移配方**: 先在目标版本实测公网与内网请求的授权事件，再调整策略；不要假设存在“恢复逐次审批”的配置，除非目标 tag 的配置目录明确声明。保留 SSRF 与私网拒绝的 fail-closed 测试。
+- **验证**: 公网、loopback、私网和被拒目标分别测试，记录实际授权事件及结果。
+- **来源**: [alpha.1 release notes「其他变更」](https://github.com/deepseek-ai/deepseek-harness/releases/tag/dsh-v0.1.2-alpha.1)
+
+---
+
+### DSH-0.1.2-A1-08 · Web/API 通道启用一次性 launch token 与统一认证
+
+- **类型**: security
+- **适用对象**: 自建 loopback HTTP/WS/RPC、浏览器页面或自定义 `/api` 路由的插件
+- **影响触点**: #6
+- **操作级别**: required-if-hit
+- **症状**: 网络访问 Web UI 或直接调用 `/api` 的旧通道可能收到 401/403；绕过认证的私有路由形成安全缺口。
+- **迁移配方**: 使用宿主 Connection/Gateway 的认证与注册路由，不复制或绕过 launch token；完整 `/api` 请求在路由分发前校验 browser session、Host 与 Origin。`/api/session.export` 等 exact Fetch route 同样受保护。
+- **验证**: 无 token、已消费 token、错误 Host/Origin 必须拒绝；合法 launch URL 建立的会话可调用 Remote 与注册 Fetch route。
+- **来源**: [alpha.1 release notes「其他变更」](https://github.com/deepseek-ai/deepseek-harness/releases/tag/dsh-v0.1.2-alpha.1) · [APIProxy→Remote 架构笔记「Browser authentication」](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/.agents/notes/implemented/architecture/2026-08-10-unary-apiproxy-remote-migration.md)
+
+---
+
+### DSH-0.1.2-A1-09 · 新能力：模型设置页可接入提供方登录配置
 
 - **类型**: capability
-- **影响触点**: #5（UI 注册）
-- **症状**: 无（机会型卡片）
-- **迁移配方**: 提供方类插件可把自建的登录 UI 迁入宿主模型设置页，减少
-  自绘弹窗。
-- **验证**: 注册项在设置页可见可用。
-- **来源**: [release notes](https://github.com/deepseek-ai/deepseek-harness/releases/tag/dsh-v0.1.2-alpha.1) 「新增功能」节。
-
----
-
-### ALPHA1-09 · 新能力：支持注册第三方语言
-
-- **类型**: capability
+- **适用对象**: 模型提供方插件
 - **影响触点**: #5
-- **症状**: 无（机会型卡片）
-- **迁移配方**: 曾自带 i18 补丁的插件可改用官方注册机制。
-- **验证**: 注册语言在宿主设置中可选且生效。
-- **来源**: [release notes](https://github.com/deepseek-ai/deepseek-harness/releases/tag/dsh-v0.1.2-alpha.1) 「新增功能」节。
+- **操作级别**: optional
+- **症状**: 无；这是可选能力。
+- **迁移配方**: 采用前先从目标 tag 的公开类型/示例确认注册入口；若只找到内部 UI 接口，标「待确认」，不要 patch 设置页。
+- **验证**: 登录入口可见、凭据写入走宿主凭据服务、卸载插件后入口消失。
+- **来源**: [alpha.1 release notes「新增功能」](https://github.com/deepseek-ai/deepseek-harness/releases/tag/dsh-v0.1.2-alpha.1)
 
 ---
 
-### ALPHA1-10 · 新能力：子代理可指定 provider / model / 推理力度 / 最大输出长度
+### DSH-0.1.2-A1-10 · 新能力：支持注册第三方语言
 
 - **类型**: capability
-- **影响触点**: #3（调用方）、#5（选择器 UI）
-- **症状**: 无（机会型卡片）
-- **迁移配方**: 管理子代理的插件可透传新参数；开启子代理模型选择后 Agent 可
-  在授权范围内自选。
-- **验证**: 带参启动一个子代理，断言参数生效。
-- **来源**: [release notes](https://github.com/deepseek-ai/deepseek-harness/releases/tag/dsh-v0.1.2-alpha.1) 「新增功能」节。
+- **适用对象**: 提供本地化资源的 UI 插件
+- **影响触点**: #5
+- **操作级别**: optional
+- **症状**: 无；这是可选能力。
+- **迁移配方**: 用目标 tag 的公开语言注册 API 替代自建 i18n patch；未找到公开入口时不要猜测接口。
+- **验证**: 语言可选、切换后生效、缺失键按宿主规则回退。
+- **来源**: [alpha.1 release notes「新增功能」](https://github.com/deepseek-ai/deepseek-harness/releases/tag/dsh-v0.1.2-alpha.1)
 
 ---
 
-### ALPHA1-11 · DeepSeek 官方适配器默认上报已启用插件包名+版本
+### DSH-0.1.2-A1-11 · 新能力：子代理可选择 provider/model/推理力度/输出上限
 
 - **类型**: capability
-- **影响触点**: 无代码触点；**用户隐私面**
-- **症状**: 无（知情型卡片）
-- **迁移配方**: 面向用户的插件应在文档中告知此默认行为，并指出配置中可关闭；
-  不需要代码改动。
-- **验证**: 不适用。
-- **来源**: [release notes](https://github.com/deepseek-ai/deepseek-harness/releases/tag/dsh-v0.1.2-alpha.1) 「新增功能」节。
+- **适用对象**: 子代理编排或选择器插件
+- **影响触点**: #3、#5
+- **操作级别**: optional
+- **症状**: 无；这是可选能力。
+- **迁移配方**: 从目标 tag 类型定义确认确切参数名与授权约束后再透传；不要根据 release notes 自造对象结构。
+- **验证**: 带参启动子代理，核对授权范围、实际 provider/model、推理力度与最大输出长度。
+- **来源**: [alpha.1 release notes「新增功能」](https://github.com/deepseek-ai/deepseek-harness/releases/tag/dsh-v0.1.2-alpha.1)
 
 ---
 
-### ALPHA1-12 · 宿主平台修复杂项（间接影响）
+### DSH-0.1.2-A1-12 · 官方 DeepSeek 适配器默认附带插件包名与版本
+
+- **类型**: privacy
+- **适用对象**: 使用官方 DeepSeek 适配器的部署与面向用户的插件
+- **影响触点**: 无（部署/隐私面）
+- **操作级别**: informational
+- **症状**: 启用插件的包名与版本默认随请求提供；部署可通过配置关闭。
+- **迁移配方**: 插件代码通常无需修改；部署维护者应审阅目标 tag 的配置项，按自身隐私政策决定是否关闭，并向用户准确说明宿主行为。
+- **验证**: 在不打印凭据或请求正文的前提下，仅验证配置开关是否改变元数据附带状态。
+- **来源**: [alpha.1 release notes「新增功能」](https://github.com/deepseek-ai/deepseek-harness/releases/tag/dsh-v0.1.2-alpha.1)
+
+---
+
+### DSH-0.1.2-A1-13 · 平台 shell 与目录选择器修复可能淘汰旧 workaround
 
 - **类型**: fix
-- **影响触点**: #6（依赖持久 shell 输出时序的插件）
-- **症状**: 曾为绕过下列问题加的 workaround 行为失配——macOS/Linux 持久
-  PowerShell 启动过早输出不完整、Linux 持久 Bash 管道读取提前返回空输出、
-  macOS Bash 大量子进程导致宿主卡顿、Windows 目录选择器截断特定编码路径。
-- **迁移配方**: 检索 workaround 注释与适配分支，逐一验证是否可移除。
-- **验证**: 移除后在对应平台跑真实会话。
-- **来源**: [release notes](https://github.com/deepseek-ai/deepseek-harness/releases/tag/dsh-v0.1.2-alpha.1) 「问题修复」节。
+- **适用对象**: 为持久 PowerShell/Bash 或 Windows 目录选择器维护兼容 workaround 的插件
+- **影响触点**: #4、#7
+- **操作级别**: conditional
+- **症状**: 旧 workaround 可能产生重复等待、错误截断或平台分支漂移。
+- **迁移配方**: 只在对应平台复现确认修复后，逐条删除有证据已不需要的 workaround；不要一次性清理所有兼容分支。
+- **验证**: macOS/Linux 持久 shell、macOS 多子进程、Windows 特定编码路径分别做目标平台测试。
+- **来源**: [alpha.1 release notes「问题修复」](https://github.com/deepseek-ai/deepseek-harness/releases/tag/dsh-v0.1.2-alpha.1)
 
 ---
 
-*未收卡片的宿主侧变化（对插件无直接触点）：会话流折叠/宽度自适应/token 用量
-展示、回合导航、字号调节、启动性能优化、图片压缩策略、会话记录磁盘占用、
-安全说明更新、提示词顺序、Web 一次性 token 认证、vLLM 思考预算。*
+*未建卡的宿主 UI/性能变化不代表“确定无 API 影响”；这里只表示官方材料未声明
+插件迁移动作。发现真实插件受影响时，应补带一手证据的卡片。*

--- a/skills/plugin-upgrade/references/v0.1.2-alpha.2.md
+++ b/skills/plugin-upgrade/references/v0.1.2-alpha.2.md
@@ -1,74 +1,96 @@
+---
+kind: dsh-version-card-set
+schema: 1
+from: dsh-v0.1.2-alpha.1
+to: dsh-v0.1.2-alpha.2
+status: reviewed
+coverage: curated
+cardCount: 4
+idPrefix: DSH-0.1.2-A2
+verifiedAt: 2026-08-30
+---
+
 # 变更卡片 · 0.1.2-alpha.2
 
-> **相对基线**: `dsh-v0.1.2-alpha.1`
+> 本文件是**插件相关变更的精选清单，不是完整 API diff**。
+>
 > **上游比较**: [dsh-v0.1.2-alpha.1...dsh-v0.1.2-alpha.2](https://github.com/deepseek-ai/deepseek-harness/compare/dsh-v0.1.2-alpha.1...dsh-v0.1.2-alpha.2)
-> **Release Notes**: [中文](https://github.com/deepseek-ai/deepseek-harness/releases/tag/dsh-v0.1.2-alpha.2)
-> 卡片格式见 [references/README.md](README.md)。触点编号对应 [pre-flight 清单](pre-flight.md)。
+> · **Release Notes**: [dsh-v0.1.2-alpha.2](https://github.com/deepseek-ai/deepseek-harness/releases/tag/dsh-v0.1.2-alpha.2)
+> · 卡片格式见 [references/README.md](README.md)
+> · 触点编号见 [pre-flight.md](pre-flight.md)
 
 ---
 
-### ALPHA2-01 · `SessionEvent.ignorable` 恢复
-
-- **类型**: fix（对 [ALPHA1-02](v0.1.2-alpha.1.md) 的回滚）
-- **影响触点**: #2（内部事件名）
-- **症状**: 无新破坏；曾按 ALPHA1-02 迁移、删除 `ignorable` 依赖的插件，
-  现在可以（但不必须）恢复原过滤逻辑。
-- **迁移配方**: 目标版本 ≥ alpha.2 时：恢复读取 `ignorable` 的代码可原样
-  回归；若已改用事件类型白名单且运行良好，保留新写法亦可——两种都合法。
-  写新代码时建议仍以字段为准、白名单兜底，防后续版本再波动。
-- **验证**: 事件回放夹具下断言两种实现的过滤结果一致。
-- **来源**: [release notes](https://github.com/deepseek-ai/deepseek-harness/releases/tag/dsh-v0.1.2-alpha.2) 「其他变更」节。
-
----
-
-### ALPHA2-02 · Remote 网关统一 `RemoteError` 异常封装
-
-- **类型**: behavior
-- **影响触点**: #3（内部服务探测，承接 [ALPHA1-01](v0.1.2-alpha.1.md)）
-- **症状**: 迁到 Remote 后若仍按旧异常形状写 catch（如裸 `Error.message`
-  前缀匹配），错误分类会失效。
-- **迁移配方**: 所有 Remote 调用点的错误处理统一改为：
-
-  1. `catch (e)` 先判 `RemoteError`；
-  2. 按 `code` 分支处理已知业务码（如 `session/not-found`、
-     `session/agent-busy`）；
-  3. `gateway/internal` 与未知码走通用兜底（重试/上报），不再解析消息文本。
-
-- **验证**: 对每个调用点单测至少两条错误码路径 + 一条未知码路径。
-- **来源**: [release notes](https://github.com/deepseek-ai/deepseek-harness/releases/tag/dsh-v0.1.2-alpha.2) 「其他变更」节 ·
-  架构笔记 [ctx-remote-failure-vocabulary](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/.agents/notes/implemented/architecture/2026-08-28-ctx-remote-failure-vocabulary.md)
-
----
-
-### ALPHA2-03 · NPM 包 peer dependency 裁剪
-
-- **类型**: behavior
-- **影响触点**: 打包/分发面（无源码触点；影响安装与解析）
-- **症状**: 依赖解析行为变化——曾因 peer 冲突被迫 pin 版本或加
-  overrides 的安装脚本，可能不再需要；反之，隐式依赖旧 peer 的插件在
-  严格包管理器下可能暴露缺失依赖。
-- **迁移配方**: 在干净环境（无缓存）重装一遍插件及其依赖；移除不再需要的
-  overrides；补齐暴露出的显式依赖。
-- **验证**: `pnpm install` / `npm install` 干净环境零警告零报错。
-- **来源**: [release notes](https://github.com/deepseek-ai/deepseek-harness/releases/tag/dsh-v0.1.2-alpha.2) 「问题修复」节（"优化 NPM 包中的 peer dependency 依赖"）。
-
----
-
-### ALPHA2-04 · Node.js 24.0–24.11.1 启动失败修复
+### DSH-0.1.2-A2-01 · 恢复第三方持久事件的 `SessionEvent.ignorable`
 
 - **类型**: fix
-- **影响触点**: #6（环境检测/启动包装）
-- **症状**: 无新破坏。
-- **迁移配方**: 检索插件内为绕过该 Node 缺陷加的版本检测、engines 限制或
-  降级提示，逐一验证是否可移除；受影响的 Node 版本区间是 24.0–24.11.1。
-- **验证**: 在 Node 24 最新版与 LTS 各跑一次冷启动。
-- **来源**: [release notes](https://github.com/deepseek-ai/deepseek-harness/releases/tag/dsh-v0.1.2-alpha.2) 「问题修复」节。
+- **适用对象**: 生产第三方持久 SessionEvent 的插件，以及 persistence/reload/transport 集成
+- **影响触点**: #2
+- **操作级别**: required-if-hit
+- **症状**: alpha.1 无法保留外部 informational event 的 marker；alpha.2 恢复后，旧适配若继续删除 marker，会让第一方 reader 拒绝包含未知事件的 Session。
+- **迁移配方**: producer 只对“即使跳过也不影响重建”的 informational event 写 `ignorable: true`；JSONL、SQLite、API transport 和 generated catalog 必须保留该字段。未知事件没有 marker 时仍是 required-on-read，必须 fail closed；禁止把所有外部事件推断成可忽略。SQLite 物理格式升到 schema 20，打开 alpha.1 数据前先按目标存储 provider 的 cutover/rebuild 规则验证，不臆造跨 schema 迁移。
+- **验证**: 未知且 `ignorable: true` 的事件可持久化、reload 并被安全跳过；未知 required 事件被拒；已有 alpha.1 数据的启动/重建路径经过实测。
+- **来源**: [alpha.2 release notes](https://github.com/deepseek-ai/deepseek-harness/releases/tag/dsh-v0.1.2-alpha.2) · [retain ignorable external session events 决策](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/.agents/notes/implemented/architecture/2026-08-30-retain-ignorable-external-session-events.md) · 回滚 [DSH-0.1.2-A1-02](v0.1.2-alpha.1.md)
 
 ---
 
-*未收卡片的宿主侧变化（对插件无直接触点）：界面显示连接异常状态并支持自动
-重试/立即重连、会话标题区显示活动定时计划、插件列表按会话/全局分组与 Agent
-Preset 切换、菜单/滚动条/文件链接/diff 统计改善、长会话历史处理效率、回答
-末尾 token 用量展示、web_search 失败报端点明细、权限分类本地化、`@` 菜单
-面包屑修复、设置窗口焦点返回。其中「插件列表分组」值得插件作者知晓：宿主
-对插件的作用域展示变精细了，但无 API 变化。*
+### DSH-0.1.2-A2-02 · Remote unary 统一 `RemoteResult` / `RemoteError` 词汇
+
+- **类型**: breaking
+- **适用对象**: 使用 `ctx.remote` 或承接 Remote failure 的 Host/Web Client 集成
+- **影响触点**: #3
+- **操作级别**: required-if-hit
+- **症状**: 解析 `Error.message`、给每次调用套防御性 catch、或跨 realm 使用 `instanceof RemoteError` 会误分业务失败与本地装配缺陷。
+- **迁移配方**: Unary Remote 调用解析为 `RemoteResult<T>`，业务/载体失败在结果分支中处理：
+
+  ```ts
+  const result = await ctx.remote.sessionTitle.rename(args)
+  if (!result.ok) {
+    switch (result.error.code) {
+      case 'session/not-found':
+      case 'session/agent-busy':
+        // 按业务语义处理 result.error.details
+        break
+      default:
+        // 上报或向用户呈现；不要默认重试有副作用的调用
+        break
+    }
+  }
+  ```
+
+  Remote 调用不会因普通业务/载体失败 reject；装配故障应暴露而不是被防御性 catch 吞掉。只有上层接住主动 `throw result.error` 的值时，才用
+  `isRemoteFailure`（`@deepseek-ai/dsh-api-gateway/client`）做结构判别；永远不要用
+  `instanceof`。重试必须同时满足“错误码可重试、操作幂等、用户策略允许”。
+- **验证**: 覆盖成功、`session/not-found`、`session/agent-busy`、取消、未知业务码和本地装配缺陷；本地缺陷不得被当 Remote failure 吞掉。
+- **来源**: [RemoteError failure vocabulary](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/.agents/notes/implemented/architecture/2026-08-28-ctx-remote-failure-vocabulary.md) · [adding a Remote API](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/docs/cookbook/adding-a-remote-api.md)
+
+---
+
+### DSH-0.1.2-A2-03 · NPM 包裁剪不必要的 peer dependency
+
+- **类型**: behavior
+- **适用对象**: 插件打包、安装与依赖图维护
+- **影响触点**: 无（打包/分发面）
+- **操作级别**: conditional
+- **症状**: 目标包的 peer 解析集合变化；旧 override 可能仍有其他用途，隐式依赖也可能在严格包管理器下暴露。
+- **迁移配方**: 先按 lockfile 选择仓库现用的唯一包管理器；在隔离目录用 frozen lockfile/等价模式验证。逐条证明 override 只为已裁剪 peer 服务后再删除，不切换包管理器、不重写另一套 lockfile、不以“所有 warning 为零”为目标。
+- **验证**: 安装成功；没有新增与目标升级相关的 peer 错误；依赖图和打包产物只出现预期变化。
+- **来源**: [alpha.2 release notes「问题修复」](https://github.com/deepseek-ai/deepseek-harness/releases/tag/dsh-v0.1.2-alpha.2)
+
+---
+
+### DSH-0.1.2-A2-04 · Node.js 24.0–24.11.1 启动失败修复
+
+- **类型**: fix
+- **适用对象**: 启动包装器、Node engines 限制和临时降级逻辑
+- **影响触点**: #7
+- **操作级别**: conditional
+- **症状**: 无新破坏；为受影响区间添加的 workaround 可能不再需要。
+- **迁移配方**: 只删除有证据专门绕过该缺陷的 engines 限制或版本分支；保留其他 Node 兼容约束。
+- **验证**: 目标支持的 Node LTS 与 Node 24 最新修复版本分别冷启动；HMR 场景按插件实际支持范围验证。
+- **来源**: [alpha.2 release notes「问题修复」](https://github.com/deepseek-ai/deepseek-harness/releases/tag/dsh-v0.1.2-alpha.2)
+
+---
+
+*未建卡的宿主 UI/性能变化仅表示官方材料未声明插件迁移动作，不等于已证明没有
+API 或行为影响。发现真实插件受影响时，应补一手来源与可复现验证。*


### PR DESCRIPTION
## Summary

Hardens `plugin-upgrade` after the repository review and integrates the safety/runtime work already merged on main.

- splits the workflow into explicit read-only inspect, installed-plugin update, and DSH host-migration modes
- requires a preview + confirmation before every write/install/script action; adds dirty-worktree, credential, provenance, rollback, runtime activation, and no-default-retry rules
- corrects the alpha.1/alpha.2 cards for `RemoteResult`/`RemoteError`, `SessionEvent.ignorable`, PTC rename, Headless stdout/stderr, WebFetch, Web launch authentication, peer dependencies, and Node 24
- replaces ambiguous IDs with full-version IDs and adds directed `from/to` card-set metadata
- aligns the migration taxonomy with the community standard's six classes and adds #7 subprocess/output parsing
- upgrades the legacy fixture to seven static touchpoints and marks it non-executable
- adds a dependency-free validator + GitHub Actions gate for Skill frontmatter, links, card schema/count/IDs/corridors, cross-references, regex validity, and fixture coverage
- fixes the official DSH link, adds installation examples, package scripts, and the declared MIT license

## Validation

- `npm test`
- `node --check scripts/validate.mjs`
- `git diff --check`

Local result: `Validation OK: 1 skill, 2 card sets, 17 cards, 8 Markdown files, 7 touchpoint fixtures`.

Refs #1.
