### PR TITLE
fix(plugin-upgrade): tighten alpha2 runtime contracts

### DIFF
--- a/skills/plugin-upgrade/references/v0.1.2-alpha.2.md
+++ b/skills/plugin-upgrade/references/v0.1.2-alpha.2.md
@@ -28,8 +28,8 @@ verifiedAt: 2026-08-30
 - **影响触点**: #2
 - **操作级别**: required-if-hit
 - **症状**: alpha.1 无法保留外部 informational event 的 marker；alpha.2 恢复后，旧适配若继续删除 marker，会让第一方 reader 拒绝包含未知事件的 Session。
-- **迁移配方**: producer 只对“即使跳过也不影响重建”的 informational event 写 `ignorable: true`；JSONL、SQLite、API transport 和 generated catalog 必须保留该字段。未知事件没有 marker 时仍是 required-on-read，必须 fail closed；禁止把所有外部事件推断成可忽略。SQLite 物理格式升到 schema 20，打开 alpha.1 数据前先按目标存储 provider 的 cutover/rebuild 规则验证，不臆造跨 schema 迁移。
-- **验证**: 未知且 `ignorable: true` 的事件可持久化、reload 并被安全跳过；未知 required 事件被拒；已有 alpha.1 数据的启动/重建路径经过实测。
+- **迁移配方**: producer 只对“旧 reader 即使省略其语义也不影响重建”的 informational event 写 `ignorable: true`；该 marker 不是消费端过滤指令，reload 后事件仍保留在 loaded events。JSONL、SQLite、API transport 和 generated catalog 必须原样保留字段；未知事件没有 marker 时仍是 required-on-read，必须 fail closed。SQLite provider 只接受 schema 20，不自动迁移 alpha.1 的 schema 19，并拒绝其他 schema；升级前先在 alpha.1 备份/导出，或按 provider 文档重建 alpha.2 存储，不能直接复用并期待自动升级。
+- **验证**: 未知且 `ignorable: true` 的事件持久化/reload 后仍存在于 loaded events，旧 reader 可省略其语义；未知 required 事件被拒；schema 19 被明确拒绝，完成备份/导出或重建后的 schema 20 可启动。
 - **来源**: [alpha.2 release notes](https://github.com/deepseek-ai/deepseek-harness/releases/tag/dsh-v0.1.2-alpha.2) · [retain ignorable external session events 决策](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/.agents/notes/implemented/architecture/2026-08-30-retain-ignorable-external-session-events.md) · 回滚 [DSH-0.1.2-A1-02](v0.1.2-alpha.1.md)
 
 ---
@@ -47,12 +47,15 @@ verifiedAt: 2026-08-30
   const result = await ctx.remote.sessionTitle.rename(args)
   if (!result.ok) {
     switch (result.error.code) {
+      case 'gateway/cancelled':
+        // 结束当前操作或沿调用链传播取消；不要重试或报通用错误
+        return
       case 'session/not-found':
       case 'session/agent-busy':
         // 按业务语义处理 result.error.details
         break
       default:
-        // 上报或向用户呈现；不要默认重试有副作用的调用
+        // 保留 code/details 并上报；仅明确瞬态且幂等的操作才可重试
         break
     }
   }
@@ -60,8 +63,8 @@ verifiedAt: 2026-08-30
 
   Remote 调用不会因普通业务/载体失败 reject；装配故障应暴露而不是被防御性 catch 吞掉。只有上层接住主动 `throw result.error` 的值时，才用
   `isRemoteFailure`（`@deepseek-ai/dsh-api-gateway/client`）做结构判别；永远不要用
-  `instanceof`。重试必须同时满足“错误码可重试、操作幂等、用户策略允许”。
-- **验证**: 覆盖成功、`session/not-found`、`session/agent-busy`、取消、未知业务码和本地装配缺陷；本地缺陷不得被当 Remote failure 吞掉。
+  `instanceof`。`gateway/cancelled` 应终止/静默取消或沿调用链传播；`gateway/internal` 与未知码默认保留原始 `code/details` 并上报，不重试。只有明确瞬态码、幂等操作且用户策略允许时才重试。
+- **验证**: 覆盖成功、`gateway/cancelled`、`session/not-found`、`session/agent-busy`、`gateway/internal`、未知业务码和本地装配缺陷；取消不得变成通用错误，internal/未知不得自动重试。
 - **来源**: [RemoteError failure vocabulary](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/.agents/notes/implemented/architecture/2026-08-28-ctx-remote-failure-vocabulary.md) · [adding a Remote API](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/docs/cookbook/adding-a-remote-api.md)
 
 ---
@@ -86,8 +89,8 @@ verifiedAt: 2026-08-30
 - **影响触点**: #7
 - **操作级别**: conditional
 - **症状**: 无新破坏；为受影响区间添加的 workaround 可能不再需要。
-- **迁移配方**: 只删除有证据专门绕过该缺陷的 engines 限制或版本分支；保留其他 Node 兼容约束。
-- **验证**: 目标支持的 Node LTS 与 Node 24 最新修复版本分别冷启动；HMR 场景按插件实际支持范围验证。
+- **迁移配方**: 只删除有证据专门绕过该缺陷的 engines 限制或版本分支；保留其他 Node 兼容约束。验证矩阵必须包含故障窗口内版本，不能只测 latest/LTS。
+- **验证**: 至少在官方 CI 使用的 Node 24.9（故障窗口 24.0–24.11.1）、修复后的 Node 24.12 或当前 24.x、以及受支持的 Node 22 LTS 上冷启动；插件涉及 HMR 时三档都验证 HMR。
 - **来源**: [alpha.2 release notes「问题修复」](https://github.com/deepseek-ai/deepseek-harness/releases/tag/dsh-v0.1.2-alpha.2)
 
 ---


### PR DESCRIPTION
## Summary

Tightens three alpha.2 runtime contracts from fixed-tag source verification:

- `SessionEvent.ignorable` keeps the event in loaded events; it permits an older reader to omit semantic handling. Documents SQLite schema 19→20 as an explicit backup/export or rebuild cutover, not an automatic migration.
- `gateway/cancelled` terminates/propagates cancellation without retry or generic error reporting; `gateway/internal` and unknown codes preserve code/details and default to report-only.
- Node validation now covers 24.9 (the affected 24.0–24.11.1 window), 24.12/current 24.x, and Node 22 LTS instead of only latest/LTS.

## Validation

- `npm test`
- `node --check scripts/validate.mjs`
- `git diff --check`

Result: `Validation OK: 1 skill, 2 card sets, 20 cards, 8 Markdown files, 7 touchpoint fixtures`.
