### PR TITLE
feat: add dsh-upgrade-audit skill for cross-version external-compat audits

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,10 @@ cp -r dsh-plugin-upgrade-skill/skills/* .cursor/skills/
 | [plugin-write](skills/plugin-write/) | 按目标 Harness 合约编写 DSH 插件，区分官方单仓包与外部可安装插件 | 按目标 Harness 版本 |
 | [plugin-test](skills/plugin-test/) | 为 DSH 插件变更选择最小充分测试层级，覆盖单元测试、覆盖率、真实 API、快照、Web 及真实发布入口 | 跨版本验证 |
 
+## 版本兼容审计（dsh-upgrade-audit）
+
+[dsh-upgrade-audit](skills/dsh-upgrade-audit/) 审计两个 DSH 版本间的外部兼容性与回滚——npm 包公共 API、CLI 面、线上协议、会话落盘数据、模型可见契约，并显式检测 revert。有源码检出时走 git tag 对比；无源码自动降级下载 npm 双版本分析。产出标准 upgrade-report 目录（UPGRADE-ADAPTATION 报告 + 边界签名表），为 plugin-upgrade 的版本变更卡片提供证据。真实案例：[0.1.2-alpha.1 → alpha.2 审计报告](skills/dsh-upgrade-audit/examples/0.1.2alpha1-to-0.1.2alpha2/UPGRADE-ADAPTATION.md)。
+
 ## 版本数据现状
 
 | 版本区间 | 状态 | 卡片文件 | 说明 |

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ cp -r dsh-plugin-upgrade-skill/skills/* .cursor/skills/
 
 ## 版本兼容审计（dsh-upgrade-audit）
 
-[dsh-upgrade-audit](skills/dsh-upgrade-audit/) 审计两个 DSH 版本间的外部兼容性与回滚——npm 包公共 API、CLI 面、线上协议、会话落盘数据、模型可见契约，并显式检测 revert。有源码检出时走 git tag 对比；无源码自动降级下载 npm 双版本分析。产出标准 upgrade-report 目录（UPGRADE-ADAPTATION 报告 + 边界签名表），为 plugin-upgrade 的版本变更卡片提供证据。真实案例：[0.1.2-alpha.1 → alpha.2 审计报告](skills/dsh-upgrade-audit/examples/0.1.2alpha1-to-0.1.2alpha2/UPGRADE-ADAPTATION.md)。
+[dsh-upgrade-audit](skills/dsh-upgrade-audit/) 审计两个 DSH 版本间的外部兼容性与回滚，产出 UPGRADE-ADAPTATION 报告 + 边界签名表，为版本卡片提供证据。案例：[0.1.2-alpha.1 → alpha.2](skills/dsh-upgrade-audit/examples/0.1.2alpha1-to-0.1.2alpha2/UPGRADE-ADAPTATION.md)。
 
 ## 版本数据现状
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -40,4 +40,4 @@ description: 一句话说明做什么、何时触发，以及重要的只读/写
 
 ## 版本兼容审计（独立条目）
 
-**[dsh-upgrade-audit](dsh-upgrade-audit/)**（作者 [@oh-my-dsh](https://github.com/oh-my-dsh)）——审计两个 DSH 版本间的外部兼容性与回滚：源码检出走 git tag 对比，无源码自动降级下载 npm 双版本；产出标准 upgrade-report 目录（UPGRADE-ADAPTATION + 边界签名表），为版本变更卡片提供证据。独立分节维护，不改上方收录清单，避免 upstream 更新表格时的冲突。
+**[dsh-upgrade-audit](dsh-upgrade-audit/)**（[@oh-my-dsh](https://github.com/oh-my-dsh)）——审计两个 DSH 版本间的外部兼容与回滚，产出 UPGRADE-ADAPTATION 报告 + 边界签名表，为版本卡片提供证据。独立分节维护，不改收录清单。

--- a/skills/README.md
+++ b/skills/README.md
@@ -33,5 +33,11 @@ description: 一句话说明做什么、何时触发，以及重要的只读/写
 ## 收录清单
 
 | Skill | 说明 | 作者 |
-1: @ours
-| [dsh-upgrade-audit](dsh-upgrade-audit/) | 审计两个 DSH 版本间的外部兼容性与回滚：源码检出走 git tag 对比，无源码自动降级下载 npm 双版本；产出标准 upgrade-report 目录（UPGRADE-ADAPTATION + 边界签名表），为版本变更卡片提供证据 | [@oh-my-dsh](https://github.com/oh-my-dsh) |
+|---|---|---|
+| [plugin-upgrade](plugin-upgrade/) | 只读检查、已安装插件升级、宿主兼容迁移；七类触点 + 版本卡片 + 安全回滚 | [@oh-my-dsh](https://github.com/oh-my-dsh) |
+| [plugin-write](plugin-write/) | 编写 DSH 插件，按目标 Harness 版本选择扩展形态，并区分官方单仓与外部插件规则 | [@omdsh-dev](https://github.com/omdsh-dev) |
+| [plugin-test](plugin-test/) | 为 DSH 插件变更选择测试层级，并覆盖真实组合、发布产物与目标版本产品入口 | [@omdsh-dev](https://github.com/omdsh-dev) |
+
+## 版本兼容审计（独立条目）
+
+**[dsh-upgrade-audit](dsh-upgrade-audit/)**（作者 [@oh-my-dsh](https://github.com/oh-my-dsh)）——审计两个 DSH 版本间的外部兼容性与回滚：源码检出走 git tag 对比，无源码自动降级下载 npm 双版本；产出标准 upgrade-report 目录（UPGRADE-ADAPTATION + 边界签名表），为版本变更卡片提供证据。独立分节维护，不改上方收录清单，避免 upstream 更新表格时的冲突。

--- a/skills/README.md
+++ b/skills/README.md
@@ -33,7 +33,5 @@ description: 一句话说明做什么、何时触发，以及重要的只读/写
 ## 收录清单
 
 | Skill | 说明 | 作者 |
-|---|---|---|
-| [plugin-upgrade](plugin-upgrade/) | 只读检查、已安装插件升级、宿主兼容迁移；七类触点 + 版本卡片 + 安全回滚 | [@oh-my-dsh](https://github.com/oh-my-dsh) |
-| [plugin-write](plugin-write/) | 编写 DSH 插件，按目标 Harness 版本选择扩展形态，并区分官方单仓与外部插件规则 | [@omdsh-dev](https://github.com/omdsh-dev) |
-| [plugin-test](plugin-test/) | 为 DSH 插件变更选择测试层级，并覆盖真实组合、发布产物与目标版本产品入口 | [@omdsh-dev](https://github.com/omdsh-dev) |
+1: @ours
+| [dsh-upgrade-audit](dsh-upgrade-audit/) | 审计两个 DSH 版本间的外部兼容性与回滚：源码检出走 git tag 对比，无源码自动降级下载 npm 双版本；产出标准 upgrade-report 目录（UPGRADE-ADAPTATION + 边界签名表），为版本变更卡片提供证据 | [@oh-my-dsh](https://github.com/oh-my-dsh) |

--- a/skills/dsh-upgrade-audit/SKILL.md
+++ b/skills/dsh-upgrade-audit/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: dsh-upgrade-audit
+description: 审计两个 DSH 版本之间的外部兼容性——npm 包 API、CLI 面、线上协议、会话落盘数据、配置、模型可见契约——并显式检测回滚（revert），产出标准化的 upgrade-report 目录。有 deepseek-harness 源码检出时走 git tag 对比；没有源码（第三方 repo 场景）时自动降级为下载 npm 两个版本的已发布包做分析。只要用户要求 检查/对比/审计 两个 DSH 版本——例如「检查 dsh-vX -> dsh-vY 对于外部兼容来说相对 X 是否有更多的改动或者回滚」「对比两个版本的 breaking changes」「版本升级审计」「生成 upgrade report」「这个版本能安全升吗」——即使用户只给了两个版本号、没说源码在哪，也要使用本 skill。
+---
+
+# dsh-upgrade-audit
+
+审计两个 DSH 版本之间**仓库外消费者**可观察的一切变化，并写出用户期望的报告集。这个问题的固定形态是：*相对 from 而言，to 是否有更多的改动或者回滚？*——"更多改动"指外部可见的破坏（导出删除、线上错误码改名、数据格式拒读）；"回滚"指 `from` 中存在的行为在区间内被 revert 蓄意撤回。两者都要证据：commit message 和子代理摘要只是主张，只有对两棵树（源码文件或已发布包）读过之后的结论才是证据。
+
+外部兼容 = 仓库外消费者能观察到的一切：npm 包公共 API（exports、类型、签名、依赖面）、`dsh` CLI（命令、flag、profile、配置键）、线上协议（SDK JSON-RPC、remote 网关/BFF、ACP、hooks）、会话落盘数据（JSONL 日志、SQLite 库及其版本守卫）、模型可见面（工具名/schema、系统提示词输出）、Python SDK 的预期。内部重构只是背景，不是发现——聚合计数即可。
+
+## Phase 0 — 解析输入与模式
+
+输入：两个版本标识（接受 `0.1.2-alpha.2`、`dsh-v0.1.2-alpha.2`、dist-tag `alpha`/`latest`/`next`）。按特异性从高到低选分析模式：
+
+1. **上下文路径**——用户在消息里点名了 deepseek-harness 检出目录。验证：根 `package.json` + `packages/` + `AGENTS.md` 齐备。
+2. **`DSH_SOURCE_PATH` 环境变量**——同样验证。（可选 `DSH_NPM_REGISTRY` 覆盖 npm registry。）
+3. **CWD 启发**——当前目录本身就是 deepseek-harness 检出（同样标记）。
+4. **npm 模式**——以上皆无（第三方 repo 的默认路径）：下载两个版本的已发布包做分析。
+
+源码模式审计 git tag；npm 模式审计发布工件。审计核心（侦察面、分类、核验、报告）两者共享，物化方式和部分证据源不同。选 npm 模式前要知道它的边界：**npm 版本集 ≠ git tag 集**（如 `0.1.2-alpha.1` 打了 tag 但从未发布——物化脚本会带已发布清单退出，应把缺口摆给用户，不要自行替换版本对）；CLI 闭包不含全部可发布包（SQLite 持久化后端不是 CLI 依赖，脚本以补充包形式安装）。
+
+## 输出契约
+
+全部落在一个目录：`tmp/<fromNorm>-to-<toNorm>/`（规范化：去 `dsh-v`、预发布段去点——`dsh-v0.1.2-alpha.1` → `0.1.2alpha1`）。源码模式建在检出内（已 gitignore）；npm 模式建在当前项目内。目标目录已存在时多半是先前手工做的报告——先停下来问，不要覆盖。
+
+| 工件 | 源码模式 | npm 模式 |
+|---|---|---|
+| `commits.txt`、`reverts.txt` | 来自 git；revert 并入 CHANGELOG | 来自 GitHub compare 富化（私有仓库则无） |
+| `files.txt`、`diffstat.txt`、全量 `.diff` | git 树 diff | `manifest-diff.txt`（逐包 manifest diff）+ `a/`、`b/` 已发布包树 |
+| `CHANGELOG.md` | 按类型分类，**必须有 Reverts 分节** | 有富化时生成；否则省略并明说 |
+| `UPGRADE-ADAPTATION.md` | 审计报告（两模式同一骨架） | 相同；头部记录模式与版本出处 |
+
+报告语言跟随用户语言（[examples/](examples/0.1.2alpha1-to-0.1.2alpha2/UPGRADE-ADAPTATION.md) 既有报告为英文，属历史约定不强制）。
+
+## Phase 1 — 物化两棵树
+
+**源码模式**——先验纯度，merge base 不是 `from` 本身意味着基漂移，必须停下报告，不能对着移动的基线做 diff：
+
+```sh
+git merge-base <from> <to>   # 必须等于 <from> 的 commit
+node <skill-dir>/scripts/gen-artifacts.mjs <from> <to> tmp/<pair>
+```
+
+**npm 模式**：
+
+```sh
+node <skill-dir>/scripts/materialize-npm.mjs <from> <to> tmp/<pair>
+```
+
+脚本向 registry 解析两个版本（缺失则 exit 1 并带已发布清单——把缺口摆给用户），以 `--ignore-scripts` 把 `@deepseek-ai/dsh` 依赖闭包加 SQLite 补充包装进 `a/` 与 `b/`，对每个 `@deepseek-ai/*` 包做 manifest diff 生成 `manifest-diff.txt`，并从公开 GitHub 仓库富化（`commits.txt`、`reverts.txt`）——所以没有源码检出也能做回滚检测。
+
+按 stats 输出定侦察规模：≤40 个非合并 commit → 按侦察面清单单跑内联；40–250 → 合并 3–4 个面；更多 → 全量六面。密度对比要翻上一对的 `commits.txt`——按**时间序**取紧邻前一对，永远不要只抓 `tmp/` 里最新的目录。
+
+## Phase 2 — 先立共享事实
+
+跑一次，喂给每个子代理，免得各自重复推导：
+
+- **格式守卫**——源码模式读两个 tag 上的 `SESSION_FORMAT_VERSION`（`packages/core/session/src/types.ts`）与 SQLite `SCHEMA_VERSION`（`packages/session/session-persistence-sqlite/src/schema.ts`）；npm 模式从 `dsh-session` 与补充包的已发布 `lib/*.js` 里 grep 同名常量。守卫跳号且无迁移路径 = 硬数据破坏，放报告最前面。
+- **回滚清单**——源码模式：`git log --grep='[Rr]evert' <from>..<to>`；npm 模式：富化的 `reverts.txt`（没有 → 回滚*意图*不可检测，明说，只做 from→to 差量审计）。
+- **Python SDK**——源码模式：diff `python/`；npm 模式：超出 npm 工件范围，一句话说明即可。
+
+## Phase 3 — 并行面扫描
+
+一批并行派发每面一个只读侦察代理，带 Phase 2 共享事实和 [references/audit-playbook.md](references/audit-playbook.md) 的输出契约：分节 **REMOVED**（最前——候选破坏/回滚）、**CHANGED**（before → after）、**ADDED**、**RENAMED**；每条带 包/路径、符号或字段、影响面类别（SDK 消费者 / CLI 用户 / 配置作者 / 会话数据 / 模型可见 / 协议对端 / web UI / npm 安装者）；结尾一行判定。面的目标路径清单（分模式）在 playbook。
+
+## Phase 4 — 发布前核验
+
+侦察输出是线索，不是发现。每条 REMOVED、回滚和线上声明都要亲自复核：源码模式用 `git show <tag>:<path>` / `git ls-tree` 对两个 tag；npm 模式读两棵已发布树（`a/node_modules/...` vs `b/node_modules/...`）。这一步有真实教训：侦察代理曾把 alpha.1 里就存在的包报成"alpha.2 新增"。无法核验的内容要么标 `[INFERENCE]`，要么删掉。
+
+## Phase 5 — 写 UPGRADE-ADAPTATION.md
+
+按 [references/audit-playbook.md](references/audit-playbook.md) 骨架：头部（区间、统计、模式与出处、源码模式的纯性说明）、**Verdict**（直接回答比较性问题）、§1 回滚、按消费者影响排序的破坏分节（删除项在前，每条标注谁会被破坏，配 **Adapt:** 行）、**Confirmed unchanged**（兼容性成立的部分与破坏同等重要）、边界签名表 `[API surface | from | to | changed?]`、编号迁移清单。完整实例见 [examples/0.1.2alpha1-to-0.1.2alpha2/](examples/0.1.2alpha1-to-0.1.2alpha2/UPGRADE-ADAPTATION.md)（源码模式真实审计）。对话回复跟随用户语言。
+
+## 护栏
+
+- 只读：源码模式不动 `tmp/<pair>/` 之外的任何东西；npm 模式只写自己的 `tmp/<pair>/` 且以 `--ignore-scripts` 装进该目录——绝不把 dsh 包装进宿主项目的 `node_modules`。
+- 优先树级事实（已发布文件、双 tag 读取），不信日志推导的叙事。
+- 内部无关 churn（测试、notes、i18n、样式）聚合成一个计数，不逐条列。
+- npm 模式如实记录局限：无富化就没有 git 历史；CLI tarball 只发 `lib/`（配置组成通过各 bundle 包的 `cordis.patch.yml` + manifest 审计）；Python SDK 超范围。
+- 20 个 commit 的区间不要全量扇出；500 个 commit 的区间不要内联。规模判错是审计变陈旧或变浅的主因。
+
+## 与 plugin-upgrade 的关系
+
+本 skill 产出**宿主版本间的兼容性证据**（报告 + 边界签名表）；[plugin-upgrade](../plugin-upgrade/) 消费这类证据（版本变更卡片）执行单个插件的迁移。审计发现可直接供给卡片「实战批注」；给 `plugin-upgrade` 补卡时引用本 skill 的报告目录而非凭记忆转述。

--- a/skills/dsh-upgrade-audit/evals/evals.json
+++ b/skills/dsh-upgrade-audit/evals/evals.json
@@ -1,0 +1,29 @@
+{
+  "skill_name": "dsh-upgrade-audit",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "检查一下 dsh-v0.1.1-rc.1 -> dsh-v0.1.1-rc.2 对于外部兼容来说相对 rc.1 是否有更多的改动或者回滚？如果有请制作一个 ./tmp/0.1.1rc1-to-0.1.1rc2/（在 deepseek-harness 源码检出里执行）",
+      "expected_output": "检测到 tmp/0.1.1rc1-to-0.1.1rc2/ 已存在（技能诞生前的手工报告），先询问而非覆盖；31-commit 区间走内联单跑（不全量扇出）；merge-base 纯度通过；rc.1..rc.2 恰有一个 Revert commit（projection 注册形式），必须方向性上报为回滚。",
+      "files": []
+    },
+    {
+      "id": 2,
+      "prompt": "对比 dsh-v0.1.0-rc.8 和 dsh-v0.1.1-rc.1，我主要关心 SDK/协议和 session 数据这两块的外部兼容，生成 upgrade 报告目录。",
+      "expected_output": "按用户关注点缩放为 2 个侦察面（SDK & 线上协议、会话数据）而非六面全量，但仍产出全套工件（含边界签名表）；两个格式守卫的值从两侧树读取并报告；报告目录 tmp/0.1.0rc8-to-0.1.1rc1/。",
+      "files": []
+    },
+    {
+      "id": 3,
+      "prompt": "我没拉 deepseek-harness 源码，就在这个插件仓库里直接对比 0.1.2-alpha.1 和 0.1.2-alpha.2 两个 npm 版本，出个兼容报告。",
+      "expected_output": "npm 模式陷阱：0.1.2-alpha.1 从未发布到 npm——正确行为是物化脚本 exit 1 后向用户展示已发布清单与 dist-tags、说明缺口并确认替代对（如 rc.2 → alpha.2），绝不静默替换版本对继续审计；若用户确认替代对，则 materialize-npm 产出 a/、b/ 树、manifest-diff.txt 与 GitHub 富化的 commits.txt/reverts.txt，报告头部记录 Mode: npm packages 与版本出处。",
+      "files": []
+    },
+    {
+      "id": 4,
+      "prompt": "帮我审计 dsh-v0.1.0-rc.7 到 dsh-v0.1.0-rc.8 之间的 breaking changes 和回滚，输出报告目录，并和上一个区间的破坏密度对比一下。",
+      "expected_output": "337-commit 全量六面扇出 + merge-base 纯度检查 + 回滚清查 + 报告目录 tmp/0.1.0rc7-to-0.1.0rc8/。密度对比陷阱：rc.7→rc.8 是时间上最早的已审计对，正确行为是指出不存在可比较的前序对报告，而不是抓 tmp/ 里最新的目录（那是更晚的区间）或编造对比。",
+      "files": []
+    }
+  ]
+}

--- a/skills/dsh-upgrade-audit/examples/0.1.2alpha1-to-0.1.2alpha2/CHANGELOG.md
+++ b/skills/dsh-upgrade-audit/examples/0.1.2alpha1-to-0.1.2alpha2/CHANGELOG.md
@@ -1,0 +1,191 @@
+# Changelog: dsh-v0.1.2-alpha.1 → dsh-v0.1.2-alpha.2
+
+Generated from `git log dsh-v0.1.2-alpha.1..dsh-v0.1.2-alpha.2` (157 commits; merge commits excluded).
+
+## Release (2)
+
+- 3f1b46a5db (2026-08-30) release(dsh): 0.1.2-alpha.2
+- 6af96785b5 (2026-08-29) release(vendor): cordis 4.0.2, cosmokit 1.8.3, group 1.0.2, hmr 1.0.17, include 1.0.7, loader 1.0.3, logger-console 1.0.2, schemastery 3.18.2, timer 1.1.4
+
+## Features (13)
+
+- 45455aae77 (2026-08-24) feat(release): route dsh prerelease dist-tags
+- e5f36cc70f (2026-08-29) feat(plugin-inventory): carry every agent preset's composition and group the settings plugin list by scope
+- 943a544899 (2026-08-26) feat: classify Host dependency exports
+- c55beac34a (2026-08-26) feat: verify Host dependency export identity
+- de256e8bc1 (2026-08-26) feat: enforce published dependency policy
+- 19b4d7f26c (2026-08-29) feat(web): add connection recovery indicator
+- 9effa0c6b3 (2026-08-28) feat(ui-chat): split turn stats into usage and time pills with dialogs
+- 5ba375fd88 (2026-08-28) feat(client): hover swim morph for the hero fish
+- f15078532f (2026-08-27) feat(ui-chat): reshape the usage trigger as an icon-row pill
+- 10b31043ab (2026-08-26) feat(ci): assign coverage partitions by recorded file duration
+- bb1df10c69 (2026-08-27) feat(ui-chat): collapse the turn tail into one clickable meta line
+- e841fb6049 (2026-08-26) feat(web): surface active schedules in session views
+- 2a9b940ef5 (2026-08-25) feat(web): list active reminders in the session header
+
+## Bug Fixes (57)
+
+- 8769d57c98 (2026-08-30) fix(web): localize permission preset labels
+- b7bccd5897 (2026-08-30) fix(docs): repair reverted session note references
+- 2f673e5aba (2026-08-30) fix(agent-presets): register the display subpath in tsconfig paths
+- 8349cc6c73 (2026-08-29) fix(agent-presets): live-mount-first inventory, per-runtime mounts, localized shipped preset names
+- 675efe73f2 (2026-08-29) fix: node 24.9 internal issue
+- d5a9e5b274 (2026-08-29) fix(web): publish the drill claim before the descent edit
+- 9162bc69bd (2026-08-27) fix(release): harden dependency verification
+- 91b5a01980 (2026-08-26) fix: complete dependency policy generation
+- 3e56eaaa0f (2026-08-29) fix(atomic-write): retry transient Windows replacement
+- 7fbd33de00 (2026-08-29) fix(snapshot): keep fixture lifecycle tests source-clean
+- 1f8d7b73af (2026-08-29) fix(snapshot): own fixture listener lifecycle
+- 84c7ae3398 (2026-08-29) fix(web): align connection indicator labels
+- 674a1e95a3 (2026-08-29) fix(api): rename the failure marker, harden cross-realm discrimination, and mark the packed-record violation
+- f9e8fc8f8a (2026-08-28) fix(api): identity-stable $host facts and a whole-record host info hook
+- 2f2e6d627b (2026-08-28) fix(api): resolve review findings on stream boundary, inject staleness, and ctx discipline
+- 5af9eec51c (2026-08-28) fix(api): address review findings on the gateway client failure face
+- d40d678b93 (2026-08-28) fix(api): repair runtime closure, gateway client bundle, and $host coverage
+- 9055a8af3a (2026-08-28) fix(snapshot): bind fixture servers to OS-assigned ports
+- ececf8c170 (2026-08-28) fix(web): address hero fish hover review feedback
+- 84df0f11ae (2026-08-28) fix(web): use primary color for subagent setting label
+- 6daed7c5aa (2026-08-28) fix(client): make trigger-menu Enter an explicit no-op while refinement pends
+- 21d039be1b (2026-08-28) fix(web): label the Turn-time TTFT row as first-token latency, not an average
+- 1278877d91 (2026-08-28) fix(client): dismiss stat dialogs through the shared outside-pointer hook
+- f6d4f2149d (2026-08-28) fix(webworker-runtime): restore v1 title cache fixture
+- aa70a737ae (2026-08-28) fix(web-search): guide users to endpoint settings
+- 5c9ca1f25b (2026-08-28) fix(session-title): preserve v1 title cache schema
+- d576865f76 (2026-08-28) fix(client): remove the hero glow under the new-session input
+- 452013effa (2026-08-28) fix(client): web session and input UI polish
+- f55c676485 (2026-08-28) fix(web-search): clarify endpoint recovery guidance
+- 5a8ef5f3f5 (2026-08-28) fix(web): tighten schedule catalog evidence
+- 19b215f426 (2026-08-28) fix(ui-schedule): scope Escape dismissal to catalog
+- 2bcd4cc552 (2026-08-27) fix(agent-presets): treat absent turn boundary as blank
+- e719eee47f (2026-08-27) fix(web): guide search endpoint recovery
+- 8c67d49ca5 (2026-08-27) fix(api): simplify projection reconciliation
+- c3b694312f (2026-08-27) fix(web): harden schedule catalog state handling
+- beaa5638b4 (2026-08-27) fix(session): centralize projection baseline precedence
+- 57d8a79bfe (2026-08-27) fix(session): validate seeded projection boundary
+- 11a5bc5083 (2026-08-27) fix(api): preserve projection baseline precedence
+- dd3e1c8490 (2026-08-26) fix(session): replay projection baselines in order
+- 14bdba0924 (2026-08-26) fix(notices): refresh Claude SDK payload versions
+- 96c1c762d5 (2026-08-26) fix(session-projection): preserve optional registrations
+- cd18de61d8 (2026-08-26) fix(session-projection): close migration coverage gaps
+- e296e79b18 (2026-08-26) fix(session-projection): complete mandatory compositions
+- a6c7c70d4f (2026-08-26) fix(session-projection): close review findings from the fold migration
+- e6bf040dc3 (2026-08-26) fix(session-query): use renamed tool call id
+- 3759ea5dfe (2026-08-26) fix(agent-team): keep projection through runtime disposal
+- 5521b98143 (2026-08-26) fix(session-projection): isolate host state from wire snapshots
+- cdba045dfc (2026-08-25) fix(session): trust authoritative projection frames
+- 5fe7dc333f (2026-08-25) fix(session): reconcile cached projection hints
+- c26ca6acb6 (2026-08-20) fix(session-projection-cache): drain in-flight writes on disposal; sync stale lockfile and generated docs
+- 30334322eb (2026-08-19) fix(apiproxy): crop host-only units from wire projection blocks
+- 5ef3f0bd94 (2026-08-19) fix: resolve remaining review findings — explicit turnBoundary dependency and uniform missing-key handling
+- 2a4f6541d6 (2026-08-19) fix: revert the projection-registration form per review
+- f364d6ba37 (2026-08-19) fix: address ds-review-bot findings on the projection migration
+- 3f5fc12b4c (2026-08-19) fix(web): restore settings focus after commit
+- 8ac1bd64e2 (2026-08-06) fix(web): document settings focus restoration
+- 0289791d5d (2026-08-06) fix(web): restore focus after closing settings
+
+## Performance (7)
+
+- 51a6eabb27 (2026-08-28) perf(api): replace shift-backed stream queues
+- a12e9de5f7 (2026-08-28) perf(session): stat the probe parent only on Windows
+- 722d9f016b (2026-08-27) perf(goal): avoid copying open-turn event suffix
+- ba4bd08bc3 (2026-08-27) perf(llm-retry): reset state without scanning keys
+- 6c4bbf7300 (2026-08-21) perf(goal): read durable state from session projection
+- 6def839f56 (2026-08-21) perf(team): project durable state incrementally
+- 89b5bc276f (2026-08-21) perf(session-projection): skip history reads for in-order events
+
+## Refactoring (21)
+
+- 9135a13a8b (2026-08-30) refactor(consumers): remove cross-package runtime relays
+- f4e49ccf8f (2026-08-30) refactor(services): move shared values behind service APIs
+- 6c53fe6e2a (2026-08-30) refactor(values): make shared primitives duplicate-install safe
+- cebd0a2031 (2026-08-29) refactor(plugin-inventory): match group title and switcher pill to the General-settings row idiom
+- 0f06f973c4 (2026-08-29) refactor(plugin-inventory): settings-row style group headers
+- 5eb7195f9d (2026-08-29) refactor(plugin-inventory): menu-pill preset switcher, collapsible groups, inline preset-provided rows
+- ccfbbb443a (2026-08-29) refactor(connection): centralize websocket recovery
+- 804b1ffbfc (2026-08-28) refactor(api): converge the Remote failure vocabulary and client surface
+- d25ace0f22 (2026-08-28) refactor(api): require the session projection registry
+- 8645053ca0 (2026-08-28) refactor(goal, permission, plan): require the projection registry
+- 6f16d5868c (2026-08-28) refactor(ui-chat): drop the flat usage-variant debug switch and square narrow pills
+- 6717cb8d19 (2026-08-27) refactor(session): trim projection migration diff
+- 1c2acd9157 (2026-08-27) refactor(permission): project the seed boundary
+- 42e0781cda (2026-08-27) refactor(agent-team): name the Team projection explicitly
+- 85bf796a95 (2026-08-27) refactor(subagent): retain identity projection state
+- 212df86cf8 (2026-08-26) refactor(session): migrate simple folds to projections
+- c7abeb23bf (2026-08-26) refactor(session): keep approval outside projection migration
+- 3d05fdfbfb (2026-08-26) refactor(session): keep instruction and skill scans on event log
+- 5ddbc6e71f (2026-08-19) refactor(session-projection): checkpoint every projection unit (migration side)
+- b0c2e2bf01 (2026-08-19) refactor(session-title): keep title input as an O(1) projection
+- 1a72ae202a (2026-08-19) refactor(session): migrate host state reads to projections
+
+## Reverts (2)
+
+- 2c6ff296af (2026-08-30) Revert "Merge pull request #3087 from deepseek-harness/worktree/remove-ignorable-session-events"
+- 842f42d7ea (2026-08-19) Revert "fix: resolve remaining review findings — explicit turnBoundary dependency and uniform missing-key handling"
+
+## Documentation (23)
+
+- f46e4a8ada (2026-08-24) docs(release): define dsh prerelease channels
+- 5fae1d02f5 (2026-08-30) docs(web): describe localized permission labels
+- 089e044e5b (2026-08-30) docs(session): clarify external event compatibility
+- 29b65af60b (2026-08-30) docs(session): retain ignorable events for external plugins
+- 795d8ec985 (2026-08-30) docs: describe runtime dependency ownership
+- cc5173f4cf (2026-08-29) docs(testing): state the concurrent execution model where tests are written
+- 1d81fc7540 (2026-08-29) docs(testing): give the review checklist its own test-reliability entry
+- e440634456 (2026-08-26) docs: define published dependency faces
+- 596a13d1cb (2026-08-29) docs(testing): add platform-semantics and lane-budget rules to the skill
+- 73a723f37f (2026-08-29) docs(api): correct the api-gateway reference codes and the failure-vocabulary note
+- a4f7193d24 (2026-08-28) docs: drop the Remote-failure bullet from packages/AGENTS.md
+- 2b750cfb51 (2026-08-28) docs(api): document the converged ctx.remote programming surface
+- 94c714d813 (2026-08-28) docs(testing): add CI test reliability skill
+- 5156226cb9 (2026-08-28) docs(notes): record the hero glow removal, consolidating the one-axis-scroll note
+- f14f50416e (2026-08-28) docs(notes): record the turn-tail stat pill decision
+- b36f3d323a (2026-08-27) docs(session): align projection hint ordering
+- 68c48109e3 (2026-08-27) docs(session): align projection replay criteria
+- 650e96cb4d (2026-08-27) docs(session-projection): correct initialization contract
+- ef4dde9fe2 (2026-08-26) docs: reconcile projection catalogs after master merge
+- 73a1dae665 (2026-08-21) docs(session-projection): sync generated catalog translations
+- 54d5d92c08 (2026-08-21) docs(session-projection): refresh generated catalogs
+- 58ebaa63d0 (2026-08-19) docs(notes): refresh superseded projection notes for the mandatory seam
+- 86831ea9a2 (2026-08-19) docs(notes): date the mandatory projection-seam note 2026-08-19
+
+## Tests (25)
+
+- 19c3a270fa (2026-08-30) test(agent-presets): key mounted-row assertions by entry id
+- 34bdc81b47 (2026-08-30) test(deps): enforce runtime dependency ownership
+- 1e3ca1a4b3 (2026-08-29) test(ci): tolerate reaped timeout descendants
+- 08bfeda7e8 (2026-08-29) test(e2e): use Flash for live adapter coverage
+- 4d92a61e00 (2026-08-29) test(e2e): reserve pro for adapter coverage
+- b46d36d3bf (2026-08-27) test(release): verify dual-version npm layout
+- 18480ff902 (2026-08-29) test(connection): verify and document recovery behavior
+- 90505636cd (2026-08-29) test(ci): carry the hook budget and raise the Lefthook suite to the lane value
+- 41cd24f3f6 (2026-08-28) test(api): cover the non-Error terminal escape in RemoteStream
+- 143748bae9 (2026-08-28) test(deque): pin storage release behavior
+- f2b9875c47 (2026-08-28) test(session): await projection cache write-back
+- 66d0bbd5b5 (2026-08-28) test(web): align e2e suite with the hero-glow removal and menu retention
+- 00f2a701bd (2026-08-28) test(scripts): align the translation-pairing-merge budget with the coverage lane
+- bc88e152c5 (2026-08-27) test(ui-chat): restore turn-tail assertions lost in the rebase merge
+- 3a34b7870e (2026-08-27) test(agent-team): cover failed projection reads
+- 9e184cde37 (2026-08-27) test(python): restore strict live response smoke
+- b2071a50b9 (2026-08-27) test(api): complete session manager coverage
+- dfb9b9475f (2026-08-27) test(web): close schedule catalog review gaps
+- 8042ac94a3 (2026-08-27) test(web): make schedule locale assertion deterministic
+- 48f79a52d8 (2026-08-26) test(session-query): model non-error rejection
+- f3d6433d9d (2026-08-26) test(agent-presets): mount projection seam in baseless harness
+- c3468623ea (2026-08-26) test(python-sdk): accept explanatory live responses
+- 4d34d59733 (2026-08-26) test(webworker-runtime): refresh title projection fixture
+- 9cd9c7f634 (2026-08-26) test(web): complete schedule catalog validation
+- cf06f10229 (2026-08-26) test(session-controller): cover cold host-only projection cache
+
+## Chores / CI (5)
+
+- b27c8fbc02 (2026-08-30) chore(deps): refresh package manifests
+- a3207a758b (2026-08-29) chore: package.json update
+- 02a542f49f (2026-08-28) chore(docs): regenerate the slot catalog for the hostInfo hook rename
+- 39a5a1d7e4 (2026-08-28) chore(docs): regenerate catalogs, graphs, and the message-feedback golden
+- 5fe390dc8b (2026-08-26) chore: keep generated notices current
+
+## Other (non-conventional subjects) (2)
+
+- 46a8e83094 (2026-08-28) ci: refresh checks before merge
+- 907c6334c1 (2026-08-19) Remove Knip from repository tooling
+

--- a/skills/dsh-upgrade-audit/examples/0.1.2alpha1-to-0.1.2alpha2/README.md
+++ b/skills/dsh-upgrade-audit/examples/0.1.2alpha1-to-0.1.2alpha2/README.md
@@ -1,0 +1,14 @@
+# Example: 0.1.2-alpha.1 → 0.1.2-alpha.2 audit report
+
+本 skill（源码模式）在 deepseek-harness 检出里产出的真实审计报告，区间 `dsh-v0.1.2-alpha.1..dsh-v0.1.2-alpha.2`（234 commits，其中 157 个非合并；1,604 files changed，+27,862 / −14,050）。
+
+展示的输出契约全貌：
+
+- `UPGRADE-ADAPTATION.md` — 头部区间统计与 merge-base 纯度说明、Verdict、§1 回滚分节（含方向性判定）、按消费者影响排序的破坏分节（每条带 **Adapt:** 行）、Confirmed unchanged、边界签名表、编号 Adaptation checklist
+- `CHANGELOG.md` — 按类型分类的 commit 清单，**必须包含 Reverts 分节**
+
+机械工件（`commits.txt`、`files.txt`、`diffstat.txt`、全量 `.diff`）不入库，需要时在 deepseek-harness 检出里重新生成：
+
+```sh
+node <skill-dir>/scripts/gen-artifacts.mjs dsh-v0.1.2-alpha.1 dsh-v0.1.2-alpha.2 tmp/0.1.2alpha1-to-0.1.2alpha2
+```

--- a/skills/dsh-upgrade-audit/examples/0.1.2alpha1-to-0.1.2alpha2/UPGRADE-ADAPTATION.md
+++ b/skills/dsh-upgrade-audit/examples/0.1.2alpha1-to-0.1.2alpha2/UPGRADE-ADAPTATION.md
@@ -1,0 +1,140 @@
+# Upgrade Adaptation: dsh-v0.1.2-alpha.2 ← dsh-v0.1.2-alpha.1
+
+External-compatibility audit for plugin authors, integrators, and data holders. Companion artifacts in this directory: `CHANGELOG.md` (157 commits, categorized), `commits.txt`, `files.txt` (name-status), `diffstat.txt`, `alpha1-to-alpha2.diff` (full diff).
+
+Range: `dsh-v0.1.2-alpha.1` (2026-08-28) → `dsh-v0.1.2-alpha.2` (2026-08-30). Release commit: `3f1b46a5db` release(dsh): 0.1.2-alpha.2 (merged via PR #3334, `0a53fb55be`). 234 commits total (157 non-merge). 1,604 files changed, +27,862 / −14,050.
+
+History is merge-base-pure: `git merge-base dsh-v0.1.2-alpha.1 dsh-v0.1.2-alpha.2` = `cd5ef81481` = alpha.1 itself (the PR #3248 merge commit). No rebase or base drift, so the range log and the tree diff describe the same change set.
+
+## Verdict
+
+Smaller than the previous transition (rc2→alpha1: 796 non-merge commits / 6,421 files; this one: 156 / 1,604) but with a **higher density of externally visible changes**, including the first two explicit reverts ("回滚") in this release line:
+
+1. **`revert(session): restore ignorable event compatibility`** (`2c6ff296af`, PR #3325) — undoes alpha.1's fail-closed unknown-event vocabulary (PR #3087). Side effect: the SQLite session-store physical schema changed under it, so **alpha.2 hard-rejects every SQLite session DB written by alpha.1** (§2). JSONL logs stay compatible.
+2. **`fix(web): restore localized permission labels`** (`9e1bdefc72`, PR #3326) — re-lands the localized permission labels that a prior merge dropped (web UI only).
+
+Both projection-review reverts (`2a4f6541d6`, `842f42d7ea`) are internal plugin-registration form changes, visible only to authors hand-registering goal/permission/plan projection units.
+
+No commit carries a `BREAKING CHANGE` footer. Breaking items below are flagged **BREAKING** with the affected consumer class.
+
+## 1. Reverts (rollbacks relative to alpha.1)
+
+- `2c6ff296af` Revert "Merge pull request #3087 …remove-ignorable-session-events" + `b7bccd5897` docs repair + `b7a77f4f08` merge-forward. Alpha.1 refused to interpret any log containing an unknown event type; alpha.2 restores the `ignorable` envelope marker: unknown events marked `ignorable: true` are skipped, unmarked unknown events still refuse (message now reads "…unknown to this harness **and not marked ignorable**; refusing…"). `SessionEvent` gains `ignorable?: true` (envelope validator accepts only `ignorable: true`). This is additive relaxation toward older semantics, but it repurposed the SQLite packed-row column (§2).
+- `9e1bdefc72` restore localized permission labels (web UI copy only).
+- `2a4f6541d6` / `842f42d7ea` projection-registration form: pre-existing goal, permission-presets, and plan-mode units go back to the `ctx.inject(['sessionProjections'], …)` child-registration form; new projection units keep required-inject direct register. Internal; no public symbol change.
+
+## 2. SQLite session store: schema 19 → 20, hard reject both directions (BREAKING for session data)
+
+`packages/session/session-persistence-sqlite`: `SCHEMA_VERSION` 19 → 20; `events.is_packed INTEGER NOT NULL CHECK(0,1)` becomes nullable `ignorable INTEGER CHECK(NULL/0/1)` (`ignorable=0` = packed chunk-run sentinel, `ignorable=1` = ignorable scalar, `NULL` = ordinary). `set-user-version-19.sql` deleted, `set-user-version-20.sql` added.
+
+- `configureDatabase` throws `session database at "<path>" has schema version 19, incompatible with this build (20)` before any read. **No migration** (pre-release stance: "rejected, never migrated"). Alpha.1-created SQLite session DBs are unopenable by alpha.2; the file is untouched, so recovery is: open with the alpha.1 binary, or export externally, then let alpha.2 start a fresh store.
+- Lineage for context: rc2=17 → alpha.1=19 → alpha.2=20. Every step hard-rejects; this is not a new policy, but it IS a new break relative to alpha.1 specifically.
+- JSONL is unaffected: `SESSION_FORMAT_VERSION` stays 0; envelope and record encoding byte-identical when `ignorable` is absent. Alpha.2 reads every alpha.1 JSONL log identically. Asymmetry: alpha.1 cannot read alpha.2 logs that contain `ignorable`-marked events (envelope validator rejects the extra key) — intended forward-compat, not a regression.
+
+## 3. Remote failure vocabulary converged → `RemoteError` + namespaced codes (BREAKING for RPC/web clients)
+
+Commit `804b1ffbfc` "refactor(api): converge the Remote failure vocabulary and client surface" (+1,081 files across packages/api + packages/typert).
+
+Wire-visible (gateway/BFF clients that match on error code strings):
+
+- All 17 gateway codes renamed bare → namespaced: `ambiguous-endpoint` → `gateway/ambiguous-endpoint` … (`packages/api/gateway/src/types.ts`). Domain codes likewise: `bad-request` → `gateway/bad-request`, `session-not-found` → `session/not-found`, `agent-preset-not-found` → `agent-preset/not-found`, `settings-conflict` → `settings/conflict`, `credential-rejected` → `credential/rejected`, `workspace-*` → `workspace/*`, `directory-*` → `directory-picker/*`, subagent codes → `subagent/*`. New `gateway/cancelled`; `agent-preset/invalid` added, `agent-preset-invalid` removed.
+- The generic `internal` wrapper around agent-preset failures is gone — unrelated failures now propagate raw as thrown errors instead of `{code:'internal'}`.
+- Remote method names unchanged; no HTTP routes added or removed; one additive optional field: `SessionWireEvent.ignorable?: true`.
+
+Compile-visible (TS consumers):
+
+- Removed types/classes: `ClientResult`, `ClientFailure`, `transportResult` (`packages/api/session-controller/src/client/contract/result.ts` deleted), `RpcError`, `RpcErrorCode`, `RpcErrorDetailsMap` (`packages/client/connection/src/rpc.ts`), `RemoteStreamError` (`packages/api/gateway`), `sessionStreamFailure`, `SessionError`, `WorkspaceError`, `SettingsError`, `CredentialError` maps, `TypertLookupFailure`, `TypertRemoteFailure`, `LlmModelDiscoveryError` re-export, and six agent-preset error classes (`UnknownPresetError`, `PresetMountError`, `PresetLockedError`, `InvalidPresetIdError`, `PresetExistsError`, `PresetNotWritableError`) with `AgentPresetError` / `AgentPresetErrorDetailsMap`.
+- Replacements (new in typert-protocol/gateway): `RemoteError` class, `remoteErrorOf()`, `RemoteFailure` / `RemoteResult`, `RemoteErrorCode`, `RemoteErrorDetailsMap` (domain owners module-augment it), `isRemoteFailure`, `RemoteHostFacts`. Discriminate by `error.code`, not `instanceof`.
+- Runtime export removal: `SESSION_CONTROLLER_REMOTE_EVENTS` (`@deepseek-ai/dsh-api-session-controller/remote-events`) is now type-only; the forwarded event set itself is unchanged (`api-session/activity|added|error|removed|status`).
+
+**Adapt:** any client narrowing failures by class or by bare code string must switch to the namespaced `RemoteErrorCode` vocabulary.
+
+## 4. Shared primitives moved to new packages (BREAKING for importers of the old paths)
+
+New packages: `@deepseek-ai/dsh-util-values` (`JsonValue`, `isJsonValue`, `snapshotJsonValue`, `deepEqualJson`, `assertNever`, `deepFreeze`), `@deepseek-ai/dsh-deque`, `@deepseek-ai/dsh-util-time`, plus `brandString` in `@deepseek-ai/dsh-brand`.
+
+- `@deepseek-ai/dsh-session` root no longer exports `isJsonValue`, `snapshotJsonValue`, `JsonValue` (`src/json.ts` deleted → `packages/util/values/src/index.ts`, implementation verbatim).
+- `@deepseek-ai/dsh-llm` no longer exports `assertNever` / `deepFreeze`.
+- `@deepseek-ai/dsh-tools` no longer re-exports `JsonValue`; `SDK_SECTION_ORDER` const removed from `./src/*` path.
+- `@deepseek-ai/dsh-settings` no longer exports `deepEqualJson`.
+- Brand factories (`SessionId`, `ToolCallId`, `MessageId`) keep their names/signatures in their owning packages (now `brandString`-backed) — not removals.
+
+## 5. Settings API rework (BREAKING for plugin authors registering settings sections)
+
+`@deepseek-ai/dsh-settings`:
+
+- `settingsNamespace(value)` brand function **removed**. Namespaces are plain literal strings, type-checked via `SettingsNamespaceInput`; runtime `TypeError` for names not matching `^[a-z][a-z0-9-]*$` (untyped JS strings previously passed silently — misconfiguration now fails loud).
+- `installSettingsSection(ctx, ns, …)` free function **removed** → service method `SettingsProvider.installSection(ns, schema, entry, hooks)` (same `SettingsSectionHooks` type).
+- Per-package namespace constants renamed (values unchanged): `AGENT_LOOP_SETTINGS_NAMESPACE`, `AGENT_DEFAULT_MODEL_SETTINGS_NAMESPACE`, `SHELL_SETTINGS_NAMESPACE`, `WEB_SEARCH_DEEPSEEK_SETTINGS_NAMESPACE`, `PERMISSION_SETTINGS_NAMESPACE`.
+- `settings.yaml` document format unchanged.
+
+## 6. System-prompt ordering API (BREAKING for prompt-positioning plugins)
+
+`@deepseek-ai/dsh-system-prompt` removes `FIRST_PARTY_SECTION_ORDER` and `PERSONA_ORDER` (alpha.2 has zero remaining refs). Replacements: `SystemPrompt.getSectionOrder(name)` / `getContextOrder(name)` with exported name types `PromptSectionOrderName`, `PromptContextOrderName`; new centralized context placements `SANDBOX_POLICY: 110`, `APPROVAL_POLICY: 115`, `SUBAGENT_DELEGATION: 120`. `PERSONA_SECTION` string kept. **Rendered prompt output is byte-identical** (order values unchanged); only the accessor moved. `@deepseek-ai/dsh-persona` drops its `PERSONA_ORDER` re-export.
+
+## 7. Session projections become a hard dependency (BREAKING for custom profiles)
+
+`session-projection` existed at alpha.1 (dsh-base already mounted it), but alpha.2 makes `sessionProjections` a **hard injection** across the ecosystem: `agent-loop`, `agent`, `agent-instructions`, `agent-presets`, `goal`, `tool-goal`, `hooks-claude-code`, `hooks-codex`, `llm-retry`, `permission-presets`, `plan-mode`, `sandbox-policy`, `session-title`, `terminal-bash`, `time-context`, `tmux-context`, `token-meter`, `tool-session-query`, `tool-subagent`, `tool-todo` (~19 plugins, see `docs/config-catalog.md` `Requires:`).
+
+- **Custom cordis.yml graphs / patch overlays** that mount any of these without `@deepseek-ai/dsh-session-projection` now **fail loud at load**. Shipped profiles are fine: base already mounts it; `sdk-minimal` gained the row (`packages/bundle/sdk-minimal/cordis.patch.yml`).
+- Event-scan folds became projection units: `foldTeam` → `teamProjectionDefinition` (`fold.ts` renamed `projection.ts`), `foldPlanMode` → `planProjectionDefinition`, `effectivePermissionPreset`/`applyKnobEvent` → permission projection + `resolve`/`derive`, `effectiveSandboxMode` → `sandboxMode` projection unit, `collectSessionTitleMessages` → private under `titleProjectionDefinition` + new `titleInput` projection key (stateVersion 3). All fold results over unchanged logs are identical.
+- New public projection type: `TurnBoundaryProjection` (`@deepseek-ai/dsh-agent`), `turnBoundaryProjectionDefinition` (`@deepseek-ai/dsh-agent-loop`, stateVersion 2). `lastTurn`/step-boundary logic reads the projection instead of scanning `session.events` — same observable values.
+
+## 8. Connection / gateway behavior (visible to remote clients)
+
+- Connection state machine: `reconnecting` → split `disconnected` / `connecting`; new `reconnect()` and `setNetworkAvailable()`, `onReconnectRequested` sink; stream clients now delegate retry to the Connection (`packages/client/connection`).
+- Gateway heartbeat default `websocketHeartbeatIntervalMs` **30000 → 2000** with a pong deadline that terminates peers missing a pong before the next interval (`packages/api/gateway/src/index.ts`, `stream-server.ts`). Set the config key explicitly if a 30s cadence was assumed.
+- `$host` RemoteHostFacts broadcast added; gateway peerDependencies trimmed to cordis only.
+
+## 9. Web UI removals (behavior changes)
+
+- `ConnectionBanner` → `ConnectionIndicator` / `ConnectionIndicatorState` (same package `@deepseek-ai/dsh-client-ui-primitives`).
+- `AgentPresetRow` + `PresetMenu` (+ `AgentPresetRowProps`/`AgentPresetRowInjected`) removed from `@deepseek-ai/dsh-client-ui-agent-preset`; preset composition UI moved to the plugin-inventory settings tab (`ui-settings-plugin-inventory`, grouped by scope).
+- `TurnUsageDisclosure` removed (per-turn usage panel collapsed into a clickable turn-tail meta line) — never package-exported; visual change only.
+
+## 10. Publishing and distribution
+
+- All packages: `publishConfig.access: "public"`, explicit `files` lists, and `@deepseek-ai/cordis` moved to `peerDependencies` (release gate verifies dependency faces and npm-install layout; `feat: enforce published dependency policy`, `9162bc69bd`). Vendored framework bumped: **cordis 4.0.2, cosmokit 1.8.3, schemastery 3.18.2, timer 1.1.4, loader 1.0.3, hmr 1.0.17, include 1.0.7, logger-console 1.0.2, group 1.0.2** (`release(vendor)`, `6af96785b5`) — plugin authors must match the cordis 4.0.x peer range.
+- Prerelease dist-tags: dsh alpha builds publish under the `alpha` dist-tag, canary/rc under `next` (`45455aae77`); `latest` no longer receives prereleases. Update install commands (`npm i @deepseek-ai/dsh@alpha`) accordingly.
+- `release.yml` gains a `dependencies` job (verify-package-dependencies + verify-npm-install-layout) gating `pack`; publish path itself unchanged (manual dispatch from a `dsh-v*` tag).
+- CI now tests Node 24.9 (v1-loader window) and ships the loader shape-detection fix (vendor loader 1.0.3): `dsh web` no longer serves an empty client graph on Node 24.0–24.11.1 — an external bug fix, not a break.
+
+## 11. Confirmed unchanged (compatibility holds)
+
+- **SDK JSON-RPC wire protocol**: `packages/sdk/protocol` byte-identical (requests `initialize`/`session/prompt`/`shutdown`, notifications `session.event`/`session.status`/`subagent.started`/`subagent.finished`, NDJSON framing, error codes). TS and Python SDK clients interoperate with alpha.2 servers in both directions; `python/sdk` untouched apart from one runtime dep. The `sdk` profile composition is unchanged.
+- **CLI**: zero command, flag, or env-var removals in `apps/cli` / `cmdline`; no preset roster changes (standard / ptc / minimal / cordis intact — presets dir byte-identical). Additions only: schedule overlay example, `agent-presets` `./display` export + `compositionInventory()` (in-process, not `@Remote`).
+- **Model-visible contracts**: `run_code` name and parameter schema text unchanged; tool registry/catalog unchanged; system-prompt section names, texts, and order values byte-identical; known event vocabulary unchanged (51 types).
+- **HTTP surface**: no routes added or removed anywhere; no request-payload field changes in existing routes.
+- **JSONL session logs**: alpha.2 reads every alpha.1 log identically (§2).
+
+## 12. Boundary-signature table
+
+Mechanical boundary comparison (merge-base-verified tree diff; package maps compared with jq across all 271→275 package.json files).
+
+| API surface | alpha.1 | alpha.2 | changed? |
+|---|---|---|---|
+| package.json `exports`/`files`/`bin`/`main`/`types`/`engines` maps | 271 packages | 275 packages | **Narrowed/removed: none.** Additive only: `agent-presets` +`./display`, `schedule` +`./client`, 4 new packages (`ui-schedule`, `util/values`, `util/deque`, `util/time`) |
+| `SESSION_FORMAT_VERSION` (JSONL log format) | `0` | `0` | unchanged — alpha.1 JSONL logs read identically by alpha.2 |
+| SQLite `SCHEMA_VERSION` (session store) | `19` | `20` | **changed — hard reject, no migration, both directions** |
+| Exported symbols per changed package (`src/index.ts`, 119 files swept) | — | — | changed in ~20 packages; removals itemized in §3–§7; brand factories kept |
+| SDK JSON-RPC wire (`packages/sdk/protocol`) | 3 methods + 4 notifications | identical (byte-for-byte) | unchanged — TS/Python interop holds both directions |
+| Gateway/BFF error-code vocabulary | bare codes (`ambiguous-endpoint`, `session-not-found`, …) | namespaced (`gateway/*`, `session/*`, …) | **changed on the wire** (§3) |
+| HTTP routes (gateway/webserver/controllers) | — | — | unchanged (0 added, 0 removed); one additive optional wire field `ignorable` on session events |
+| `dsh` CLI commands/flags/env/profiles | — | — | unchanged (`apps/cli`, `boot/cmdline`: zero source changes) |
+| Model-visible tool contracts (`run_code` schema, tool catalog) | — | — | unchanged |
+| System-prompt output (sections, order values) | — | — | unchanged (only the ordering accessor API moved, §6) |
+| Known session event vocabulary | 51 types | 51 types | unchanged + optional `ignorable` envelope marker |
+| Vendored `@deepseek-ai/cordis` peer range | cordis 4.0.x (1.0.2 line) | cordis 4.0.2 | changed patch-level; peer requirement now explicit (§10) |
+
+## Adaptation checklist
+
+1. Hold SQLite session data? Export via alpha.1 (`session-log-export` zip is unchanged) or accept the fresh store; alpha.2 will refuse the v19 file.
+2. Match Remote failures by class/bare code? → `RemoteError` + `RemoteErrorCode` (`gateway/*`, `session/*`, …) via `remoteErrorOf()` / `isRemoteFailure`.
+3. Import `JsonValue`/`isJsonValue`/`snapshotJsonValue`/`assertNever`/`deepFreeze`/`deepEqualJson`? → `@deepseek-ai/dsh-util-values`.
+4. Call `settingsNamespace()` / `installSettingsSection()`? → plain namespace strings + `SettingsProvider.installSection(...)`.
+5. Position prompt sections with `FIRST_PARTY_SECTION_ORDER` / `PERSONA_ORDER` / `SDK_SECTION_ORDER`? → `systemPrompt.getSectionOrder(name)`.
+6. Hand-compose cordis.yml with any of the ~19 projection-consuming plugins? → mount `@deepseek-ai/dsh-session-projection`.
+7. Use `foldTeam` / `foldPlanMode` / `effectivePermissionPreset` / `effectiveSandboxMode` / `collectSessionTitleMessages`? → the corresponding `*ProjectionDefinition` + registry.
+8. Catch `RemoteStreamError` / use `ConnectionState.reconnecting`? → `RemoteError('gateway/…')` + `disconnected`/`connecting`; note the 2s heartbeat default.
+9. Import `ConnectionBanner` / `AgentPresetRow` / `PresetMenu`? → `ConnectionIndicator`; plugin-inventory composition tab.
+10. Pinning `@deepseek-ai/cordis`? → 4.0.2; installing the CLI? → use the `alpha` dist-tag.

--- a/skills/dsh-upgrade-audit/references/audit-playbook.md
+++ b/skills/dsh-upgrade-audit/references/audit-playbook.md
@@ -1,0 +1,97 @@
+# Audit Playbook（审计手册）
+
+侦察派发模板、六面目标清单、报告骨架的参考文档。SKILL.md 负责阶段顺序，需要哪节读哪节。
+
+## 六个标准侦察面
+
+按区间规模合并或拆分（SKILL.md Phase 0）。目标是快路径；`files.txt` 或 `manifest-diff.txt` 显示清单没覆盖的面时，侦察应自行扩展。
+
+| # | 侦察面 | 目标（源码模式） | 目标（npm 模式） |
+|---|---|---|---|
+| 1 | Core API | `packages/core/**`（session、agent、agent-loop、tools、system-prompt、scope）、`packages/util/**` 的 src：导出增删改名、签名变化、事件 map、工具 schema、系统提示词结构 | `dsh-session`、`dsh-agent*`、`dsh-tools`、`dsh-system-prompt` 等包的 `lib/types/*.d.ts`（类型面）+ `lib/*.js`（运行时常量）+ package.json |
+| 2 | SDK & 线上协议 | `packages/sdk/**`、`packages/api/remotes`、`subagent-dsh-sdk`、`bundle/sdk-app`、`bundle/sdk-minimal`：JSON-RPC 方法、payload 字段（新增必填 = 线上破坏；删除 = 客户端破坏）、通知、协议常量、bundle 组成 | 对应 `dsh-sdk-*`、`dsh-api-remotes`、`dsh-subagent-dsh-sdk` 包的已发布 lib + 两棵树里 `dsh-headless`/`dsh-base` 等的 `cordis.patch.yml` |
+| 3 | CLI & 配置 | `apps/cli`、`packages/boot/**`、`packages/bundle/**`、`packages/settings/**`、`packages/credentials/**`、`packages/preset/**`、`docs/config-catalog.md`、`.github/workflows/release.yml`：命令/flag/环境变量、schemastery 键（删改名 = 配置作者破坏）、默认值、preset 名册、发布流程 | `dsh` 包（bin、lib 内 commander 定义与 --help）、各 bundle 包 `cordis.patch.yml` diff、`dsh-settings`/`dsh-agent-presets` 的 lib、GitHub 富化的 release 相关 commit |
+| 4 | Remote / BFF | `packages/api/gateway`、`packages/api/*-controller`、`packages/client/connection`、`packages/host/webserver`：流/journal/snapshot 事件、错误码词汇、HTTP 路由、连接状态机、鉴权流 | `dsh-api-gateway`、`dsh-api-*-controller`、`dsh-client-connection` 的已发布 lib：错误码常量、心跳默认值、事件名 |
+| 5 | 会话数据 | `packages/session/**`、`packages/session-query/**`、`packages/core/session`、`session-format-guard.expected.e2e.ts`：两个格式守卫、迁移还是拒绝（读守卫代码，不读 README）、JSONL 编码、投影/查询/导出面 | `dsh-session` + 补充包 `dsh-session-persistence-sqlite` 的 lib 常量与 `resources/sql/`、`dsh-session-query*`、`dsh-session-log-export` |
+| 6 | 回滚清查 | 全树：`git diff --name-status` 的 D/R（跳过测试/notes/i18n）、所有变更 `src/index.ts` 的导出删除、删掉的 CLI flag/配置键/preset/docs 章节；逐条归类「迁移了」还是「没了」 | `reverts.txt`（富化）+ `manifest-diff.txt` 全量过一遍：只在一棵树出现的包、exports/files/bin 收窄的包 |
+
+## 侦察派发模板
+
+一批并行发出。每个 prompt 都带 Phase 2 共享事实（格式守卫、回滚清单、Python 行）、本契约、及其侦察面目标。
+
+```
+# Goal
+Audit external-compatibility changes between <from> and <to> in <repo/mode>. External = observable by consumers outside the repo.
+
+# Constraints
+- READ-ONLY. 源码模式用 `git diff <from>..<to> -- <paths>` 和 `git show <tag>:<path>`；npm 模式只读 `a/`、`b/` 两棵已发布树。不 build、不 test、不 lint。
+- 每条发现分类：ADDED / REMOVED / CHANGED（before → after）/ RENAMED。REMOVED 放最前。
+- 每条带 包/路径、符号或字段、变化类型、影响面类别（SDK 消费者 / CLI 用户 / 配置作者 / 会话数据 / 模型可见 / 协议对端 / web UI / npm 安装者）。
+- 内部无关重构（私有 helper、测试、文档措辞）：聚合成一个计数，不逐条列。
+- 不确定就说不确定；没读过的不要猜。
+
+# Output
+Markdown：`## <facade>` → `### REMOVED` / `### CHANGED` / `### ADDED`，结尾一行判定："External-compat delta: <low/medium/high> — <一句话>"。
+```
+
+## 核验规则（Phase 4）
+
+侦察输出是线索，不是发现。进入报告前：
+
+1. **存在性主张**：两个树上分别 `git ls-tree <tag> --name-only <dir>` 或 ls 两棵已发布树。报"新增"的包/导出必须在 `from` 侧不存在。
+2. **删除主张**：`git show <to>:<path>` 或 `b/node_modules/...` 里不得再有该符号；找到替代品并点名，找不到就写「没了」。
+3. **取值主张**（默认值、常量、schema 版本）：在两侧树里读常量本身。
+4. **线上主张**（错误码、字段、路由）：diff 声明它的文件，不看 changelog。
+5. 核验不了的删掉，或保留为 `[INFERENCE]` 并写明缺什么证据。
+
+## UPGRADE-ADAPTATION.md 骨架
+
+报告语言跟随用户；骨架如下（英文标题与 [examples/ 实例报告](../examples/0.1.2alpha1-to-0.1.2alpha2/UPGRADE-ADAPTATION.md) 一致）。
+
+```markdown
+# Upgrade Adaptation: <to> ← <from>
+
+<一句话受众说明。工件清单。>
+
+Range: `<from>` (<date>) → `<to>` (<date>). Release commit: `<sha>`. <N> commits total (<n> non-merge). <files> files changed, +<ins> / −<del>.
+[npm 模式加一行：Mode: npm packages (resolved <va> -> <vb>), GitHub enrichment <status>]
+
+History is merge-base-pure: `git merge-base <from> <to>` = <sha> = <from> itself. [不纯：停下解释漂移，不要继续。]
+
+## Verdict
+<直接回答比较性问题：破坏更多吗？有真回滚吗？与上一区间的密度对比。点名 1-3 个最重要事实。>
+
+## 1. Reverts (rollbacks relative to <from>)
+<每条 revert 一个编号项：sha、subject、方向变化、波及面。没有也要写"未发现"并说明查找方式。>
+
+## 2..N. 破坏分节（按消费者影响排序）
+<每面：REMOVED 在前，**BREAKING** + 消费者类别，before → after，替代品，**Adapt:** 行。确认安全的面各一行。>
+
+## Confirmed unchanged (compatibility holds)
+<成立的互操作：协议、CLI、JSONL 日志、模型可见契约。每行带证据。>
+
+## Boundary-signature table
+| API surface | <from> | <to> | changed? |
+|---|---|---|---|
+| package.json exports/files/bin/main maps | ... | ... | ... |
+| SESSION_FORMAT_VERSION | ... | ... | ... |
+| SQLite SCHEMA_VERSION | ... | ... | ... |
+| SDK JSON-RPC wire | ... | ... | ... |
+| Gateway/BFF error codes | ... | ... | ... |
+| HTTP routes | ... | ... | ... |
+| dsh CLI commands/flags | ... | ... | ... |
+| Model-visible tool contracts | ... | ... | ... |
+| Known session event vocabulary | ... | ... | ... |
+
+## Adaptation checklist
+<编号、祈使句、一条一个动作——上面点名的每类消费者一张迁移卡。>
+```
+
+## 报告约定
+
+- "回滚"是方向性的：`from` 中存在、区间内被 revert 撤回的行为。修复性地恢复旧行为算；纯内部在途重构的 revert 不算，除非波及面跨出了某个侦察面。
+- 影响面类别是报告的索引方案：每条破坏都要点名谁会破（SDK 消费者 / CLI 用户 / 配置作者 / 会话数据 / 模型可见 / 协议对端 / web UI / npm 安装者）。
+- 边界签名表是记录摘要；正文分节是它的证据。表行与正文矛盾 = 报告有 bug。
+- 密度对比：`tmp/<prev-pair>/commits.txt` 存在时，在 Verdict 里并排报两个区间的非合并 commit 数与破坏数；**按时间序**取紧邻前一对。npm 模式的历史报告可能只有 `manifest-diff.txt` 可比，如实说明。
+- npm 模式富化的 `commits.txt` 受 GitHub compare API 限制：commit 列表最多 250 条（stats 里 `truncated: true`），大区间的回滚清单可能不全——报告须写明覆盖率；需要完整历史时改用源码模式，或按区间切片多次调用 compare。
+- 与 `plugin-upgrade` 的版本变更卡片衔接：报告的边界签名表与 §1 回滚可直接作为卡片素材；给卡片补「实战批注」时引用报告目录路径，不凭记忆转述。

--- a/skills/dsh-upgrade-audit/scripts/gen-artifacts.mjs
+++ b/skills/dsh-upgrade-audit/scripts/gen-artifacts.mjs
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+/**
+ * Generate the raw artifacts and categorized CHANGELOG for a dsh tag-pair audit.
+ *
+ * Usage: node gen-artifacts.mjs <from-tag> <to-tag> <out-dir>
+ *
+ * Writes into <out-dir>: commits.txt, files.txt, diffstat.txt,
+ * <fromNorm>-to-<toNorm>.diff, CHANGELOG.md. Prints a stats JSON to stdout.
+ * Read-only on the repository besides the output directory.
+ */
+import { execFileSync } from 'node:child_process'
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const [, , from, to, out] = process.argv
+if (!from || !to || !out) {
+  console.error('Usage: node gen-artifacts.mjs <from-tag> <to-tag> <out-dir>')
+  process.exit(2)
+}
+
+/** Run git, throwing with the command name on failure. */
+function git(...args) {
+  return execFileSync('git', args, { encoding: 'utf8', maxBuffer: 1 << 30 })
+}
+
+/** dsh-v0.1.2-alpha.2 -> 0.1.2alpha2; dsh-v0.1.1-rc.2 -> 0.1.1rc2. */
+function normalizeTag(tag) {
+  const m = tag.match(/^(?:dsh-)?v?(\d+\.\d+\.\d+)(?:-(.+))?$/)
+  if (!m) throw new Error(`cannot normalize tag: ${tag}`)
+  return m[1] + (m[2] ? m[2].replace(/\./g, '') : '')
+}
+
+const sectionTitles = {
+  release: 'Release',
+  feat: 'Features',
+  fix: 'Bug Fixes',
+  perf: 'Performance',
+  refactor: 'Refactoring',
+  revert: 'Reverts',
+  docs: 'Documentation',
+  test: 'Tests',
+  chore: 'Chores / CI',
+  other: 'Other (non-conventional subjects)',
+}
+
+const commitLineRe = /^[0-9a-f]+ \(\d{4}-\d{2}-\d{2}\) (.*)$/
+
+/** Conventional-type bucket; `Revert "…"` merge-subject lines count as reverts. */
+function classify(subject) {
+  if (/^Revert /.test(subject)) return 'revert'
+  const m = subject.match(/^(feat|fix|perf|refactor|revert|docs|test|chore|release)(\(|:)/i)
+  return m ? m[1].toLowerCase() : 'other'
+}
+
+mkdirSync(out, { recursive: true })
+
+const mergeBase = git('merge-base', from, to).trim()
+const fromCommit = git('rev-parse', `${from}^{commit}`).trim()
+const pure = mergeBase === fromCommit
+
+const commitLines = git('log', '--no-merges', '--pretty=format:%h (%ad) %s', '--date=short', `${from}..${to}`)
+  .split('\n')
+  .filter(Boolean)
+
+const buckets = {}
+for (const key of Object.keys(sectionTitles)) buckets[key] = []
+for (const line of commitLines) {
+  const subject = line.match(commitLineRe)?.[1] ?? line
+  buckets[classify(subject)].push(line)
+}
+
+let changelog = `# Changelog: ${from} → ${to}\n\nGenerated from \`git log ${from}..${to}\` (${commitLines.length} commits; merge commits excluded).\n\n`
+for (const [key, title] of Object.entries(sectionTitles)) {
+  if (!buckets[key].length) continue
+  changelog += `## ${title} (${buckets[key].length})\n\n${buckets[key].map((r) => `- ${r}`).join('\n')}\n\n`
+}
+
+const diffName = `${normalizeTag(from)}-to-${normalizeTag(to)}.diff`
+const files = {
+  'commits.txt': commitLines.join('\n') + '\n',
+  'files.txt': git('diff', '--name-status', from, to),
+  'diffstat.txt': git('diff', '--stat', from, to),
+  [diffName]: git('diff', from, to),
+  'CHANGELOG.md': changelog,
+}
+for (const [name, content] of Object.entries(files)) {
+  writeFileSync(join(out, name), content.endsWith('\n') ? content : content + '\n')
+}
+
+const total = Number(git('rev-list', '--count', `${from}..${to}`).trim())
+const shortstat = git('diff', '--shortstat', from, to).trim()
+const stats = {
+  from,
+  to,
+  outDir: out,
+  mergeBasePurity: pure ? 'pure' : `DRIFT: merge-base ${mergeBase} != from ${fromCommit}`,
+  totalCommits: total,
+  nonMergeCommits: commitLines.length,
+  filesChanged: Number(shortstat.match(/(\d+) files? changed/)?.[1] ?? 0),
+  insertions: Number(shortstat.match(/(\d+) insertion/)?.[1] ?? 0),
+  deletions: Number(shortstat.match(/(\d+) deletion/)?.[1] ?? 0),
+  artifacts: Object.keys(files),
+}
+console.log(JSON.stringify(stats, null, 2))

--- a/skills/dsh-upgrade-audit/scripts/materialize-npm.mjs
+++ b/skills/dsh-upgrade-audit/scripts/materialize-npm.mjs
@@ -1,0 +1,158 @@
+#!/usr/bin/env node
+/**
+ * Materialize two published @deepseek-ai/dsh versions for an npm-mode audit.
+ *
+ * Usage: node materialize-npm.mjs <versionA> <versionB> <out-dir> [--packages name1,name2] [--no-github]
+ *
+ * Versions accept npm versions (0.1.2-alpha.2), dsh tag spellings (dsh-v0.1.2-alpha.2),
+ * or dist-tags (alpha, latest, next). Installs the CLI dependency closure (plus any
+ * supplement packages, default: the SQLite persistence backend) into <out-dir>/a and
+ * /b with scripts disabled, then emits a manifest diff and GitHub commit enrichment
+ * when the repository is public. Prints a stats JSON to stdout; exits 1 with the
+ * published version list when a requested version is not on the registry.
+ */
+import { execFileSync } from 'node:child_process'
+import { mkdirSync, writeFileSync, readdirSync, readFileSync, existsSync } from 'node:fs'
+import { join } from 'node:path'
+
+const CLI = '@deepseek-ai/dsh'
+const DEFAULT_SUPPLEMENTS = ['@deepseek-ai/dsh-session-persistence-sqlite']
+const args = process.argv.slice(2)
+const [va, vb, out] = args.filter((a) => !a.startsWith('--'))
+if (!va || !vb || !out) {
+  console.error('Usage: node materialize-npm.mjs <versionA> <versionB> <out-dir> [--packages name1,name2] [--no-github]')
+  process.exit(2)
+}
+function flagValue(name) {
+  const i = args.indexOf(name)
+  return i >= 0 ? args[i + 1] : undefined
+}
+const supplements = flagValue('--packages')?.split(',') ?? DEFAULT_SUPPLEMENTS
+const useGithub = !args.includes('--no-github')
+
+/** dsh-v0.1.2-alpha.2 -> 0.1.2alpha2 (report-directory naming). */
+function normalizeTag(tag) {
+  const m = tag.match(/^(?:dsh-)?v?(\d+\.\d+\.\d+)(?:-(.+))?$/)
+  return m ? m[1] + (m[2] ? m[2].replace(/\./g, '') : '') : tag
+}
+
+function npm(...a) {
+  return execFileSync('npm', [...a, '--loglevel=error'], { encoding: 'utf8', maxBuffer: 1 << 28, stdio: ['ignore', 'pipe', 'pipe'] })
+}
+
+/** Resolve a spec (version or dist-tag) against the registry; null when absent. */
+function resolve(spec) {
+  try {
+    return { spec, resolved: JSON.parse(npm('view', `${CLI}@${spec}`, 'version', '--json')) }
+  } catch {
+    return { spec, resolved: null }
+  }
+}
+const published = JSON.parse(npm('view', CLI, 'versions', '--json'))
+const distTags = JSON.parse(npm('view', CLI, 'dist-tags', '--json'))
+const repository = npm('view', CLI, 'repository.url').trim().replace(/^git\+|\.git$/g, '')
+const [a, b] = [resolve(va), resolve(vb)]
+const missing = [a, b].filter((r) => !r.resolved)
+if (missing.length) {
+  console.log(JSON.stringify({ error: 'requested version(s) not published', requested: missing.map((m) => m.spec), published, distTags }, null, 2))
+  process.exit(1)
+}
+
+const supplementsResolved = supplements.map((p) => {
+  try {
+    return { pkg: p, resolved: JSON.parse(npm('view', `${p}@${b.resolved}`, 'version', '--json')) }
+  } catch {
+    return { pkg: p, resolved: null }
+  }
+})
+
+/** Install one root: CLI closure + supplement packages, scripts disabled. */
+function materialize(root, version) {
+  mkdirSync(root, { recursive: true })
+  writeFileSync(join(root, 'package.json'), JSON.stringify({ name: 'dsh-upgrade-audit-root', private: true }, null, 2) + '\n')
+  const specs = [`${CLI}@${version}`, ...supplements.filter((s) => s.resolved).map((s) => `${s.pkg}@${version}`)]
+  execFileSync('npm', ['install', '--ignore-scripts', '--omit=dev', '--no-audit', '--no-fund', '--loglevel=error', ...specs], {
+    cwd: root,
+    encoding: 'utf8',
+    maxBuffer: 1 << 28,
+    stdio: ['ignore', 'ignore', 'inherit'],
+  })
+}
+
+materialize(join(out, 'a'), a.resolved)
+materialize(join(out, 'b'), b.resolved)
+
+/** Scoped packages present under node_modules/@deepseek-ai in a root. */
+function scopedPkgs(root) {
+  const dir = join(root, 'node_modules', '@deepseek-ai')
+  return existsSync(dir) ? readdirSync(dir).sort() : []
+}
+const pkgsA = scopedPkgs(join(out, 'a'))
+const pkgsB = scopedPkgs(join(out, 'b'))
+const manifestFields = ['version', 'bin', 'files', 'exports', 'dependencies', 'peerDependencies']
+
+let manifestDiff = `# package.json manifest diff: ${CLI} ${a.resolved} -> ${b.resolved}\n\n`
+for (const name of new Set([...pkgsA, ...pkgsB].sort())) {
+  const pa = join(out, 'a', 'node_modules', '@deepseek-ai', name, 'package.json')
+  const pb = join(out, 'b', 'node_modules', '@deepseek-ai', name, 'package.json')
+  const fa = existsSync(pa) ? JSON.parse(readFileSync(pa, 'utf8')) : null
+  const fb = existsSync(pb) ? JSON.parse(readFileSync(pb, 'utf8')) : null
+  if (!fa || !fb) {
+    manifestDiff += `## ${name}: ${fa ? 'REMOVED in b' : 'ADDED in b'}\n\n`
+    continue
+  }
+  const deltas = manifestFields
+    .filter((f) => JSON.stringify(fa[f] ?? null) !== JSON.stringify(fb[f] ?? null))
+    .map((f) => `- ${f}:\n  a: ${JSON.stringify(fa[f] ?? null)}\n  b: ${JSON.stringify(fb[f] ?? null)}`)
+  if (deltas.length) manifestDiff += `## ${name} (${fa.version} -> ${fb.version})\n\n${deltas.join('\n')}\n\n`
+}
+writeFileSync(join(out, 'manifest-diff.txt'), manifestDiff)
+
+/** GitHub compare enrichment: commit list + revert detection across the tag pair. */
+let enrichment = { attempted: false }
+if (useGithub && repository.includes('github.com')) {
+  enrichment.attempted = true
+  const [, owner, repo] = repository.match(/github\.com[/:]([^/]+)\/([^/]+)$/) ?? []
+  if (owner) {
+    const range = `dsh-v${a.resolved}...dsh-v${b.resolved}`
+    try {
+      const res = await fetch(`https://api.github.com/repos/${owner}/${repo}/compare/${range}`)
+      if (res.ok) {
+        const data = await res.json()
+        const commits = (data.commits ?? []).map((c) => `${c.sha.slice(0, 10)} (${c.commit.author.date.slice(0, 10)}) ${c.commit.message.split('\n')[0]}`)
+        writeFileSync(join(out, 'commits.txt'), commits.join('\n') + '\n')
+        const reverts = commits.filter((c) => /revert/i.test(c))
+        writeFileSync(join(out, 'reverts.txt'), reverts.join('\n') + '\n')
+        enrichment = {
+          attempted: true,
+          ok: true,
+          range,
+          totalCommits: data.total_commits,
+          commitsListed: commits.length,
+          truncated: commits.length < data.total_commits,
+          reverts: reverts.length,
+        }
+      } else {
+        enrichment = { attempted: true, ok: false, status: res.status }
+      }
+    } catch (e) {
+      enrichment = { attempted: true, ok: false, error: String(e) }
+    }
+  }
+}
+
+const stats = {
+  from: { requested: a.spec, resolved: a.resolved },
+  to: { requested: b.spec, resolved: b.resolved },
+  distTags,
+  publishedVersions: published,
+  outDir: out,
+  supplements: supplementsResolved,
+  packagesA: pkgsA.length,
+  packagesB: pkgsB.length,
+  packagesOnlyInA: pkgsA.filter((p) => !pkgsB.includes(p)),
+  packagesOnlyInB: pkgsB.filter((p) => !pkgsA.includes(p)),
+  github: enrichment,
+  artifacts: ['a/', 'b/', 'manifest-diff.txt', ...(enrichment.ok ? ['commits.txt', 'reverts.txt'] : [])],
+}
+console.log(JSON.stringify(stats, null, 2))


### PR DESCRIPTION
## 背景

`plugin-upgrade` 回答的是「怎么把插件升上去」，但升级决策本身缺一个证据层：目标宿主版本相对当前版本，对外部消费者到底多了哪些破坏、有没有蓄意回滚？官方征集帖（deepseek-ai/deepseek-harness discussions/5120）也提到版本变更卡片需要版本间的兼容性证据。本 PR 新增 `dsh-upgrade-audit` skill 来生产这类证据。

## 改动

**新 skill `skills/dsh-upgrade-audit/`** —— 审计两个 DSH 版本之间**仓库外消费者**可观察的一切变化（npm 包公共 API、CLI 面、线上协议、会话落盘数据、配置、模型可见契约），并显式检测回滚（revert）：

- **双模式**：有 deepseek-harness 源码检出时走 git tag 对比（merge-base 纯度门禁，基漂移即停）；无源码（第三方 repo 场景）自动降级下载 npm 两个已发布版本物化分析（`--ignore-scripts`，只装进报告目录，绝不污染宿主 node_modules）
- **六个标准侦察面**：Core API / SDK & 线上协议 / CLI & 配置 / Remote-BFF / 会话数据 / 回滚清查，按区间规模决定内联或并行子代理扇出；派发契约与目标清单在 `references/audit-playbook.md`
- **Phase 4 核验规则**：侦察输出是线索不是发现——存在性/删除/取值/线上四类主张逐一在两棵树里复核，核验不了的标 `[INFERENCE]` 或删除
- **标准输出契约**：一个 `tmp/<from>-to-<to>/` 目录，含 `commits.txt`、`files.txt`、`diffstat.txt`、全量 diff、分类 `CHANGELOG.md`（**强制 Reverts 分节**）、`UPGRADE-ADAPTATION.md`（Verdict → 回滚 → 按消费者影响排序的破坏分节，每条带 **Adapt:** 行 → Confirmed unchanged → 边界签名表 → 编号 Adaptation checklist）
- **scripts**：`gen-artifacts.mjs`（源码模式工件 + 分类 changelog）、`materialize-npm.mjs`（npm 物化 + 逐包 manifest diff + GitHub compare 富化；版本从未发布时 exit 1 带已发布清单，不静默替换版本对）
- **evals 4 条**：覆盖已有手工报告不覆盖、按用户关注点缩面、npm 版本从未发布的陷阱、最早区间无前序可比时的密度对比陷阱
- **与 plugin-upgrade 的关系**：本 skill 产出宿主版本间的兼容性证据（报告 + 边界签名表），供 `plugin-upgrade` 版本变更卡片「实战批注」直接引用

## 案例

`examples/0.1.2alpha1-to-0.1.2alpha2/` 收录了本 skill（源码模式）在 deepseek-harness 检出里对 `dsh-v0.1.2-alpha.1..dsh-v0.1.2-alpha.2` 的真实审计产物（234 commits / 157 非合并 / 1,604 files changed）：

- [`UPGRADE-ADAPTATION.md`](skills/dsh-upgrade-audit/examples/0.1.2alpha1-to-0.1.2alpha2/UPGRADE-ADAPTATION.md) — 完整报告骨架示范：Verdict 直接回答「破坏密度高于上一区间 + 首现两个显式 revert」；§1 回滚分节；SQLite schema 19→20 双向硬拒、Remote 错误码命名空间化等破坏分节各带消费者类别与 Adapt 行；边界签名表 12 行逐面判定
- [`CHANGELOG.md`](skills/dsh-upgrade-audit/examples/0.1.2alpha1-to-0.1.2alpha2/CHANGELOG.md) — 分类 commit 清单含 Reverts 分节

机械工件（commits/files/diffstat/diff）不入库，可用 `gen-artifacts.mjs` 一条命令复现（见该目录 README）。

## 验证

- `node scripts/validate.mjs` 通过（4 skill / 2 card sets / 26 Markdown，仓库内相对链接全解析）
- 案例即本 skill 流程的真实产物，非手工拼装