### PR TITLE
fix(plugin-upgrade): correct bootstrap and producer seams

### DIFF
--- a/skills/plugin-upgrade/references/v0.1.2-alpha.1.md
+++ b/skills/plugin-upgrade/references/v0.1.2-alpha.1.md
@@ -151,16 +151,16 @@ verifiedAt: 2026-08-30
 
 ---
 
-### DSH-0.1.2-A1-08 · Web/API 通道启用一次性 launch token 与统一认证
+### DSH-0.1.2-A1-08 · Web/API 通道使用 process-scoped bootstrap token 与签名 Cookie
 
 - **类型**: security
 - **适用对象**: 自建 loopback HTTP/WS/RPC、浏览器页面或自定义 `/api` 路由的插件
 - **影响触点**: #6
 - **操作级别**: required-if-hit
-- **症状**: 网络访问 Web UI 或直接调用 `/api` 的旧通道可能收到 401/403；绕过认证的私有路由形成安全缺口。
-- **迁移配方**: 使用宿主 Connection/Gateway 的认证与注册路由，不复制或绕过 launch token；完整 `/api` 请求在路由分发前校验 browser session、Host 与 Origin。`/api/session.export` 等 exact Fetch route 同样受保护。
-- **验证**: 无 token、已消费 token、错误 Host/Origin 必须拒绝；合法 launch URL 建立的会话可调用 Remote 与注册 Fetch route。
-- **来源**: [alpha.1 release notes「其他变更」](https://github.com/deepseek-ai/deepseek-harness/releases/tag/dsh-v0.1.2-alpha.1) · [APIProxy→Remote 架构笔记「Browser authentication」](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/.agents/notes/implemented/architecture/2026-08-10-unary-apiproxy-remote-migration.md)
+- **症状**: 网络访问 Web UI 或直接调用 `/api` 的旧通道可能收到 401/403；绕过认证的私有路由形成安全缺口。bootstrap token 并非 strict single-use：同一进程内可重复兑换，进程重启才轮换。
+- **迁移配方**: token 只用于 `GET /?token=...`，成功后 303 到 `/` 并签发绑定 authority 的 HttpOnly/SameSite Cookie；不要把 token 放进 `/api`、WS URL 或 Authorization header。官方 `/api` Remote/RPC/exact Fetch route 与 `/api/remote.mux` 会调用 Connection auth gate。直接用 `ctx.webServer.register()` / `registerUpgrade()` 的自建 route **不会自动继承**认证、Host/Origin fence、CORS 或 TLS；handler 应先调用 `ctx.connection.requestRejection(req)`，或改用 Connection 所有的 carrier/seam。raw/Node client 需先兑换并保存 Cookie。
+- **验证**: 错误 Host/Origin 返回 403，无/坏 Cookie 返回 401；正确 bootstrap token 在同一进程可重复兑换 Cookie；合法 Cookie 可调用官方 `/api`/WS；自建 route 在未显式接入 gate 前不能被视为已保护。
+- **来源**: [alpha.1 browser auth](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/packages/client/connection/src/browser-auth.ts) · [alpha.1 Connection routes](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/packages/client/connection/src/index.ts) · [alpha.1 raw WebServer](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/packages/host/webserver/src/index.ts)
 
 ---
 

--- a/skills/plugin-upgrade/references/v0.1.2-alpha.2.md
+++ b/skills/plugin-upgrade/references/v0.1.2-alpha.2.md
@@ -28,8 +28,8 @@ verifiedAt: 2026-08-30
 - **影响触点**: #2
 - **操作级别**: required-if-hit
 - **症状**: alpha.1 无法保留外部 informational event 的 marker；alpha.2 恢复后，旧适配若继续删除 marker，会让第一方 reader 拒绝包含未知事件的 Session。
-- **迁移配方**: producer 只对“旧 reader 即使省略其语义也不影响重建”的 informational event 写 `ignorable: true`；该 marker 不是消费端过滤指令，reload 后事件仍保留在 loaded events。JSONL、SQLite、API transport 和 generated catalog 必须原样保留字段；未知事件没有 marker 时仍是 required-on-read，必须 fail closed。SQLite provider 只接受 schema 20，不自动迁移 alpha.1 的 schema 19，并拒绝其他 schema；升级前先在 alpha.1 备份/导出，或按 provider 文档重建 alpha.2 存储，不能直接复用并期待自动升级。
-- **验证**: 未知且 `ignorable: true` 的事件持久化/reload 后仍存在于 loaded events，旧 reader 可省略其语义；未知 required 事件被拒；schema 19 被明确拒绝，完成备份/导出或重建后的 schema 20 可启动。
+- **迁移配方**: producer 只对“旧 reader 即使省略其语义也不影响重建”的 informational event 写 `ignorable: true`；该 marker 不是消费端过滤指令，reload 后事件仍保留在 loaded events。alpha.2 恢复的是 envelope/persistence/reload/transport 的保留语义，公开 live `Session.append(...)` 仍没有 `ignorable` 参数；普通插件若只有该 API，应把 producer seam 标为能力缺口，不能靠 cast 假装已有公开入口。JSONL、SQLite、API transport 和 generated catalog 必须原样保留字段；未知事件没有 marker 时仍是 required-on-read。SQLite provider 只接受 schema 20，不自动迁移 schema 19，并拒绝其他 schema；升级前先备份/导出或按 provider 文档重建。
+- **验证**: 手工 envelope/seed 或拥有 persistence seam 的测试中，未知且 `ignorable: true` 的事件 reload 后仍存在于 loaded events，旧 reader 可省略其语义；未知 required 事件被拒；常规 `Session.append` 不应被文档成支持该字段；schema 19 被拒绝，重建后的 schema 20 可启动。
 - **来源**: [alpha.2 release notes](https://github.com/deepseek-ai/deepseek-harness/releases/tag/dsh-v0.1.2-alpha.2) · [retain ignorable external session events 决策](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/.agents/notes/implemented/architecture/2026-08-30-retain-ignorable-external-session-events.md) · 回滚 [DSH-0.1.2-A1-02](v0.1.2-alpha.1.md)
 
 ---


### PR DESCRIPTION
## Summary

Corrects two fixed-tag contract details:

- replaces the misleading "one-time launch token" wording with the actual process-scoped bootstrap token → authority-bound Cookie flow; documents that custom `ctx.webServer` routes do not inherit Connection auth automatically
- clarifies that alpha.2 restores `SessionEvent.ignorable` envelope/persistence/reload semantics, but regular live `Session.append(...)` still exposes no `ignorable` producer parameter

## Validation

- `npm test`
- `git diff --check`

Result: `Validation OK: 1 skill, 2 card sets, 20 cards, 14 Markdown files, 7 touchpoint fixtures`.
