### PR TITLE
docs(i18n): add English and Simplified Chinese entry docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,23 @@
 # DSH Plugin Upgrade Skill
 
-**DeepSeek Harness 插件生态的 agent skill**，社区共建。提供版本无关的迁移指南、破坏性变更配方和真实迁移示例。
+**English** | [简体中文](README.zh-CN.md)
 
-[DSH（DeepSeek Harness）](https://github.com/deepseek-ai/deepseek-harness) 是"一切皆插件"的 agent harness。本仓库提供 DSH 插件升级的 agent skill——从检查更新、阅读 changelog，到迁移配置、源码适配、验证结果。
+A community-maintained agent skill for the DeepSeek Harness plugin ecosystem, with version-aware migration guidance, breaking-change recipes, and field-tested examples.
 
-## 特色
+[DSH (DeepSeek Harness)](https://github.com/deepseek-ai/deepseek-harness) is an agent harness where everything is a plugin. This repository helps agents inspect updates, read changelogs, migrate configuration and source code, and verify DSH plugin upgrades.
 
-- **持续更新** — 每个 DSH 版本对应一张独立的迁移卡片，按序应用即可跨版本升级
-- **社区共建** — 基于真实迁移实践（如 [dsh-web #5120](https://github.com/deepseek-ai/deepseek-harness/discussions/5120)），持续补充痛点与配方
-- **结构化数据** — 版本卡片格式统一，支持工具化（未来可自动生成迁移 diff）
-- **多 agent 支持** — 兼容 Claude Code、Codex、Gemini CLI、Cursor 等主流 AI 编程工具
+## Features
 
-## 快速开始
+- **Continuously updated** — Version cards form an ordered migration corridor across DSH releases.
+- **Community-tested** — Recipes incorporate real migrations such as [dsh-web #5120](https://github.com/deepseek-ai/deepseek-harness/discussions/5120).
+- **Structured data** — Version cards follow a stable schema suitable for tooling.
+- **Multi-agent support** — Works with Claude Code, Codex, Gemini CLI, Cursor, and other coding agents.
 
-### 使用 skills CLI（推荐）
+## Quick start
 
-最快路径——一条命令安装到 70+ 种 agent：
+### skills CLI (recommended)
+
+Install for 70+ supported agents with one command:
 
 ```bash
 npx skills add oh-my-dsh/dsh-plugin-upgrade-skill
@@ -23,24 +25,27 @@ npx skills add oh-my-dsh/dsh-plugin-upgrade-skill
 
 ### Claude Code
 
-**Marketplace 安装**：
+**Marketplace:**
 
 ```bash
 /plugin marketplace add oh-my-dsh/dsh-plugin-upgrade-skill
 /plugin install dsh-plugin-upgrade-skill
 ```
 
-> **SSH 错误？**如果没有配置 GitHub SSH 密钥，使用 HTTPS URL：
+> **SSH error?** Use the HTTPS URL if GitHub SSH keys are unavailable:
+>
 > ```bash
 > /plugin marketplace add https://github.com/oh-my-dsh/dsh-plugin-upgrade-skill.git
 > /plugin install dsh-plugin-upgrade-skill
 > ```
-> 或全局配置 Git 重写 SSH 为 HTTPS：
+>
+> Or configure Git to rewrite GitHub SSH URLs:
+>
 > ```bash
 > git config --global url."https://github.com/".insteadOf git@github.com:
 > ```
 
-**本地/开发模式**：
+**Local development:**
 
 ```bash
 git clone https://github.com/oh-my-dsh/dsh-plugin-upgrade-skill.git
@@ -49,133 +54,132 @@ claude --plugin-dir /path/to/dsh-plugin-upgrade-skill
 
 ### Codex
 
-通过 marketplace 或本地目录安装：
+Install from the marketplace or a local directory:
 
 ```bash
 # Marketplace
 codex plugin add oh-my-dsh/dsh-plugin-upgrade-skill
 
-# 本地
+# Local
 git clone https://github.com/oh-my-dsh/dsh-plugin-upgrade-skill.git
 codex plugin add ./dsh-plugin-upgrade-skill
 ```
 
 ### Gemini CLI
 
-直接从仓库或本地克隆安装：
+Install from GitHub or a local clone:
 
 ```bash
-# 从仓库
+# GitHub
 gemini skills install https://github.com/oh-my-dsh/dsh-plugin-upgrade-skill.git --path skills
 
-# 本地
+# Local
 git clone https://github.com/oh-my-dsh/dsh-plugin-upgrade-skill.git
 gemini skills install ./dsh-plugin-upgrade-skill/skills/
 ```
 
 ### Cursor
 
-将 `skills/` 复制到 `.cursor/skills/`：
+Copy `skills/` into `.cursor/skills/`:
 
 ```bash
 git clone https://github.com/oh-my-dsh/dsh-plugin-upgrade-skill.git
 cp -r dsh-plugin-upgrade-skill/skills/* .cursor/skills/
 ```
 
-## 使用
+## Usage
 
-### 斜杠命令（Claude / Gemini）
+### Slash command (Claude / Gemini)
 
-安装后可使用 `/dsh-upgrade` 命令：
+After installation:
 
 ```bash
 /dsh-upgrade 0.1.2
 ```
 
-或直接在对话中提问：
+Or ask directly:
 
-```
-我需要把插件从 0.1.1 升级到 0.1.2，有哪些破坏性变更？
-```
-
-### Skill 调用（任意 agent）
-
-对于没有斜杠命令的 agent，直接引用 skill：
-
-```
-使用 plugin-upgrade skill 帮我升级 DSH 插件到 0.1.2
+```text
+What breaking changes affect my plugin when upgrading DSH from 0.1.1 to 0.1.2?
 ```
 
-## Skill 索引
+### Skill invocation (any agent)
 
-| Skill | 说明 | 版本覆盖 |
+For agents without slash commands:
+
+```text
+Use the plugin-upgrade skill to upgrade my DSH plugin to 0.1.2.
+```
+
+## Skill index
+
+| Skill | Purpose | Version coverage |
 | --- | --- | --- |
-| [plugin-upgrade](skills/plugin-upgrade/) | 三模式安全升级：只读检查、已安装插件升级、DSH 宿主兼容迁移；含七类触点、版本卡片与回滚约束 | 0.1.1 → 0.1.2 |
-| [plugin-write](skills/plugin-write/) | 按目标 Harness 合约编写 DSH 插件，区分官方单仓包与外部可安装插件 | 按目标 Harness 版本 |
-| [plugin-test](skills/plugin-test/) | 为 DSH 插件变更选择最小充分测试层级，覆盖单元测试、覆盖率、真实 API、快照、Web 及真实发布入口 | 跨版本验证 |
+| [plugin-upgrade](skills/plugin-upgrade/) | Safe inspection, installed-plugin updates, and DSH host compatibility migration with seven touchpoint classes, version cards, and rollback constraints | 0.1.1 → 0.1.2 |
+| [plugin-write](skills/plugin-write/) | Write DSH plugins against a target Harness contract while distinguishing official monorepo packages from external installable plugins | Target Harness version |
+| [plugin-test](skills/plugin-test/) | Select the smallest sufficient validation layer across unit, coverage, real API, snapshot, Web, and published-entry tests | Cross-version validation |
 
-## 版本数据现状
+## Migration data status
 
-| 版本区间 | 状态 | 卡片文件 | 说明 |
+| Version corridor | Status | Card set | Notes |
 | --- | --- | --- | --- |
-| 0.1.1 → 0.1.2 alpha.1 | ✅ 完成 | [v0.1.2-alpha.1.md](skills/plugin-upgrade/references/v0.1.2-alpha.1.md) | Alpha 1 破坏性变更 |
-| 0.1.1 → 0.1.2 alpha.2 | ✅ 完成 | [v0.1.2-alpha.2.md](skills/plugin-upgrade/references/v0.1.2-alpha.2.md) | Alpha 2 增量变更 |
-| 0.1.1 → 0.1.2 走廊 | ✅ 完成（基于 alpha.2） | [rollup-0.1.2.md](skills/plugin-upgrade/references/rollup-0.1.2.md) | Rollup 层增量：跨 cohort 共存、未发布 cohort 安装、`RemoteResult` 错误流、分层验证 |
-| 0.1.1 → 0.1.2 | 🔄 待官方发布 tag | — | 0.1.2 正式版尚未发布（当前最新：alpha.2） |
-| 0.1.2 → 0.1.3+ | 📝 待认领 | — | 等待社区贡献（[贡献指南](CONTRIBUTING.md)） |
+| 0.1.1 → 0.1.2 alpha.1 | ✅ Complete | [v0.1.2-alpha.1.md](skills/plugin-upgrade/references/v0.1.2-alpha.1.md) | Alpha 1 breaking changes |
+| 0.1.1 → 0.1.2 alpha.2 | ✅ Complete | [v0.1.2-alpha.2.md](skills/plugin-upgrade/references/v0.1.2-alpha.2.md) | Alpha 2 incremental changes |
+| 0.1.1 → 0.1.2 corridor | ✅ Complete for alpha.2 | [rollup-0.1.2.md](skills/plugin-upgrade/references/rollup-0.1.2.md) | Cross-cohort compatibility, unpublished cohort installation, `RemoteResult` flow, and layered validation |
+| 0.1.1 → 0.1.2 final | 🔄 Awaiting official tag | — | DSH 0.1.2 final is not published; alpha.2 is the current tracked target |
+| 0.1.2 → 0.1.3+ | 📝 Unclaimed | — | Contributions welcome; see [CONTRIBUTING.md](CONTRIBUTING.md) |
 
-## 参考资源
+## References
 
-- [官方仓库](https://github.com/deepseek-ai/deepseek-harness) — DSH 主仓库
-- [Discussion #5120](https://github.com/deepseek-ai/deepseek-harness/discussions/5120) — 社区迁移实践与痛点征集
-- [dsh-web 迁移实例](https://github.com/zhu1090093659/dsh-web) — @zhu1090093659 的完整迁移案例
+- [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) — Official DSH repository
+- [Discussion #5120](https://github.com/deepseek-ai/deepseek-harness/discussions/5120) — Community migration findings and pain points
+- [dsh-web migration](https://github.com/zhu1090093659/dsh-web) — Full migration by @zhu1090093659
 
-## 安装与触发
+## Installation and triggering
 
-项目级使用可把 `skills/plugin-upgrade/` 复制到：
+For project-local use, copy `skills/plugin-upgrade/` to:
 
 ```text
 <your-project>/.agents/skills/plugin-upgrade/
 ```
 
-也可以让 DSH 本地 Skill provider 直接加载本仓库的 `skills/` 根目录。确认目录中保留
-`SKILL.md` 与 `references/`，不要只复制主文件。
+DSH's local Skill provider can also load this repository's `skills/` root. Keep `SKILL.md` together with `references/`; copying only the entry file is insufficient.
 
-示例请求：
+Example requests:
 
-- `只读检查这个 DSH 插件有没有新版本，不要修改任何文件。`
-- `把已安装插件升级到 1.4.0，先给计划，确认后再执行。`
-- `把这个插件从 dsh-v0.1.1-rc.2 适配到 dsh-v0.1.2-alpha.2。`
+- `Inspect this DSH plugin for updates without modifying any files.`
+- `Upgrade the installed plugin to 1.4.0. Show the plan and wait for confirmation before writing.`
+- `Migrate this plugin from dsh-v0.1.1-rc.2 to dsh-v0.1.2-alpha.2.`
 
-## 目录
+## Layout
 
 ```text
 skills/<skill-name>/
 ├── SKILL.md
-├── references/     # 按需加载的版本事实与清单
-└── examples/       # 静态夹具，不默认执行
-scripts/validate.mjs            # Skill 结构校验
-scripts/validate-manifests.mjs  # 多 agent manifest 校验
+├── references/     # Version facts and checklists loaded on demand
+└── examples/       # Static fixtures; never executed by default
+scripts/validate.mjs            # Skill structure validation
+scripts/validate-manifests.mjs  # Multi-agent manifest validation
 ```
 
-## 贡献与验证
+## Contributing and validation
 
-1. 按 [skills/README.md](skills/README.md) 编写或更新 Skill；
-2. 版本卡遵循 [card schema](skills/plugin-upgrade/references/README.md)；
-3. 运行：
+1. Follow [skills/README.md](skills/README.md) when creating or updating a skill.
+2. Follow the [version-card schema](skills/plugin-upgrade/references/README.md).
+3. Run:
 
 ```sh
 node scripts/validate.mjs
 node scripts/validate-manifests.mjs
 ```
 
-4. 提 PR，并说明已运行的验证。
+4. Open a PR and list the validation performed.
 
-## 致谢
+## Acknowledgements
 
-- [@ccch1mneyyy](https://github.com/ccch1mneyyy) — issue #1 提案和 alpha 版本卡片
-- [@zhu1090093659](https://github.com/zhu1090093659) — [dsh-web](https://github.com/zhu1090093659/dsh-web) 迁移实践与详细痛点记录
-- [@tianyicui](https://github.com/tianyicui) — discussion #5120 发起和官方征集
+- [@ccch1mneyyy](https://github.com/ccch1mneyyy) — Issue #1 proposal and alpha version cards
+- [@zhu1090093659](https://github.com/zhu1090093659) — [dsh-web](https://github.com/zhu1090093659/dsh-web) migration findings
+- [@tianyicui](https://github.com/tianyicui) — Discussion #5120 and official migration call
 
 ## License
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,187 @@
+# DSH Plugin Upgrade Skill
+
+[English](README.md) | **简体中文**
+
+**DeepSeek Harness 插件生态的 agent skill**，社区共建。提供版本无关的迁移指南、破坏性变更配方和真实迁移示例。
+
+[DSH（DeepSeek Harness）](https://github.com/deepseek-ai/deepseek-harness) 是“一切皆插件”的 agent harness。本仓库提供 DSH 插件升级的 agent skill——从检查更新、阅读 changelog，到迁移配置、源码适配、验证结果。
+
+## 特色
+
+- **持续更新** — 每个 DSH 版本对应一张独立的迁移卡片，按序应用即可跨版本升级
+- **社区共建** — 基于真实迁移实践（如 [dsh-web #5120](https://github.com/deepseek-ai/deepseek-harness/discussions/5120)），持续补充痛点与配方
+- **结构化数据** — 版本卡片格式统一，支持工具化（未来可自动生成迁移 diff）
+- **多 agent 支持** — 兼容 Claude Code、Codex、Gemini CLI、Cursor 等主流 AI 编程工具
+
+## 快速开始
+
+### 使用 skills CLI（推荐）
+
+最快路径——一条命令安装到 70+ 种 agent：
+
+```bash
+npx skills add oh-my-dsh/dsh-plugin-upgrade-skill
+```
+
+### Claude Code
+
+**Marketplace 安装**：
+
+```bash
+/plugin marketplace add oh-my-dsh/dsh-plugin-upgrade-skill
+/plugin install dsh-plugin-upgrade-skill
+```
+
+> **SSH 错误？**如果没有配置 GitHub SSH 密钥，使用 HTTPS URL：
+>
+> ```bash
+> /plugin marketplace add https://github.com/oh-my-dsh/dsh-plugin-upgrade-skill.git
+> /plugin install dsh-plugin-upgrade-skill
+> ```
+>
+> 或全局配置 Git 重写 SSH 为 HTTPS：
+>
+> ```bash
+> git config --global url."https://github.com/".insteadOf git@github.com:
+> ```
+
+**本地/开发模式**：
+
+```bash
+git clone https://github.com/oh-my-dsh/dsh-plugin-upgrade-skill.git
+claude --plugin-dir /path/to/dsh-plugin-upgrade-skill
+```
+
+### Codex
+
+通过 marketplace 或本地目录安装：
+
+```bash
+# Marketplace
+codex plugin add oh-my-dsh/dsh-plugin-upgrade-skill
+
+# 本地
+git clone https://github.com/oh-my-dsh/dsh-plugin-upgrade-skill.git
+codex plugin add ./dsh-plugin-upgrade-skill
+```
+
+### Gemini CLI
+
+直接从仓库或本地克隆安装：
+
+```bash
+# 从仓库
+gemini skills install https://github.com/oh-my-dsh/dsh-plugin-upgrade-skill.git --path skills
+
+# 本地
+git clone https://github.com/oh-my-dsh/dsh-plugin-upgrade-skill.git
+gemini skills install ./dsh-plugin-upgrade-skill/skills/
+```
+
+### Cursor
+
+将 `skills/` 复制到 `.cursor/skills/`：
+
+```bash
+git clone https://github.com/oh-my-dsh/dsh-plugin-upgrade-skill.git
+cp -r dsh-plugin-upgrade-skill/skills/* .cursor/skills/
+```
+
+## 使用
+
+### 斜杠命令（Claude / Gemini）
+
+安装后可使用 `/dsh-upgrade` 命令：
+
+```bash
+/dsh-upgrade 0.1.2
+```
+
+或直接在对话中提问：
+
+```text
+我需要把插件从 0.1.1 升级到 0.1.2，有哪些破坏性变更？
+```
+
+### Skill 调用（任意 agent）
+
+对于没有斜杠命令的 agent，直接引用 skill：
+
+```text
+使用 plugin-upgrade skill 帮我升级 DSH 插件到 0.1.2
+```
+
+## Skill 索引
+
+| Skill | 说明 | 版本覆盖 |
+| --- | --- | --- |
+| [plugin-upgrade](skills/plugin-upgrade/) | 三模式安全升级：只读检查、已安装插件升级、DSH 宿主兼容迁移；含七类触点、版本卡片与回滚约束 | 0.1.1 → 0.1.2 |
+| [plugin-write](skills/plugin-write/) | 按目标 Harness 合约编写 DSH 插件，区分官方单仓包与外部可安装插件 | 按目标 Harness 版本 |
+| [plugin-test](skills/plugin-test/) | 为 DSH 插件变更选择最小充分测试层级，覆盖单元测试、覆盖率、真实 API、快照、Web 及真实发布入口 | 跨版本验证 |
+
+## 版本数据现状
+
+| 版本区间 | 状态 | 卡片文件 | 说明 |
+| --- | --- | --- | --- |
+| 0.1.1 → 0.1.2 alpha.1 | ✅ 完成 | [v0.1.2-alpha.1.md](skills/plugin-upgrade/references/v0.1.2-alpha.1.md) | Alpha 1 破坏性变更 |
+| 0.1.1 → 0.1.2 alpha.2 | ✅ 完成 | [v0.1.2-alpha.2.md](skills/plugin-upgrade/references/v0.1.2-alpha.2.md) | Alpha 2 增量变更 |
+| 0.1.1 → 0.1.2 走廊 | ✅ 完成（基于 alpha.2） | [rollup-0.1.2.md](skills/plugin-upgrade/references/rollup-0.1.2.md) | Rollup 层增量：跨 cohort 共存、未发布 cohort 安装、`RemoteResult` 错误流、分层验证 |
+| 0.1.1 → 0.1.2 | 🔄 待官方发布 tag | — | 0.1.2 正式版尚未发布（当前最新：alpha.2） |
+| 0.1.2 → 0.1.3+ | 📝 待认领 | — | 等待社区贡献（[贡献指南](CONTRIBUTING.md)） |
+
+## 参考资源
+
+- [官方仓库](https://github.com/deepseek-ai/deepseek-harness) — DSH 主仓库
+- [Discussion #5120](https://github.com/deepseek-ai/deepseek-harness/discussions/5120) — 社区迁移实践与痛点征集
+- [dsh-web 迁移实例](https://github.com/zhu1090093659/dsh-web) — @zhu1090093659 的完整迁移案例
+
+## 安装与触发
+
+项目级使用可把 `skills/plugin-upgrade/` 复制到：
+
+```text
+<your-project>/.agents/skills/plugin-upgrade/
+```
+
+也可以让 DSH 本地 Skill provider 直接加载本仓库的 `skills/` 根目录。确认目录中保留
+`SKILL.md` 与 `references/`，不要只复制主文件。
+
+示例请求：
+
+- `只读检查这个 DSH 插件有没有新版本，不要修改任何文件。`
+- `把已安装插件升级到 1.4.0，先给计划，确认后再执行。`
+- `把这个插件从 dsh-v0.1.1-rc.2 适配到 dsh-v0.1.2-alpha.2。`
+
+## 目录
+
+```text
+skills/<skill-name>/
+├── SKILL.md
+├── references/     # 按需加载的版本事实与清单
+└── examples/       # 静态夹具，不默认执行
+scripts/validate.mjs            # Skill 结构校验
+scripts/validate-manifests.mjs  # 多 agent manifest 校验
+```
+
+## 贡献与验证
+
+1. 按 [skills/README.md](skills/README.md) 编写或更新 Skill；
+2. 版本卡遵循 [card schema](skills/plugin-upgrade/references/README.md)；
+3. 运行：
+
+```sh
+node scripts/validate.mjs
+node scripts/validate-manifests.mjs
+```
+
+4. 提 PR，并说明已运行的验证。
+
+## 致谢
+
+- [@ccch1mneyyy](https://github.com/ccch1mneyyy) — issue #1 提案和 alpha 版本卡片
+- [@zhu1090093659](https://github.com/zhu1090093659) — [dsh-web](https://github.com/zhu1090093659/dsh-web) 迁移实践与详细痛点记录
+- [@tianyicui](https://github.com/tianyicui) — discussion #5120 发起和官方征集
+
+## License
+
+[MIT](LICENSE)

--- a/skills/plugin-upgrade/SKILL.md
+++ b/skills/plugin-upgrade/SKILL.md
@@ -1,108 +1,92 @@
 ---
 name: plugin-upgrade
-description: 检查或升级已安装的 DSH（DeepSeek Harness）插件，或让插件源码适配新的 DSH 宿主版本。仅检查时保持只读；任何配置、依赖或源码写入前必须先展示计划并获得确认。
+description: Inspect or upgrade installed DSH (DeepSeek Harness) plugins, or migrate plugin source to a newer DSH host. Inspection stays read-only; show a plan and obtain confirmation before changing configuration, dependencies, or source. 用于检查、升级或适配 DSH 插件。
 ---
+
+**English** | [简体中文](SKILL.zh-CN.md)
 
 # plugin-upgrade
 
-安全完成三类任务：只读更新检查、已安装插件升级、DSH 宿主版本兼容迁移。若用户意图
-不明确，先确认模式；不要从“帮我看看更新”自行滑入安装或改代码。
+Safely handle three tasks: read-only update inspection, installed-plugin updates, and DSH host compatibility migration. If intent is unclear, confirm the mode; never turn “check for updates” into installation or source changes.
 
-## 第 0 步：选择模式
+## Step 0: choose a mode
 
-| 模式 | 用户意图 | 允许的默认动作 |
+| Mode | User intent | Default allowed action |
 |---|---|---|
-| A · inspect | 检查更新、判断是否受某版 DSH 影响 | 只读调查与报告；完成后停止 |
-| B · update | 把已安装插件升级到明确版本 | 先计划和确认，再改 composition/依赖 |
-| C · host-migrate | DSH 宿主升级后适配插件源码 | 先建版本走廊和触点清单，再计划和确认 |
+| A · inspect | Check updates or assess impact from a DSH release | Read-only investigation and report; then stop |
+| B · update | Upgrade an installed plugin to an explicit version | Plan and confirm before changing composition or dependencies |
+| C · host-migrate | Adapt plugin source after a DSH host upgrade | Build the version corridor and touchpoint inventory, then plan and confirm |
 
-本 skill 不负责“只升级 DSH core 且不处理插件”；也不允许修改 DSH core 来掩盖插件兼容
-问题。
+This skill does not handle DSH core-only upgrades, and it must not modify DSH core to conceal plugin incompatibility.
 
-## 通用只读准备
+## Shared read-only preparation
 
-1. 阅读目标仓库的 `AGENTS.md` / `CLAUDE.md` 等规则；检查 branch、HEAD、working tree、
-   submodule。发现陌生修改或未跟踪文件就停止并报告，不自动 stash/reset/clean/checkout。
-2. 识别安装轨：registry 包、Git checkout、workspace/junction 或复制安装；记录 declared
-   版本、resolved 版本、Git SHA 与当前 DSH/Node 版本。
-3. 区分文件所有权：
-   - `package.json` / lockfile：包与依赖；
-   - `dsh-plugin.json`：社区标准 manifest（若采用）；
-   - `cordis.patch.yml` / `agent.cordis.yml` / 历史 `cordis.yml`：profile composition；
-   - resolved config：运行时组合结果，只用于核对，不整对象回写。
-4. 核对目标版本来源、tag/包名、兼容范围、release notes、安装脚本与已知 breaking changes。
-   不读取、打印或提交 token、`.npmrc` 内容、凭据或会话日志。
-5. 记录回滚基线：当前 HEAD/包版本、lockfile 与将改配置的 hash/路径；说明失败后如何恢复
-   **本次明确路径**，不要承诺回滚第三方安装脚本的任意副作用。
+1. Read repository rules such as `AGENTS.md` and `CLAUDE.md`; inspect branch, HEAD, working tree, and submodules. Stop and report unfamiliar changes or untracked files. Never auto-stash, reset, clean, or checkout.
+2. Identify the installation track: registry package, Git checkout, workspace/junction, or copied install. Record declared and resolved versions, Git SHA, and current DSH/Node versions.
+3. Preserve file ownership boundaries:
+   - `package.json` and lockfile: package and dependencies;
+   - `dsh-plugin.json`: community-standard manifest, when present;
+   - `cordis.patch.yml`, `agent.cordis.yml`, and legacy `cordis.yml`: profile composition;
+   - resolved config: runtime evidence only; never write the whole object back.
+4. Verify the target source, tag/package name, compatibility range, release notes, install scripts, and known breaking changes. Never read, print, or commit tokens, `.npmrc` contents, credentials, or session logs.
+5. Record the rollback baseline: current HEAD/package version, lockfile, and hashes or paths for configuration that may change. Describe recovery only for the explicit paths owned by this task; do not promise rollback of arbitrary third-party script effects.
 
-## 模式 A · inspect（只读）
+## Mode A · inspect (read-only)
 
-输出：当前/可用版本、来源、兼容范围、breaking changes、建议目标、风险与验证计划。不得
-改文件、安装依赖、执行 lifecycle script、`git pull` 或切换版本。用户若决定执行，再进入
-模式 B 或 C 并单独确认。
+Report current and available versions, source, compatibility range, breaking changes, recommended target, risks, and validation plan. Do not edit files, install dependencies, run lifecycle scripts, use `git pull`, or switch versions. If the user chooses to proceed, enter Mode B or C with separate confirmation.
 
-## 模式 B · update（升级已安装插件）
+## Mode B · update an installed plugin
 
-1. 按安装轨选择唯一更新方式；有 lockfile 时只使用对应包管理器，不混用 npm/pnpm/bun。
-2. 生成变更计划：精确目标版本、将执行的命令、会改的文件、可能执行的生命周期脚本、
-   配置迁移和回滚步骤。
-3. **任何写入或安装前取得用户明确确认**；即使没有 breaking change 也一样。
-4. 在独立 branch/worktree 中做最小修改；配置用路径级 patch，保留未知字段。Git 来源先
-   fetch/比较明确 tag 或 commit，不对脏工作区直接 `git pull`。
-5. 按“验证与报告”执行；失败时只恢复本次拥有的路径并报告残留副作用。
+1. Select one update mechanism from the installation track. When a lockfile exists, use its package manager only; do not mix npm, pnpm, and bun.
+2. Present the exact target, commands, files, lifecycle scripts, configuration migration, and rollback steps.
+3. **Obtain explicit confirmation before any write or install**, even when no breaking change is known.
+4. Make the smallest change in a dedicated branch or worktree. Patch configuration by path and preserve unknown fields. For Git installs, fetch and compare an explicit tag or commit; never `git pull` a dirty worktree.
+5. Run “Validation and reporting.” On failure, restore only paths owned by this task and report residual effects.
 
-## 模式 C · host-migrate（插件随 DSH 升级）
+## Mode C · migrate with a DSH host upgrade
 
-1. 用精确 tag 确认 from/to；按 [references/README.md](references/README.md) 的
-   `from → to` 元数据连接版本走廊，禁止按文件名字典序。
-2. 先读完整走廊并计算最终净状态。字段在中间版本删除、目标版又恢复时，不先删再加。
-3. 按 [pre-flight.md](references/pre-flight.md) 扫描七类触点：源码 patch、事件、服务/
-   Remote、宿主文件系统、UI/命令/工具、自建通道、子进程/输出。零命中只是启发式结果，
-   仍须检查依赖/导入并跑 build 与真实挂载。
-4. 只保留与命中触点和实际 face（Host/Web Client/普通 plugin）相交的卡片。卡片是 curated
-   清单，不是完整 API diff；缺走廊边或 API 坐标时标 unsupported/待确认，不凭记忆改。
-5. 生成按 seam 分组的源码迁移计划，列命中文件、卡片、目标行为与测试；取得确认后再在
-   独立 branch/worktree 实施。`capability` 卡仅建议，不自动采用。
+1. Confirm exact from/to tags. Build the corridor from the `from → to` metadata in [references/README.md](references/README.md), never filename sort order.
+2. Read the full corridor and compute the final net state before editing. If a field is removed in one version and restored later, do not delete and re-add it.
+3. Use [pre-flight.md](references/pre-flight.md) to scan seven touchpoint classes: source patches, events, services/Remote, host filesystem, UI/commands/tools, custom channels, and subprocess/output. Zero hits are heuristic only; still inspect dependencies/imports and run build plus a real mount.
+4. Keep only cards intersecting the detected touchpoints and the actual face: Host, Web Client, or ordinary plugin. Cards are curated, not a complete API diff. Mark missing corridor edges or API coordinates unsupported/pending instead of guessing.
+5. Group the migration plan by seam, naming hit files, cards, target behavior, and tests. After confirmation, implement in a dedicated branch or worktree. Suggest `capability` cards; never adopt them automatically.
 
-## 安全边界
+## Safety boundaries
 
-- 所有写文件、安装、拉取/切换版本、运行包脚本的动作都要先展示并确认；
-- 不自动 stash/reset/clean/强制更新，不覆盖用户或其他 Agent 的工作；
-- 不泄露凭据；诊断只报告是否配置及非敏感版本/来源；
-- 不把未知 `gateway/internal` 或其他失败默认重试；仅在错误可重试、操作幂等且策略允许时重试；
-- 迁移方式不能由一手来源或可复现行为高置信确定时，停止自动修改并标「待确认」；
-- 本地观察与一手来源冲突时并列记录、复现并上报，不静默选择一方。
+- Show the plan and obtain confirmation before file writes, installs, version fetch/switch operations, or package scripts.
+- Never auto-stash, reset, clean, force-update, or overwrite user or agent work.
+- Never expose credentials; diagnostics may report only configuration presence and non-sensitive versions or sources.
+- Do not retry unknown `gateway/internal` or other failures by default. Retry only a classified transient error for an idempotent operation when policy allows it.
+- If primary sources or reproducible behavior cannot establish a migration with high confidence, stop and mark it pending review.
+- When local evidence conflicts with a primary source, record both, reproduce, and report the discrepancy.
 
-## 验证与报告
+## Validation and reporting
 
-至少按适用层级验证：
+Validate the applicable layers:
 
-1. 安装/解析：对应包管理器、lockfile 与依赖图只发生预期变化；
-2. 静态：build、typecheck、插件测试；
-3. 运行时：真实 DSH profile 冷启动、entry activate、依赖/提供的 Cordis service 不停在
-   pending；
-4. 行为：执行一条插件核心路径；宿主迁移至少完成一次消息→工具→回复，或等价专用流程；
-5. 包装器：核对退出码、stdout、stderr、取消与 teardown。
+1. Resolution: package manager, lockfile, and dependency graph contain only expected changes.
+2. Static: build, typecheck, and plugin tests.
+3. Runtime: cold-start a real DSH profile; verify entry activation and that required/provided Cordis services do not remain pending.
+4. Behavior: execute one core plugin path. Host migrations require at least one message → tool → response flow or an equivalent specialized path.
+5. Wrapper: verify exit code, stdout, stderr, cancellation, and teardown.
 
-报告固定分为：
+Structure the report as:
 
-- **已完成**：版本、文件、卡片与验证；
-- **跳过**：未命中或不适用及依据；
-- **待确认/残留风险**：缺来源、未跑平台、生命周期脚本副作用；
-- **回滚**：已记录基线与可恢复路径；
-- **建议**：可选 capability 和迁到公开 seam 的后续工作。
+- **Completed**: versions, files, cards, and validation;
+- **Skipped**: non-hits or inapplicable items with evidence;
+- **Pending/residual risk**: missing sources, untested platforms, lifecycle-script effects;
+- **Rollback**: recorded baseline and recoverable paths;
+- **Recommendations**: optional capabilities and future migration to public seams.
 
-## 参考材料
+## References
 
-| 文件 | 内容 |
+| File | Purpose |
 |---|---|
-| [references/README.md](references/README.md) | 版本走廊、卡片 schema 与维护规则 |
-| [references/pre-flight.md](references/pre-flight.md) | 七类触点自查与汇总模板 |
-| [references/v0.1.2-alpha.1.md](references/v0.1.2-alpha.1.md) | rc.2→alpha.1：14 张 curated 卡 |
-| [references/v0.1.2-alpha.2.md](references/v0.1.2-alpha.2.md) | alpha.1→alpha.2：6 张 curated 卡 |
-| [references/rollup-0.1.2.md](references/rollup-0.1.2.md) | 0.1.1 → 0.1.2 走廊（rollup）：跨 cohort 共存、未发布 cohort 安装、`RemoteResult` 错误流、分层验证清单；**基于 alpha.2，正式版需复核** |
-| [examples/legacy-plugin/](examples/legacy-plugin/) | 七类触点静态夹具（不得执行） |
+| [references/README.md](references/README.md) | Version corridors, card schema, and maintenance rules |
+| [references/pre-flight.md](references/pre-flight.md) | Seven-class touchpoint scan and report template |
+| [references/v0.1.2-alpha.1.md](references/v0.1.2-alpha.1.md) | rc.2→alpha.1: 14 curated cards |
+| [references/v0.1.2-alpha.2.md](references/v0.1.2-alpha.2.md) | alpha.1→alpha.2: 6 curated cards |
+| [references/rollup-0.1.2.md](references/rollup-0.1.2.md) | 0.1.1→0.1.2 corridor rollup: cross-cohort compatibility, unpublished cohort installation, `RemoteResult` flow, and layered validation; **based on alpha.2 and subject to final-release review** |
+| [examples/legacy-plugin/](examples/legacy-plugin/) | Static seven-touchpoint fixture; never execute it |
 
-规范背景：[dsh-community-standard](https://github.com/oh-my-dsh/dsh-community-standard)
-负责 manifest、契约坐标与协商；本 skill 处理现有插件的实际升级，引用其分类而不重定义
-规范语义。官方征集出处见 [deepseek-harness discussion #5120](https://github.com/deepseek-ai/deepseek-harness/discussions/5120)。
+[dsh-community-standard](https://github.com/oh-my-dsh/dsh-community-standard) owns manifest, contract-coordinate, and negotiation conventions. This skill handles practical upgrades and reuses that classification without redefining it. The official migration call is [deepseek-harness discussion #5120](https://github.com/deepseek-ai/deepseek-harness/discussions/5120).

--- a/skills/plugin-upgrade/SKILL.zh-CN.md
+++ b/skills/plugin-upgrade/SKILL.zh-CN.md
@@ -1,0 +1,110 @@
+---
+name: plugin-upgrade
+description: 检查或升级已安装的 DSH（DeepSeek Harness）插件，或让插件源码适配新的 DSH 宿主版本。仅检查时保持只读；任何配置、依赖或源码写入前必须先展示计划并获得确认。
+---
+
+[English](SKILL.md) | **简体中文**
+
+# plugin-upgrade
+
+安全完成三类任务：只读更新检查、已安装插件升级、DSH 宿主版本兼容迁移。若用户意图
+不明确，先确认模式；不要从“帮我看看更新”自行滑入安装或改代码。
+
+## 第 0 步：选择模式
+
+| 模式 | 用户意图 | 允许的默认动作 |
+|---|---|---|
+| A · inspect | 检查更新、判断是否受某版 DSH 影响 | 只读调查与报告；完成后停止 |
+| B · update | 把已安装插件升级到明确版本 | 先计划和确认，再改 composition/依赖 |
+| C · host-migrate | DSH 宿主升级后适配插件源码 | 先建版本走廊和触点清单，再计划和确认 |
+
+本 skill 不负责“只升级 DSH core 且不处理插件”；也不允许修改 DSH core 来掩盖插件兼容
+问题。
+
+## 通用只读准备
+
+1. 阅读目标仓库的 `AGENTS.md` / `CLAUDE.md` 等规则；检查 branch、HEAD、working tree、
+   submodule。发现陌生修改或未跟踪文件就停止并报告，不自动 stash/reset/clean/checkout。
+2. 识别安装轨：registry 包、Git checkout、workspace/junction 或复制安装；记录 declared
+   版本、resolved 版本、Git SHA 与当前 DSH/Node 版本。
+3. 区分文件所有权：
+   - `package.json` / lockfile：包与依赖；
+   - `dsh-plugin.json`：社区标准 manifest（若采用）；
+   - `cordis.patch.yml` / `agent.cordis.yml` / 历史 `cordis.yml`：profile composition；
+   - resolved config：运行时组合结果，只用于核对，不整对象回写。
+4. 核对目标版本来源、tag/包名、兼容范围、release notes、安装脚本与已知 breaking changes。
+   不读取、打印或提交 token、`.npmrc` 内容、凭据或会话日志。
+5. 记录回滚基线：当前 HEAD/包版本、lockfile 与将改配置的 hash/路径；说明失败后如何恢复
+   **本次明确路径**，不要承诺回滚第三方安装脚本的任意副作用。
+
+## 模式 A · inspect（只读）
+
+输出：当前/可用版本、来源、兼容范围、breaking changes、建议目标、风险与验证计划。不得
+改文件、安装依赖、执行 lifecycle script、`git pull` 或切换版本。用户若决定执行，再进入
+模式 B 或 C 并单独确认。
+
+## 模式 B · update（升级已安装插件）
+
+1. 按安装轨选择唯一更新方式；有 lockfile 时只使用对应包管理器，不混用 npm/pnpm/bun。
+2. 生成变更计划：精确目标版本、将执行的命令、会改的文件、可能执行的生命周期脚本、
+   配置迁移和回滚步骤。
+3. **任何写入或安装前取得用户明确确认**；即使没有 breaking change 也一样。
+4. 在独立 branch/worktree 中做最小修改；配置用路径级 patch，保留未知字段。Git 来源先
+   fetch/比较明确 tag 或 commit，不对脏工作区直接 `git pull`。
+5. 按“验证与报告”执行；失败时只恢复本次拥有的路径并报告残留副作用。
+
+## 模式 C · host-migrate（插件随 DSH 升级）
+
+1. 用精确 tag 确认 from/to；按 [references/README.md](references/README.md) 的
+   `from → to` 元数据连接版本走廊，禁止按文件名字典序。
+2. 先读完整走廊并计算最终净状态。字段在中间版本删除、目标版又恢复时，不先删再加。
+3. 按 [pre-flight.md](references/pre-flight.md) 扫描七类触点：源码 patch、事件、服务/
+   Remote、宿主文件系统、UI/命令/工具、自建通道、子进程/输出。零命中只是启发式结果，
+   仍须检查依赖/导入并跑 build 与真实挂载。
+4. 只保留与命中触点和实际 face（Host/Web Client/普通 plugin）相交的卡片。卡片是 curated
+   清单，不是完整 API diff；缺走廊边或 API 坐标时标 unsupported/待确认，不凭记忆改。
+5. 生成按 seam 分组的源码迁移计划，列命中文件、卡片、目标行为与测试；取得确认后再在
+   独立 branch/worktree 实施。`capability` 卡仅建议，不自动采用。
+
+## 安全边界
+
+- 所有写文件、安装、拉取/切换版本、运行包脚本的动作都要先展示并确认；
+- 不自动 stash/reset/clean/强制更新，不覆盖用户或其他 Agent 的工作；
+- 不泄露凭据；诊断只报告是否配置及非敏感版本/来源；
+- 不把未知 `gateway/internal` 或其他失败默认重试；仅在错误可重试、操作幂等且策略允许时重试；
+- 迁移方式不能由一手来源或可复现行为高置信确定时，停止自动修改并标“待确认”；
+- 本地观察与一手来源冲突时并列记录、复现并上报，不静默选择一方。
+
+## 验证与报告
+
+至少按适用层级验证：
+
+1. 安装/解析：对应包管理器、lockfile 与依赖图只发生预期变化；
+2. 静态：build、typecheck、插件测试；
+3. 运行时：真实 DSH profile 冷启动、entry activate、依赖/提供的 Cordis service 不停在
+   pending；
+4. 行为：执行一条插件核心路径；宿主迁移至少完成一次消息→工具→回复，或等价专用流程；
+5. 包装器：核对退出码、stdout、stderr、取消与 teardown。
+
+报告固定分为：
+
+- **已完成**：版本、文件、卡片与验证；
+- **跳过**：未命中或不适用及依据；
+- **待确认/残留风险**：缺来源、未跑平台、生命周期脚本副作用；
+- **回滚**：已记录基线与可恢复路径；
+- **建议**：可选 capability 和迁到公开 seam 的后续工作。
+
+## 参考材料
+
+| 文件 | 内容 |
+|---|---|
+| [references/README.md](references/README.md) | 版本走廊、卡片 schema 与维护规则 |
+| [references/pre-flight.md](references/pre-flight.md) | 七类触点自查与汇总模板 |
+| [references/v0.1.2-alpha.1.md](references/v0.1.2-alpha.1.md) | rc.2→alpha.1：14 张 curated 卡 |
+| [references/v0.1.2-alpha.2.md](references/v0.1.2-alpha.2.md) | alpha.1→alpha.2：6 张 curated 卡 |
+| [references/rollup-0.1.2.md](references/rollup-0.1.2.md) | 0.1.1 → 0.1.2 走廊（rollup）：跨 cohort 共存、未发布 cohort 安装、`RemoteResult` 错误流、分层验证清单；**基于 alpha.2，正式版需复核** |
+| [examples/legacy-plugin/](examples/legacy-plugin/) | 七类触点静态夹具（不得执行） |
+
+规范背景：[dsh-community-standard](https://github.com/oh-my-dsh/dsh-community-standard)
+负责 manifest、契约坐标与协商；本 skill 处理现有插件的实际升级，引用其分类而不重定义
+规范语义。官方征集出处见 [deepseek-harness discussion #5120](https://github.com/deepseek-ai/deepseek-harness/discussions/5120)。


### PR DESCRIPTION
## Summary

- make README.md the English default and add README.zh-CN.md
- make plugin-upgrade/SKILL.md the English executable entry and add SKILL.zh-CN.md
- link both language versions without creating a duplicate skill directory

## Validation

- npm test
- npm run validate
- node scripts/validate-manifests.mjs
- skill quick validation
- git diff --check