### PR TITLE
docs(i18n): translate plugin write and test skills to English

### DIFF
--- a/skills/plugin-test/SKILL.md
+++ b/skills/plugin-test/SKILL.md
@@ -1,66 +1,66 @@
 ---
 name: plugin-test
-description: 当需要为 DeepSeek Harness 插件、外部 DSH 插件包或 deepseek-harness 仓库内的包变更编写或审查测试时使用。在单元测试、覆盖率、真实 API 端到端测试、快照、Web、真实组合和构建产物烟雾测试中选择最小充分层级。对 Harness 版本迁移，使用本 Skill 内置的七类触点测试流程，并验证精确的目标版本运行时。
+description: Use when writing or reviewing tests for DeepSeek Harness plugins, external DSH plugin packages, or package changes in the deepseek-harness repository. Select the minimum sufficient levels from unit tests, coverage, real-API end-to-end tests, snapshots, Web tests, real compositions, and built-artifact smoke tests. For Harness version migrations, use this Skill's built-in seven-touchpoint test workflow and validate the exact target-version runtime.
 ---
 
-# 测试 DeepSeek Harness 插件
+# Test DeepSeek Harness Plugins
 
-选择能够证明变更正确的最小测试层级集合；不要默认运行全量测试，也不要重复已通过的检查。
+Select the smallest set of test levels that proves the change is correct. Do not run the full suite by default or repeat checks that have already passed.
 
-## 测试 Harness 版本迁移
+## Test Harness Version Migrations
 
-当任务是将现有插件适配到新的 DSH 宿主版本时：
+When adapting an existing plugin to a new DSH host version:
 
-1. 阅读 [`references/version-migration-testing.md`](references/version-migration-testing.md)，用精确的 from/to 版本建立迁移账本，并扫描七类触点。
-2. 为每条适用的 `breaking` 或 `behavior` 变更添加针对性回归测试。变更级测试只证明对应的迁移映射，不代表整个插件已通过验证。
-3. 在真实产品入口上完成精确目标版本的冷启动和完整用户轮次。类型检查、配置解析、Loader 烟雾测试和模拟 Context 都不能替代这项运行时证明。
-4. 如实报告无法获取的密钥、供应商、操作系统、浏览器、PTY 和破坏性迁移边界，不要声称已实现全面兼容。
+1. Read [`references/version-migration-testing.md`](references/version-migration-testing.md), build a migration ledger for the exact from/to versions, and scan all seven touchpoint classes.
+2. Add a targeted regression test for every applicable `breaking` or `behavior` change. A change-level test proves only that migration mapping; it does not prove the whole plugin is valid.
+3. Cold-start the exact target version through the real product entry point and complete a full user turn. Typechecking, config parsing, Loader smoke tests, and mock Contexts cannot replace this runtime proof.
+4. Report unavailable credentials, providers, operating systems, browsers, PTYs, and destructive-migration boundaries honestly. Do not claim comprehensive compatibility when any remain unverified.
 
-下文命令和仓库路径使用官方 Harness 单仓的测试层级名称。对外部插件，使用所属仓库中等价的脚本和路径；不要添加不存在的 Harness 根命令，也不要强加其单仓布局。
+The commands and repository paths below use test-level names from the official Harness monorepo. For external plugins, use equivalent scripts and paths from their own repositories. Do not add nonexistent Harness root commands or impose the monorepo layout on them.
 
-## 测试层级
+## Test Levels
 
-| 层级 | 命令 | 能够证明的内容 |
+| Level | Command | What it proves |
 |---|---|---|
-| 单元测试 | `pnpm run test` | 包的 `tests/**` 目录下的 vitest 用例，以及仓库 `scripts/**/*.spec.ts` 中的脚本用例；覆盖边界情况、错误路径、事件顺序、并发竞态和合约回归。每个注册表都要有 HMR 安全性测试：释放贡献该注册的 fiber，并断言资源已清理。 |
-| 覆盖率门槛 | `pnpm run test:coverage` | 在 Harness 单仓中，`packages/*/*/src` 要满足逐文件 100% 覆盖率；在外部插件中，遵守所属仓库声明的覆盖率门槛。覆盖率只证明代码行已执行，不证明发布后的功能真正可用。 |
-| 真实 API 端到端测试 | `pnpm run test:e2e` | 验证真实供应商 API 上的行为：包括 DeepSeek 模型，以及由各自密钥（`EXA_API_KEY`、`PERPLEXITY_API_KEY` 等）控制的供应商烟雾测试。没有对应密钥时，每个测试套件自行跳过，使无密钥 CI 保持通过。 |
-| 快照测试 | `pnpm run test:snapshot` | 验证无密钥的预期输出：固定传输合约和展示结果，同时用持久化日志固定组装后的后端行为。 |
-| Web 浏览器快照 | `pnpm run test:web` | 将 Chromium 重放结果与 `apps/web/tests/snapshots/` 比较；这是 Linux PR 的必需门槛。CI 强制使用只读的 `DSH_SNAPSHOT=replay`，绝不写入预期输出；录制和刷新只在本地进行，且所有差异都必须审查。 |
+| Unit tests | `pnpm run test` | Runs vitest cases under each package's `tests/**` and script tests under repository `scripts/**/*.spec.ts`. Cover edge cases, error paths, event ordering, concurrency races, and contract regressions. Every registry needs an HMR-safety test: dispose the fiber that contributed the registration and assert that the resource is removed. |
+| Coverage gate | `pnpm run test:coverage` | In the Harness monorepo, every file under `packages/*/*/src` must reach 100% coverage. In an external plugin, follow the coverage threshold declared by its repository. Coverage proves only that lines executed, not that the published feature actually works. |
+| Real-API end-to-end tests | `pnpm run test:e2e` | Validates behavior against real provider APIs, including DeepSeek models and provider smoke tests gated by their own credentials such as `EXA_API_KEY` and `PERPLEXITY_API_KEY`. Each suite skips itself when its credential is absent so credential-free CI remains green. |
+| Snapshot tests | `pnpm run test:snapshot` | Validates expected credential-free output, pinning transport contracts and presentation while using persisted logs to fix the assembled backend behavior. |
+| Web browser snapshots | `pnpm run test:web` | Compares Chromium replay output with `apps/web/tests/snapshots/`. This is a required Linux PR gate. CI forces read-only `DSH_SNAPSHOT=replay` and never writes expected output. Record or refresh snapshots only locally and review every difference. |
 
-当供应商密钥已可用且已授权执行真实 API 时，运行对应的端到端测试，不要因惜用推理而省略。无密钥测试只能证明管线连通；只有携密钥运行才能证明 Agent 能与真实模型协作。根据变更覆盖文件写入提示、多轮会话、工具使用和流式输出中途取消。价值最高的烟雾测试会启动真实示例、发送一条提示，并从外部检查结果。自动跳过能使无密钥 CI 不受阻塞；记录被跳过的供应商边界，绝不为了让测试通过而索要、暴露或持久化密钥。
+When provider credentials are available and real-API execution is authorized, run the corresponding end-to-end tests. Do not skip them merely to save inference spend. Credential-free tests prove only that the pipeline is connected; only credentialed runs prove that the Agent can work with a real model. Based on the change, cover file-writing prompts, multi-turn sessions, tool use, and cancellation during streaming output. The highest-value smoke test starts a real example, sends one prompt, and verifies the outcome from outside the Agent. Automatic skipping keeps credential-free CI unblocked. Record every skipped provider boundary, and never request, expose, or persist credentials merely to make tests pass.
 
-## 根据变更触面选择层级
+## Select Levels from the Change Surface
 
-- 纯逻辑或内部辅助函数 → 只运行单元测试。
-- 新增或修改包源码 → 执行所属仓库的覆盖率门槛；只有 Harness 单仓明确定义该门槛时，才使用逐文件 100% 规则。
-- 模型可见行为（提示词、工具 Schema、工具输出、Skill 目录） → 在所属示例的测试套件中添加无密钥快照，再添加真实组合测试。
-- 协议可见行为（ACP、JSON-RPC、线上传输） → 在所属示例的测试套件中添加无密钥快照。
-- 用户可见行为（CLI 输出记录、交互式终端、GUI 操作流程） → 在 Harness 单仓内使用 `apps/cli/tests/snapshots/` 或 `apps/web/tests/snapshots/`；外部插件使用所属产品入口的测试套件。
-- 供应商行为（新适配器、真实供应商特性） → 在密钥可用且已授权时执行真实 API 端到端测试。
-- 用户会实际使用的插件 → 执行非单元级的真实组合测试（见下文），绝不能只测试手工组装的 `ctx.plugin(...)`。
+- Pure logic or internal helpers → run unit tests only.
+- New or modified package source → run the repository's coverage gate. Apply the per-file 100% rule only when the Harness monorepo explicitly defines it.
+- Model-visible behavior such as prompts, tool Schemas, tool output, or Skill directories → add a credential-free snapshot to the owning example suite, then add a real-composition test.
+- Protocol-visible behavior such as ACP, JSON-RPC, or wire transport → add a credential-free snapshot to the owning example suite.
+- User-visible behavior such as CLI transcripts, interactive terminals, or GUI flows → in the Harness monorepo, use `apps/cli/tests/snapshots/` or `apps/web/tests/snapshots/`; in an external plugin, use the product-entry test suite owned by that repository.
+- Provider behavior such as a new adapter or real provider feature → run real-API end-to-end tests when credentials are available and execution is authorized.
+- A plugin that users will actually run → execute a non-unit real-composition test as described below. Never test only a manually assembled `ctx.plugin(...)`.
 
-## 必须使用快照测试的情况
+## When Snapshot Tests Are Mandatory
 
-每个非平凡的模型可见、协议可见或用户可见变更，都要通过所属仓库的可运行组合添加或更新无密钥场景。包测试、端到端断言、仅测试用的模拟组合和 PR 说明，都不能取代组装后的完整记录。在 Harness 单仓内，ACP 快照位于 `examples/<name>/tests/snapshots/`，无界面 JSONL 快照位于 `examples/headless-agent`，终端操作流程位于 `apps/cli/tests/snapshots/`，浏览器操作流程位于 `apps/web/tests/snapshots/`。使用目标检出版本当前的录制或刷新命令，并审查每一处生成差异。外部插件使用自己的快照测试框架；如果没有，则添加一个最小的真实 Loader 组合。
+Every nontrivial model-visible, protocol-visible, or user-visible change must add or update a credential-free scenario through a runnable composition owned by the repository. Package tests, end-to-end assertions, test-only mock compositions, and PR descriptions cannot replace the complete assembled record. In the Harness monorepo, ACP snapshots live under `examples/<name>/tests/snapshots/`, headless JSONL snapshots live under `examples/headless-agent`, terminal flows live under `apps/cli/tests/snapshots/`, and browser flows live under `apps/web/tests/snapshots/`. Use the record or refresh command provided by the exact target checkout and review every generated difference. External plugins should use their own snapshot framework. If they have none, add a minimal composition that runs through the real Loader.
 
-## 测试真实入口路径
+## Test the Real Entry Path
 
-- 用户可见插件需要真实组合测试：通过 Loader 和应用或进程启动测试专用 `cordis.yml`；只模拟外部服务或非确定性输入；断言模型可见请求或日志、持久化状态或用户可见输出。不要把测试选项写入发布默认值。
-- 只有回归真的会导致守卫测试失败，该守卫才有意义。当精确的目标合约要求无 `inject` 的打包或组合模块使用具名导出时，添加显式的 `expect('default' in mod).toBe(false)` 和 `unwrapExports` 往返断言，并证明它在引入回归时变红、修复后变绿。不要对目标版本支持的默认插件对象或 `Service` 类应用该守卫；应通过它的实际 Loader 合约验证这种形态。
-- “真实入口路径”指已发布的产物：包的 `bin` 必须在原生 Node 下运行其构建入口，以暴露 tsx 可能掩盖的问题，如收敛竞态、模块解析和被吞掉的加载失败。非默认索引的运行时入口和跨打包组合共享的单例模块也遵守同样要求。在 Harness 单仓中，保持其构建产物烟雾测试通过（例如目标版本中存在的 `packages/examples/*/tests/built-bin.e2e.ts` 和 `packages/code-runtime/code-runtime-worker/tests/built-lib.e2e.ts`）。在外部插件中，烟雾测试对应的打包入口。并断言在配置确实缺失时进程以非零状态退出。
-- 在 Harness 单仓中，常规测试解析使用已配置的源码平面，构建产物只由明确的构建入口烟雾测试消费。在外部插件中，遵循其解析器，但仍要添加一个明确的打包产物消费者，防止源码别名掩盖缺失导出或第二份运行时单例。
-- Harness 单仓中的子进程启动方式：CI 和已构建的测试通道通过目标检出版本的共享启动器，从构建后的 `lib/` 运行所有示例或 Cordis 配置子进程；绝不要为这些子进程手写 `--import tsx`。不加载 Cordis 的协议和操作系统夹具遵循目标仓库当前的 Node/TypeScript 约定。外部插件遵循自己的启动器，但必须覆盖打包产物。只有以源码路径解析为测试对象时才能选择 `src`，并在测试中说明该合约。
+- User-visible plugins need a real-composition test. Start a test-only `cordis.yml` through the Loader and application or process entry point. Mock only external services or nondeterministic inputs. Assert the model-visible request or log, persisted state, or user-visible output. Do not add test options to published defaults.
+- A guard test is useful only if the regression truly makes it fail. When the exact target contract requires a bundled or composition module without `inject` to use named exports, add explicit `expect('default' in mod).toBe(false)` and `unwrapExports` round-trip assertions. Prove that the test turns red when the regression is introduced and green after the fix. Do not apply this guard to default plugin objects or `Service` classes supported by the target version. Validate those forms through their actual Loader contract.
+- The "real entry path" means the published artifact. A package `bin` must run its built entry under native Node to expose issues that tsx may hide, including shutdown races, module resolution, and swallowed load failures. Apply the same rule to runtime entries outside the default index and singleton modules shared across bundle compositions. In the Harness monorepo, keep its built-artifact smoke tests green, such as `packages/examples/*/tests/built-bin.e2e.ts` and `packages/code-runtime/code-runtime-worker/tests/built-lib.e2e.ts` when they exist in the target version. In an external plugin, smoke-test its packaged entry. Assert that the process exits nonzero when required configuration is truly missing.
+- In the Harness monorepo, normal tests resolve through the configured source plane, while only explicit built-entry smoke tests consume build artifacts. In an external plugin, follow its resolver but still add one explicit packaged-artifact consumer so source aliases cannot hide a missing export or a second runtime singleton.
+- For subprocess startup in the Harness monorepo, CI and built-test channels must use the shared launcher from the target checkout to run every example or Cordis config subprocess from built `lib/`. Never hand-write `--import tsx` for those subprocesses. Protocol and operating-system fixtures that do not load Cordis follow the current Node/TypeScript convention of the target repository. External plugins follow their own launcher but must cover the packaged artifact. Choose `src` only when source-path resolution itself is the test subject, and document that contract in the test.
 
-## 保持测试有效
+## Keep Tests Effective
 
-- 优先使用真实实现，而非模拟对象。只模拟成本高或不确定的边界（LLM 适配器、网络、时钟），并保持其下游全部使用真实实现。手写替身只能证明桥接层传递了字节，不能证明发布工具具有所声称的行为。桥接工具调用测试应使用脚本化模拟模型，并保持工具和执行器真实。
-- 验证外部世界，不要相信 Agent 自报：端到端断言应在外部重新运行命令或重新读取文件；只检查 Agent 输出中的关键词，会让作弊的 Agent 通过。断言未修改文件的字节完全一致。
-- 端到端测试必须自主管理资源：在测试内创建 Harness，并在 `afterEach` 中释放，即使发生失败、重试或超时也一样。共享夹具放在普通的 `tests/harness.ts` 中，绝不要放在另一个 `*.e2e.ts` 中；导入用例会重新注册其 `describe`，从而重复调用真实 API。
-- 恢复测试按步骤分离 chunk 之前和之后的失败，并证明失败 chunk 不会派生任何消息或工具副作用；覆盖耗尽、取消、策略组合、持久化、状态、传输线计数、传输关闭型空闲超时和发布用 Loader 组合。
+- Prefer real implementations over mocks. Mock only expensive or nondeterministic boundaries such as LLM adapters, networks, and clocks, while keeping everything downstream real. A handwritten fake proves only that a bridge moved bytes; it does not prove that the published tool delivers its claimed behavior. Tests for bridged tool calls should use a scripted mock model while keeping the tool and executor real.
+- Verify the external world instead of trusting the Agent's report. End-to-end assertions should rerun commands or reread files outside the Agent. Checking only keywords in Agent output lets a cheating Agent pass. Assert that untouched files remain byte-for-byte identical.
+- End-to-end tests must own their resources. Create the Harness inside the test and dispose it in `afterEach`, including after failure, retry, or timeout. Put shared fixtures in a normal `tests/harness.ts`, never another `*.e2e.ts`; importing a test file registers its `describe` again and duplicates real-API calls.
+- Recovery tests must separate failures before and after each chunk boundary and prove that a failed chunk derives no messages or tool side effects. Cover exhaustion, cancellation, policy composition, persistence, state, wire counts, transport-close idle timeouts, and the production Loader composition.
 
-## 命令
+## Commands
 
-在 Harness 单仓中，使用目标检出版本实际提供的命令，例如 `pnpm run test`、`test:coverage`、`test:e2e`、`test:snapshot` 和 `test:web`；先确认脚本存在，不要假设历史命令列表仍然有效。在外部插件中，使用其自身脚本，打包产物，安装到隔离的精确目标版本 Profile 中，并执行产品入口冷启动和核心路径烟雾测试。对覆盖变更触面的最小测试集合只运行一次；CI 只负责其实际定义的门槛。
+In the Harness monorepo, use commands that actually exist in the target checkout, such as `pnpm run test`, `test:coverage`, `test:e2e`, `test:snapshot`, and `test:web`. Confirm each script exists instead of assuming a historical command list is still valid. In an external plugin, use its own scripts, package the artifact, install it into an isolated Profile running the exact target version, and execute a cold-start plus core-path smoke test through the product entry. Run the smallest set that covers the changed surface only once. CI proves only the gates it actually defines.
 
-参考文件入口见 [`references/README.md`](references/README.md)。
+See [`references/README.md`](references/README.md) for the reference index.

--- a/skills/plugin-test/references/README.md
+++ b/skills/plugin-test/references/README.md
@@ -1,8 +1,8 @@
-# plugin-test 参考索引
+# plugin-test Reference Index
 
-| 文件 | 适用场景 |
+| File | When to read it |
 |---|---|
-| [version-migration-testing.md](version-migration-testing.md) | 测试插件在新 Harness 版本上的兼容性 |
+| [version-migration-testing.md](version-migration-testing.md) | Test plugin compatibility with a new Harness version |
 
-普通插件变更直接按 `SKILL.md` 选择测试层级。只有涉及 Harness 版本迁移时，
-才需要额外阅读 `version-migration-testing.md`。
+For ordinary plugin changes, select test levels directly from `SKILL.md`. Read
+`version-migration-testing.md` only when the task involves a Harness version migration.

--- a/skills/plugin-test/references/version-migration-testing.md
+++ b/skills/plugin-test/references/version-migration-testing.md
@@ -1,46 +1,41 @@
-# DSH 版本迁移测试参考
+# DSH Version-Migration Testing Reference
 
-用本文件独立设计 Harness 版本迁移的回归测试。目标是证明「发布产物在精确目标版本上
-可用」，而不是只证明源码能通过类型检查。
+Use this file to design Harness version-migration regressions without another Skill. The goal is to prove that the published artifact works on the exact target version, not merely that the source passes typechecking.
 
-## 1. 建立迁移测试账本
+## 1. Build the Migration Test Ledger
 
-1. 记录精确的 from/to tag、插件已声明与实际解析的 DSH/Node 版本、lockfile 和安装轨。
-2. 按真实版本先后关系阅读每个中间版本的发行说明、源码和类型声明，折叠为目标版本净状态。
-3. 将变更分为 `breaking`、`behavior` 和 `capability`。前两类必须进入回归矩阵；
-   `capability` 只在插件实际采用时测试。
-4. 一手证据或版本边缺失时标记「待确认」，不用模拟结果补成兼容结论。
+1. Record the exact from/to tags, the declared and resolved DSH/Node versions, the lockfile, and the installation track.
+2. Read the release notes, source, and type declarations for every intermediate version in their actual version order, then fold them into the target version's net state.
+3. Classify changes as `breaking`, `behavior`, or `capability`. The first two classes must enter the regression matrix. Test a `capability` only when the plugin adopts it.
+4. Mark a missing primary source or version edge as "unverified". Never turn a mock result into a compatibility conclusion.
 
-| 版本边 | 变更 | 类型 | 命中文件 | 回归断言 | 运行时证明 |
+| Version edge | Change | Type | Affected files | Regression assertion | Runtime proof |
 |---|---|---|---|---|---|
 |  |  |  |  |  |  |
 
-## 2. 扫描触点并映射断言
+## 2. Scan Touchpoints and Map Assertions
 
-扫描受跟踪的源码、测试、脚本、CI 和根配置，排除生成物、vendor 和 `node_modules`。
+Scan tracked source, tests, scripts, CI, and root configuration. Exclude generated output, vendor directories, and `node_modules`.
 
-| 触点 | 建议搜索 | 最少回归断言 |
+| Touchpoint | Suggested search | Minimum regression assertion |
 |---|---|---|
-| #1 源码 patch | `cordis.patch.yml|patchedDependencies|patch-package|monkey` | patch 在目标上游文件可应用，或已被公开 seam 替代；上游坐标漂移必须使测试变红。 |
-| #2 事件 | `SessionEvent|session/event|ctx.on|subscribe` | producer、持久化、reload、transport 与 observer 对新语义一致；未知 required 事件不被静默丢弃。 |
-| #3 服务与 Remote | `ctx.remote|ctx.get|@Remote|/internal` | 覆盖成功、已知业务错误、未知错误、取消和装配缺陷；不用同进程替身代替线上 face。 |
-| #4 宿主文件系统 | `DSH_HOME|profiles|homedir|readFile|writeFile` | 只读写隔离的目标 Profile，路径与数据归属正确，未授权文件字节不变。 |
-| #5 UI、命令与工具 | `registerCommand|registerView|ctx.tools|ctx.effect` | 通过真实 Loader 验证注册可见、Schema/渲染正确、卸载清理和 HMR 不重复注册。 |
-| #6 自建通道 | `createServer|WebSocket|MutationObserver|localhost` | 验证认证、Host/Origin、端口生命周期、断线/重连和 teardown；loopback 不豁免认证。 |
-| #7 子进程与输出 | `child_process|spawn|execa|headless|--profile` | 断言 argv、cwd、env、取消、退出码、stdout/stderr 分类和 teardown，不只检查进程能启动。 |
+| #1 Source patch | `cordis.patch.yml|patchedDependencies|patch-package|monkey` | The patch applies to the target upstream file or has been replaced by a public seam. Upstream-coordinate drift must turn the test red. |
+| #2 Events | `SessionEvent|session/event|ctx.on|subscribe` | Producer, persistence, reload, transport, and observer agree on the new semantics. Unknown required events are not silently dropped. |
+| #3 Services and Remote | `ctx.remote|ctx.get|@Remote|/internal` | Cover success, known business failures, unknown failures, cancellation, and assembly defects. Do not replace the production face with an in-process fake. |
+| #4 Host filesystem | `DSH_HOME|profiles|homedir|readFile|writeFile` | Read and write only the isolated target Profile, preserve correct path and data ownership, and keep unauthorized files byte-identical. |
+| #5 UI, commands, and tools | `registerCommand|registerView|ctx.tools|ctx.effect` | Use the real Loader to prove registration visibility, correct Schema/rendering, unload cleanup, and no duplicate registration under HMR. |
+| #6 Custom channels | `createServer|WebSocket|MutationObserver|localhost` | Validate authentication, Host/Origin, port lifecycle, disconnect/reconnect, and teardown. Loopback does not waive authentication. |
+| #7 Subprocesses and output | `child_process|spawn|execa|headless|--profile` | Assert argv, cwd, env, cancellation, exit code, stdout/stderr classification, and teardown, not merely that the process starts. |
 
-另外单独覆盖权限/审批、peer dependency 与打包产物、隐私/数据出境。七类零命中不等于兼容；
-仍必须验证依赖解析、build、真实挂载和核心功能。
+Cover permissions and approvals, peer dependencies and packaged artifacts, and privacy or data-egress concerns separately. Zero hits across all seven classes does not prove compatibility. Dependency resolution, build, real mounting, and the core behavior still require validation.
 
-## 3. 按证明强度逐层验证
+## 3. Validate in Increasing Order of Proof Strength
 
-1. **依赖与静态**：lockfile 与依赖图无意外 cohort；typecheck、build 和静态检查通过。
-2. **变更级回归**：每个 `breaking` / `behavior` 条目至少有一条能在回归时变红的断言。
-3. **真实组合**：通过真实 Loader 启动测试 Profile，只模拟高成本或不确定的边界。
-4. **精确目标运行时**：安装已打包产物，冷启动，确认 entry activate 且服务不 pending，
-   完成一次消息→工具→回复或等价专用流程。
-5. **发布入口**：在原生 Node 下运行构建后的 `bin` 或非默认入口，覆盖模块解析、退出码和关闭竞态。
-6. **跨 cohort 声明**：若声称一份产物支持多个宿主版本，在每个声称版本上重复第 3–5 层。
+1. **Dependencies and static checks**: confirm that the lockfile and dependency graph contain no unintended cohort, then pass typecheck, build, and static checks.
+2. **Change-level regressions**: give every `breaking` or `behavior` entry at least one assertion that turns red when the regression returns.
+3. **Real composition**: start a test Profile through the real Loader and mock only expensive or nondeterministic boundaries.
+4. **Exact target runtime**: install the packaged artifact, cold-start it, confirm entry activation and that services do not remain pending, then complete one message → tool → reply flow or an equivalent specialized flow.
+5. **Published entry**: run the built `bin` or non-default entry under native Node and cover module resolution, exit codes, and shutdown races.
+6. **Cross-cohort claim**: when one artifact claims to support multiple host versions, repeat levels 3–5 on every claimed version.
 
-类型检查、配置解析、模拟 Context 或无密钥管线都不是运行时兼容证明。无法获取的供应商
-密钥、操作系统、浏览器、PTY 或破坏性数据迁移必须列为未验证边界。
+Typechecking, config parsing, mock Contexts, and credential-free pipelines are not runtime compatibility proof. List every unavailable provider credential, operating system, browser, PTY, or destructive data migration as an unverified boundary.

--- a/skills/plugin-write/SKILL.md
+++ b/skills/plugin-write/SKILL.md
@@ -1,117 +1,117 @@
 ---
 name: plugin-write
-description: 当需要创建 DeepSeek Harness 插件、外部 DSH 插件包，或 deepseek-harness 仓库内的工作区包时使用，覆盖从形态选择到验证的全流程。将工具、LLM 适配器、钩子、服务和配置等形态路由到对应参考文件，并区分上游单仓规则与外部包规则。对跨 Harness 版本的现有插件，使用本 Skill 内置的版本适配流程，再按精确的目标合约实施。
+description: Use when creating a DeepSeek Harness plugin, an external DSH plugin package, or a workspace package inside the deepseek-harness repository. Covers the full workflow from plugin-form selection through validation. Routes tool, LLM adapter, hook, service, and configuration forms to their corresponding references while separating upstream-monorepo rules from external-package rules. For an existing plugin crossing Harness versions, use this Skill's built-in version-adaptation workflow before implementing against the exact target contract.
 ---
 
-# 编写 DeepSeek Harness 插件
+# Write DeepSeek Harness Plugins
 
-创建一个插件包。先分类仓库模式和插件形态，再阅读对应的参考文件，最后使用能覆盖变更的最小门槛集合验证发布入口。
+Create a plugin package. First classify the repository mode and plugin form, then read the matching reference files, and finally validate the published entry with the smallest set of gates that covers the change.
 
-## 先选择仓库模式
+## Select the Repository Mode First
 
-| 目标 | 适用规则 |
+| Target | Rules to apply |
 |---|---|
-| 官方 `deepseek-harness` 单仓内的包 | 使用下文的仓内包、tsconfig、文档和根门槛规则。 |
-| 外部可安装 DSH 插件 | 保留该仓库的包布局和脚本。只使用精确目标 DSH 版本公开的包和导出；不要复制 `private`、workspace 版本、根 tsconfig 注册或单仓专用 README 门槛。 |
-| 适配新 DSH 宿主的现有插件 | 阅读 [`references/version-adaptation.md`](references/version-adaptation.md)，确定完整版本走廊，并执行七类触点预检。如果变更类型为 `breaking`，而用户尚未明确授权实施，先展示迁移计划并等待确认；获得授权后先完成版本适配，再使用本 Skill 的形态参考。形态示例绝不能覆盖目标源码、类型声明或发行说明。 |
+| A package inside the official `deepseek-harness` monorepo | Use the in-repository package, tsconfig, documentation, and root-gate rules below. |
+| An externally installable DSH plugin | Preserve that repository's package layout and scripts. Use only packages and exports published by the exact target DSH version. Do not copy `private`, workspace versions, root tsconfig registration, or monorepo-only README gates. |
+| An existing plugin being adapted to a new DSH host | Read [`references/version-adaptation.md`](references/version-adaptation.md), build the complete version corridor, and run the seven-class touchpoint preflight. If a change is `breaking` and the user has not yet authorized implementation, present the migration plan and wait for confirmation. After authorization, complete the version adaptation before using this Skill's form references. Form examples must never override target source, type declarations, or release notes. |
 
-从精确目标版本的清单（manifest）中确定 Cordis、Schemastery 和 DSH 的包名与版本范围。当前示例使用带作用域的 `@deepseek-ai/*` 标识；旧版目标可能不同，必须遵循其自身的发布合约。
+Derive Cordis, Schemastery, and DSH package names and version ranges from the manifest of the exact target version. Current examples use scoped `@deepseek-ai/*` identifiers. Older targets may differ and must follow their own published contracts.
 
-## 再分类插件形态
+## Then Classify the Plugin Form
 
-| 所需能力 | 形态 | 参考文件 |
+| Required capability | Form | Reference |
 |---|---|---|
-| 模型可调用的工具：读写文件、运行命令、搜索 Web | 工具插件 | `references/tool-plugin.md` |
-| 新的模型供应商 | LLM 适配器插件 | `references/llm-adapter-plugin.md` |
-| 拦截请求、工具或轮次：权限、策略、指标、遥测 | 钩子插件 | `references/hook-plugin.md` |
-| 供其他插件通过 `ctx` 消费的能力 | 服务插件 | `references/service-plugin.md` |
-| 通过 `cordis.yml` 提供用户可配置行为 | 配置插件 | `references/config-plugin.md` |
+| Model-callable tools for reading files, running commands, or searching the Web | Tool plugin | `references/tool-plugin.md` |
+| A new model provider | LLM adapter plugin | `references/llm-adapter-plugin.md` |
+| Request, tool, or turn interception for permissions, policy, metrics, or telemetry | Hook plugin | `references/hook-plugin.md` |
+| A capability consumed by other plugins through `ctx` | Service plugin | `references/service-plugin.md` |
+| User-configurable behavior supplied through `cordis.yml` | Config plugin | `references/config-plugin.md` |
 
-一个插件可以自由组合多种形态，例如带 Config 的工具插件，或同时注册工具的服务；每种形态的合约仍然全部适用。当需求不属于上述五种形态时，将其映射到已有扩展点，编写在该扩展点注册的插件；绝不直接修改 Agent 循环。
+A plugin may combine forms freely, such as a configurable tool plugin or a service that also registers tools. Every included form still has to satisfy its own contract. When a requirement does not match one of the five forms above, map it to an existing extension point and write a plugin that registers there. Never modify the Agent loop directly.
 
-| 目标 | 机制 |
+| Goal | Mechanism |
 |---|---|
-| 添加模型可调用能力 | 在 `ctx.tools` 上注册 |
-| 添加模型供应商 | 在 `ctx.llm` 上注册适配器 |
-| 为某个会话提供不同的能力集 | 在 Agent 预设中组装 |
-| 添加 Shell 执行 | 实现并注册 `ctx.bash` 后端 |
-| 添加持久终端执行 | 注册 `ctx.pty` 后端并加载 `dsh-tool-pty` |
-| 添加人类命令 | 在 `ctx.commands` 上注册 |
-| 添加后台任务 | 在 `ctx.tasks` 上注册 |
-| 添加文件系统访问或策略 | 实现 `ctx.fs` 提供方，或监听 `fs/*` 策略事件 |
-| 约束所启动的进程 | 使用 `ctx.sandbox` 后端 |
-| 拦截请求、工具或轮次 | 使用 `agent/*` 或 `tools/*` 事件；`agent/turn-stopping` 是停止轮次的事件 |
-| 添加模型可见上下文 | 调用 `agent.inject()` |
-| 添加 UI 或编辑器集成 | 驱动 `ctx.agents`，并从 `session/event` 渲染 |
-| 添加 Web 客户端聊天节点 | 注册 `ConversationNodeDefinition` 和带键渲染器 |
-| 添加持久化会话状态 | 扩展 `SessionEventMap`，并从日志渲染和重放 |
-| 分叉实时会话 | 调用 `ctx.sessions.fork(source, boundary?, childSessionId?)` |
-| 将注册范围限定到单个 Agent | 使用该 Agent 的 `agent.ctx` |
+| Add a model-callable capability | Register it on `ctx.tools` |
+| Add a model provider | Register an adapter on `ctx.llm` |
+| Provide a different capability set for one session | Assemble it in an Agent preset |
+| Add Shell execution | Implement and register a `ctx.bash` backend |
+| Add persistent terminal execution | Register a `ctx.pty` backend and load `dsh-tool-pty` |
+| Add human commands | Register them on `ctx.commands` |
+| Add background tasks | Register them on `ctx.tasks` |
+| Add filesystem access or policy | Implement a `ctx.fs` provider or listen for `fs/*` policy events |
+| Constrain launched processes | Use a `ctx.sandbox` backend |
+| Intercept requests, tools, or turns | Use `agent/*` or `tools/*` events; `agent/turn-stopping` is the turn-stopping event |
+| Add model-visible context | Call `agent.inject()` |
+| Add UI or editor integration | Drive `ctx.agents` and render from `session/event` |
+| Add Web-client conversation nodes | Register a `ConversationNodeDefinition` and keyed renderers |
+| Add persistent session state | Extend `SessionEventMap`, then render and replay from the log |
+| Fork a live session | Call `ctx.sessions.fork(source, boundary?, childSessionId?)` |
+| Scope registrations to one Agent | Use that Agent's `agent.ctx` |
 
-## 包检查清单
+## Package Checklist
 
-1. **创建仓内包** —— 只在官方单仓内，创建包含 `package.json`、`tsconfig.json`、`src/index.ts` 和 `README.md` 的 `packages/<group>/<pkg>/`。复制目标检出版本的 `packages/core/tools/package.json`，再调整名称、说明和依赖；保留目标版本的不变式：`private: true`、与根包一致的 `version`、`type: module`、`main: "lib/index.js"`、`types: "lib/types/index.d.ts"`、同时将 `exports["."]` 的 `types` 和 `default` 指向 `lib`，在对等依赖和开发依赖（peer/dev）中使用相同范围的目标 Cordis 包，在开发依赖中镜像所有 DSH 对等依赖，在 `dependencies` 中声明目标 Schemastery 包，并保留目标的 `files` 布局和包特定运行时产物。CLI 应用包要包含构建后的 `bin`。不要发布未声明的源码或过期产物。遵循目标检出版本的相对导入约定。优先选择角色匹配的现有分组；新分组只是纯容器，包必须正好位于其下一层。
+1. **Create an in-repository package** — Only in the official monorepo, create `packages/<group>/<pkg>/` with `package.json`, `tsconfig.json`, `src/index.ts`, and `README.md`. Copy `packages/core/tools/package.json` from the target checkout, then adjust its name, description, and dependencies. Preserve target-version invariants: `private: true`; the root package `version`; `type: module`; `main: "lib/index.js"`; `types: "lib/types/index.d.ts"`; both `types` and `default` in `exports["."]` pointing to `lib`; the same target Cordis range in peer and development dependencies; every DSH peer dependency mirrored in development dependencies; the target Schemastery package declared in `dependencies`; and the target `files` layout plus package-specific runtime artifacts. CLI application packages must include the built `bin`. Do not publish undeclared source or stale artifacts. Follow relative-import conventions from the target checkout. Prefer an existing group with the matching role. A new group is only a container, and the package must sit exactly one level below it.
 
-2. **注册仓内包** —— 只在官方单仓内，按目标检出版本当前开发指南的精确要求，将包加入 Host 或 Client 聚合。普通包只属于一个聚合；不要在未检查目标版本的情况下复制历史特例或文件列表。外部插件绝不修改 Harness 根配置。
+2. **Register an in-repository package** — Only in the official monorepo, add the package to the Host or Client aggregate exactly as required by the development guide in the target checkout. A normal package belongs to one aggregate only. Do not copy historical exceptions or file lists without checking the target version. External plugins must never modify Harness root configuration.
 
-3. **创建外部包** —— 保留现有包管理器和构建系统。保持 `main`、`types`、`exports`、`files`、可选 `bin`、打包组合/Profile 元数据与打包后的 tarball 一致。显式声明每个运行时依赖；在开发依赖中镜像编译所需的 DSH 对等依赖。不要仅因仓内模板如此，就把可发布的外部插件设为 `private` 或赋予 workspace 版本范围。
+3. **Create an external package** — Preserve the existing package manager and build system. Keep `main`, `types`, `exports`, `files`, optional `bin`, packaged-composition or Profile metadata, and the packed tarball consistent. Declare every runtime dependency explicitly and mirror the DSH peer dependencies needed for compilation in development dependencies. Do not make a publishable external plugin `private` or give it workspace version ranges merely because an in-repository template does so.
 
-4. **决定包拓扑** —— 对可替换能力，只在服务定义、服务提供方和消费者会独立演进时才拆分为多个包；单一用途插件保持一个包。
+4. **Choose the package topology** — For a replaceable capability, split service definition, provider, and consumer into separate packages only when they will evolve independently. Keep a single-purpose plugin in one package.
 
-5. **编写仓内包 README** —— 只在目标单仓要求时，将包特定的服务 API、配置、事件、扩展点和设计说明放在前面。在 README 末尾使用目标检出版本的规范“模型体验”顺序和“已知限制”章节。根据实现填写模型体验：每个直接、条件式、受上限约束、生命周期或辅助模型触面使用一个 H3，其下依次放置下述三个 H4，且每个标题下都要有一段正文。引用包自身拥有的稳定文本；工具 Schema 触面只描述生成工具目录中尚未包含的差异。在“KV 缓存影响”中，区分仅追加增长、稳定重复前缀、替换早期请求 token 和独立模型请求，然后列出包自身哪些变更会使复用失效。
+5. **Write the in-repository package README** — Only when required by the target monorepo, put package-specific service APIs, configuration, events, extension points, and design notes first. End the README with the canonical "Model Experience" ordering and "Known Limitations" section from the target checkout. Describe each direct, conditional, capped, lifecycle, or auxiliary-model surface in its own H3 with the following three H4 sections, each containing a prose paragraph. Quote stable text owned by the package. For a tool Schema surface, describe only differences not already present in the generated tool catalog. Under "KV Cache Impact," distinguish append-only growth, stable repeated prefixes, replacement of earlier request tokens, and independent model requests. Then list the package changes that invalidate reuse.
 
    ````markdown
-   ## 模型体验
+   ## Model Experience
 
-   ### 请求触面与生效条件
+   ### Request Surface and Activation Conditions
 
-   #### 模型看到的内容
+   #### What the Model Sees
 
-   写明精确的数据依赖字段、带锚点的生成目录链接，或引出下方逐字文本。
+   Name the exact data-dependent field, link to the generated catalog with an anchor, or introduce the verbatim text below.
 
-   ##### 需要时，在此放置该字段的逐字文本
+   ##### Place the Verbatim Field Text Here When Needed
 
    ```markdown
-   从源码精确复制任意长度的稳定系统提示词正文，或其他长篇非生成字面量。
+   Copy any stable system-prompt body or other long nongenerated literal exactly from source.
    ```
 
-   #### Token 影响
+   #### Token Impact
 
-   说明影响是固定、条件式、保留、替换、受上限约束，还是零直接 token 影响。
+   State whether the impact is fixed, conditional, retained, replaced, capped, or has zero direct token impact.
 
-   #### KV 缓存影响
+   #### KV Cache Impact
 
-   说明仅追加、前缀稳定、替换或独立行为，包括可能使复用失效的精确条件。
+   Describe append-only, prefix-stable, replacement, or independent behavior, including exact conditions that may invalidate reuse.
 
-   ## 已知限制与延后工作
+   ## Known Limitations and Deferred Work
 
-   - **消费者可见缺口** —— 写明缺失的精确操作或情况、其后果以及任何维护者约束。
+   - **Consumer-visible gap** — State the exact missing operation or condition, its consequence, and any maintainer constraint.
    ````
 
-6. **验证** —— 执行下文适用的验证块，再运行变更行为所需的专项检查和覆盖率门槛。
+6. **Validate** — Run the applicable validation block below, then run the focused checks and coverage gate required by the changed behavior.
 
-## 编写时的规则
+## Rules While Writing
 
-- 每次注册都是一项 effect：通过 `ctx` 辅助方法或带 disposer 的 `ctx.effect()` 注册，并让插件卸载清理事件监听器、工具和计时器等所有资源。
-- 在有文档的扩展点上添加新行为；不要修改 `agent-loop`。
-- 公开服务方法和类型化事件要有带 `@param`/`@returns` 的 JSDoc；类型化事件通过目标 Cordis `Events` 接口的声明合并定义，并用 `@mode` 说明分发模式。
-- 不要硬编码可调参数：不同部署可能改变的值，必须是经验证且可通过 `cordis.yml` 修改的 `Config` 字段。
-- 模型看到的所有内容都必须可以从会话日志重建。
-- 配置错误必须明确失败：绝不默默跳过缺失的引用对象；在解析器、配置、连线和进程边界验证，不要信任同进程中经类型化的调用方。
+- Treat every registration as an effect. Register through `ctx` helpers or `ctx.effect()` with a disposer, and make plugin unload clean up every event listener, tool, timer, and other resource.
+- Add new behavior at documented extension points. Do not modify `agent-loop`.
+- Give public service methods and typed events JSDoc with `@param` and `@returns`. Define typed events through declaration merging on the target Cordis `Events` interface, and document the dispatch mode with `@mode`.
+- Do not hard-code tunable values. Any value that may differ across deployments must be a validated `Config` field changeable through `cordis.yml`.
+- Everything the model sees must be reconstructible from the session log.
+- Fail explicitly on configuration errors. Never silently skip a missing referenced object. Validate at parser, configuration, wiring, and process boundaries instead of trusting an in-process typed caller.
 
-## 验证
+## Validation
 
-对官方 Harness 单仓内的包，使用目标检出版本当前的根命令；下列名称只是示例，执行前必须确认它们存在：
+For packages inside the official Harness monorepo, use current root commands from the target checkout. The names below are examples only; confirm they exist before running them:
 
 ```sh
-pnpm install            # 注册工作区
+pnpm install            # Register the workspace
 pnpm run doc-sync
 pnpm run constraints && pnpm run typecheck && pnpm run lint
 pnpm run build && pnpm run hygiene
 ```
 
-对外部插件，使用其自身的安装、类型检查、测试、静态检查和构建命令；打包可发布产物，检查内容，并将该产物加载到运行精确目标 DSH 的隔离 Profile 中。当任务是升级时，完成冷启动和一次完整的消息→工具→回复或等价核心流程，并报告所有无法覆盖的供应商、操作系统、UI 或凭据边界。
+For an external plugin, use its own install, typecheck, test, static-check, and build commands. Pack the publishable artifact, inspect its contents, and load it into an isolated Profile running the exact target DSH. For an upgrade, cold-start it and complete one message → tool → reply flow or an equivalent core flow. Report every provider, operating-system, UI, or credential boundary that remains uncovered.
 
-根据变更触面选择测试：逻辑使用单元测试；执行所属仓库的覆盖率门槛；当供应商密钥已可用且在授权范围内时，执行真实 API 端到端测试；对模型、协议或用户可见行为使用无密钥快照；对用户可见插件使用真实组合测试。包的 `bin` 入口还需要在原生 Node 下运行的构建产物烟雾测试。按上述规则完成最小充分测试集合，不要为此加载其他 Skill。
+Select tests from the changed surface: unit-test logic; run the repository's coverage gate; run real-API end-to-end tests when provider credentials are available and execution is authorized; use credential-free snapshots for model-, protocol-, or user-visible behavior; and use a real-composition test for user-visible plugins. A package `bin` entry also needs a built-artifact smoke test under native Node. Complete the minimum sufficient test set under these rules without loading another Skill.
 
-参考文件入口见 [`references/README.md`](references/README.md)。
+See [`references/README.md`](references/README.md) for the reference index.

--- a/skills/plugin-write/references/README.md
+++ b/skills/plugin-write/references/README.md
@@ -1,15 +1,15 @@
-# plugin-write 参考索引
+# plugin-write Reference Index
 
-按任务只读需要的文件：
+Read only the file needed for the task:
 
-| 文件 | 适用场景 |
+| File | When to read it |
 |---|---|
-| [version-adaptation.md](version-adaptation.md) | 将现有插件适配到新的 Harness 版本 |
-| [tool-plugin.md](tool-plugin.md) | 编写模型可调用工具 |
-| [llm-adapter-plugin.md](llm-adapter-plugin.md) | 接入模型供应商 |
-| [hook-plugin.md](hook-plugin.md) | 编写事件与策略钩子 |
-| [service-plugin.md](service-plugin.md) | 向其他插件提供服务 |
-| [config-plugin.md](config-plugin.md) | 定义可配置的插件行为 |
+| [version-adaptation.md](version-adaptation.md) | Adapt an existing plugin to a new Harness version |
+| [tool-plugin.md](tool-plugin.md) | Write a model-callable tool |
+| [llm-adapter-plugin.md](llm-adapter-plugin.md) | Connect a model provider |
+| [hook-plugin.md](hook-plugin.md) | Write event and policy hooks |
+| [service-plugin.md](service-plugin.md) | Expose a service to other plugins |
+| [config-plugin.md](config-plugin.md) | Define configurable plugin behavior |
 
-新建插件直接阅读对应形态文件；版本适配先读
-`version-adaptation.md`，再读对应形态文件。
+For a new plugin, read the matching form reference directly. For a version adaptation, read
+`version-adaptation.md` first and then the matching form reference.

--- a/skills/plugin-write/references/config-plugin.md
+++ b/skills/plugin-write/references/config-plugin.md
@@ -1,12 +1,12 @@
-# 配置插件参考
+# Config Plugin Reference
 
-接收用户通过 `cordis.yml` 提供的配置。
+Accept user configuration supplied through `cordis.yml`.
 
-> 目标版本守卫：本文档是形态参考，不是版本迁移权威。必须根据精确的目标 Harness 检出版本验证每个包标识、导出、Loader 规则和配置功能。升级时，先按 [`version-adaptation.md`](version-adaptation.md) 建立迁移账本，再以实际观测到的目标行为为准。
+> Target-version guard: this document is a form reference, not version-migration authority. Verify every package identifier, export, Loader rule, and configuration capability against the exact target Harness checkout. For an upgrade, build the migration ledger from [`version-adaptation.md`](version-adaptation.md) first, then follow the observed target behavior.
 
-## 形态
+## Shape
 
-导出 `Config` 类型和一个同名的 Schemastery Schema；直接在 Schema 字段上声明默认值：
+Export a `Config` type and a same-named Schemastery Schema. Declare defaults directly on Schema fields:
 
 ```ts
 import type { Context } from '@deepseek-ai/cordis'
@@ -19,27 +19,27 @@ export interface Config {
 }
 
 export const Config: Schema<Config> = Schema.object({
-  greeting: Schema.string().default('你好'),
+  greeting: Schema.string().default('Hello'),
   maxRetries: Schema.number().default(3),
   verbose: Schema.boolean().default(false),
 })
 
 export function apply(ctx: Context, config: Config) {
-  // 使用经验证且类型安全的用户值或 Schema 默认值。
+  // Use validated, type-safe user values or Schema defaults.
 }
 ```
 
-消费者在 `cordis.yml` 的插件行 `config` 中提供值。加载时，Cordis 根据已导出的 Schema 验证用户值并填充默认值。不要把普通对象导出为 `Config`，因为它没有实现 Cordis 要求的 Standard Schema 接口。使用 Schemastery 进行更严格的验证：`Schema.string().required()`、`Schema.number().default(30000)`、`Schema.union(['fast', 'accurate']).default('fast')`。Schema 在插件加载时执行；无效配置必须通过可操作的错误使加载失败。
+Consumers provide values under `config` on the plugin row in `cordis.yml`. During load, Cordis validates user values against the exported Schema and fills defaults. Do not export a plain object as `Config`; it does not implement the Standard Schema interface Cordis requires. Use Schemastery for stronger validation: `Schema.string().required()`, `Schema.number().default(30000)`, and `Schema.union(['fast', 'accurate']).default('fast')`. The Schema runs during plugin load. Invalid configuration must fail loading with an actionable error.
 
-## 规则
+## Rules
 
-- **不要硬编码可调参数。** 两个部署可能希望设置不同的值，必须是配置字段。判定方法是：是否可以不修改代码，只通过 `cordis.yml` 改变该值。`DEFAULT_*` 常量或测试钩子都不算可配置。协议常量、外部规范和安全不变式保持固定。
-- **无效配置必须明确失败。** 在 Schema 中表达自包含约束，使无效配置在插件加载时就失败。对服务或已注册资源的引用要使用依赖注入（`inject`），不能交给 Schema。
-- **`!!js`（绝不是 `!js`）只能用在插件 `config` 下。** Loader 元数据是静态的：`id`、`name`、`group`、`disabled`、`inject`、`intercept` 和 `isolate` 必须保持字面量。因此 `disabled: !!js ...` 是一个真值对象，会始终禁用该条目。当环境选择会改变挂载的插件时，使用显式配置覆盖。
-- **密钥不能进入配置值。** 使用目标 Schemastery 包的环境变量回退，再通过 `cordis.yml` 中的 `!!js process.env.MY_KEY` 传入；或使用通过 `ctx.credentials` 按操作解析的具名密钥引用。绝不内联凭据，也不在代码中随意读取密钥文件。
-- **包边界优先显式行为。** 默认值处理是所属实现中显式的 `resolve(request): Spec` 步骤，绝不能隐藏在 `run()` 中的 `?? default` 后面。
-- **HMR 自动生效。** 修改配置会热替换插件：框架卸载旧实例并加载新实例。因为注册都是 effect，旧实例的注册会自动清理。
+- **Do not hard-code tunable values.** A value that two deployments may want to set differently must be a configuration field. Ask whether the value can change through `cordis.yml` without modifying code. `DEFAULT_*` constants and test hooks do not count as configurable. Keep protocol constants, external specifications, and security invariants fixed.
+- **Fail explicitly on invalid configuration.** Express self-contained constraints in the Schema so invalid configuration fails during plugin loading. Reference services or registered resources through dependency injection with `inject`, not through the Schema.
+- **Use `!!js`, never `!js`, only under plugin `config`.** Loader metadata is static: `id`, `name`, `group`, `disabled`, `inject`, `intercept`, and `isolate` must remain literals. Therefore `disabled: !!js ...` creates a truthy object and always disables the entry. When environment selection changes which plugins mount, use explicit configuration overlays.
+- **Credentials must not become configuration values.** Use the environment-variable fallback from the target Schemastery package, then pass it through `cordis.yml` with `!!js process.env.MY_KEY`; or use a named credential reference resolved per operation through `ctx.credentials`. Never inline credentials or read arbitrary credential files in code.
+- **Prefer explicit behavior at package boundaries.** Resolve defaults in an explicit implementation-owned `resolve(request): Spec` step. Never hide them behind `?? default` inside `run()`.
+- **HMR works automatically.** A configuration change hot-replaces the plugin: the framework unloads the old instance and loads the new instance. Because registrations are effects, contributions from the old instance are cleaned up automatically.
 
-## 验证
+## Validation
 
-对 Schema 的接受与拒绝情况执行单元测试：有效值、无效值、缺失必填字段、应用默认值。断言错误配置会使加载明确失败，而不是被默默跳过。Schema 位于包的发布入口中，因此需要构建入口和真实组合检查：包的 `bin` 在原生 Node 下运行构建入口，且配置确实缺失时必须非零退出。在 Harness 单仓内，满足其逐文件覆盖率门槛；在外部仓库中，满足所属仓库声明的覆盖率门槛。
+Unit-test Schema acceptance and rejection: valid values, invalid values, missing required fields, and applied defaults. Assert that bad configuration makes loading fail explicitly instead of being silently skipped. Because the Schema sits on the package's published entry, run both a built-entry check and a real-composition check. A package `bin` must run its built entry under native Node, and the process must exit nonzero when required configuration is truly missing. In the Harness monorepo, satisfy its per-file coverage gate. In an external repository, satisfy its declared coverage gate.

--- a/skills/plugin-write/references/hook-plugin.md
+++ b/skills/plugin-write/references/hook-plugin.md
@@ -1,29 +1,29 @@
-# 钩子插件参考
+# Hook Plugin Reference
 
-钩子插件在不修改 Agent 循环的情况下拦截已有文档的扩展点，例如权限门、沙箱或计划模式策略、截止时间、重试、指标、遥测和请求路由。“原生钩子”是拦截点上的普通 Cordis 插件，不需要外部协议。
+A hook plugin intercepts documented extension points without modifying the Agent loop, for example permission gates, sandbox or planning policy, deadlines, retries, metrics, telemetry, and request routing. A "native hook" is an ordinary Cordis plugin registered at an interception point; it does not require an external protocol.
 
-> 目标版本守卫：本文档是形态参考，不是版本迁移权威。必须根据精确的目标 Harness 检出版本验证每个事件名、分发模式、类型和 Loader 规则。升级时，先按 [`version-adaptation.md`](version-adaptation.md) 建立迁移账本，再以实际观测到的目标行为为准。
+> Target-version guard: this document is a form reference, not version-migration authority. Verify every event name, dispatch mode, type, and Loader rule against the exact target Harness checkout. For an upgrade, build the migration ledger from [`version-adaptation.md`](version-adaptation.md) first, then follow the observed target behavior.
 
-## 瀑布式（Waterfall）语义
+## Waterfall Semantics
 
-`ctx.waterfall` 是环绕型中间件。监听器接收 `(...args, next)`；调用 `next()` 将可能已包装的结果委派给下一个服务，不调用 `next()` 就返回则会短路。值通过 `next()` 的返回值传递。协作型监听器通常修改共享请求或决策对象，然后继续委派；监听器也可以完全替换结果，下游监听器只能看到替换后的结果。只有监听器必须早于普通注册执行时，才使用 `prepend: true`。对单决策事件，短路属于设计行为：策略监听器拥有决策时可以不调用 `next()` 而返回；仅做标注或观测的监听器必须继续委派。遗漏 `next()` 会在无提示的情况下接管流程，因此绝不能误省略。分发模式是事件公开合约的一部分；还有 `emit`（广播）、`bail`（首个非 `undefined` 值）和 `serial`（顺序执行）等模式，但拦截点使用 waterfall。
+`ctx.waterfall` is around middleware. A listener receives `(...args, next)`. Calling `next()` delegates to the next service and may wrap its result. Returning without calling `next()` short-circuits the chain. Values flow through the return value of `next()`. Cooperative listeners typically modify a shared request or decision object and then delegate. A listener may also replace the result completely, in which case downstream listeners see only the replacement. Use `prepend: true` only when the listener must execute before ordinary registrations. For single-decision events, short-circuiting is intentional: a policy listener that owns the decision may return without calling `next()`. A listener that only annotates or observes must delegate. Omitting `next()` silently takes over the flow, so never omit it accidentally. Dispatch mode is part of an event's public contract. Other modes include `emit` for broadcast, `bail` for the first non-`undefined` value, and `serial` for ordered execution, but interception points use waterfall.
 
-## 选择扩展点
+## Select the Extension Point
 
-| 目标 | 扩展点 |
+| Goal | Extension point |
 |---|---|
-| 对工具调用执行允许、拒绝或询问策略 | `tools/pre-execute`，返回类型化的 `PreToolDecision` |
-| 执行后续监听器无法撤销的最终单调拒绝 | `ctx.tools.guard()` |
-| 包装分发生命周期：超时、重试、指标 | `tools/execute`（只能替换 `exec.signal`） |
-| 转换结果、替换展示、阻断结果、附加模型可见上下文 | `tools/post-execute` |
-| 观测不可变的规范化结果：审计、捕获 | `tools/result` |
-| 拦截请求、步骤或轮次 | `agent/*` 事件；`agent/turn-stopping` 是停止轮次的事件 |
-| 短路或路由模型调用 | `llm/stream` waterfall |
-| 强制单调的终止轮次策略 | 从终止工具调用 `ToolExecution.concludeTurn()` |
+| Apply allow, deny, or ask policy to a tool call | `tools/pre-execute`, returning a typed `PreToolDecision` |
+| Apply a final monotonic denial that later listeners cannot undo | `ctx.tools.guard()` |
+| Wrap dispatch lifecycle for timeouts, retries, or metrics | `tools/execute`, which may replace only `exec.signal` |
+| Transform the result, replace presentation, block the result, or append model-visible context | `tools/post-execute` |
+| Observe the immutable normalized result for audit or capture | `tools/result` |
+| Intercept a request, step, or turn | `agent/*` events; `agent/turn-stopping` is the turn-stopping event |
+| Short-circuit or route a model call | `llm/stream` waterfall |
+| Enforce a monotonic conclude-turn policy | Call `ToolExecution.concludeTurn()` from a terminal tool |
 
-工具管线的执行顺序：先运行 `tools/pre-execute` waterfall，再运行单调守卫，然后是 `tools/execute` 和 `tools/post-execute` waterfall；之后才执行工具定义拥有的 `finalizeContent` 和 `tools/result`。被拒绝或审批未通过的调用会跳过工具主体。`tools/result` 观测已冻结的无损 JSON 结果；`tools/post-execute` 在规范化前执行，可以转换结果或附加上下文。
+Tool-pipeline order is `tools/pre-execute` waterfall, monotonic guards, `tools/execute` and `tools/post-execute` waterfalls, then the tool-owned `finalizeContent` and `tools/result`. A denied call or unanswered approval skips the tool body. `tools/result` observes a frozen lossless-JSON result. `tools/post-execute` runs before normalization and may transform the result or append context.
 
-## 权限门模板
+## Permission-Gate Template
 
 ```ts
 import type { Context } from '@deepseek-ai/cordis'
@@ -36,23 +36,23 @@ export const name = 'permission-gate'
 export function apply(ctx: Context) {
   ctx.on('tools/pre-execute', async (exec, next): Promise<PreToolDecision> => {
     if (!(await isAllowed(exec))) {
-      return { kind: 'deny', reason: '被策略拒绝。' }
+      return { kind: 'deny', reason: 'Denied by policy.' }
     }
     return next()
   })
 }
 ```
 
-类型化决策包括 `{ kind: 'allow' }`、`{ kind: 'deny', reason }` 和 `{ kind: 'ask', ... }`。`ask` 通过 `ctx.approval` 发起一次性询问；审批缺失或无法回答时一律拒绝。该 waterfall 是可重排序的策略层，供沙箱、权限和计划模式插件使用。当不变式需要后续监听器无法撤销的最终单调拒绝时，使用 `ctx.tools.guard()`；插件需要包装实际分发生命周期时，使用 `tools/execute`（超时、重试、指标，只能替换 `exec.signal`）；显式转换结果时使用 `tools/post-execute`；受控观测不可变的最终结果时使用 `tools/result`。
+Typed decisions include `{ kind: 'allow' }`, `{ kind: 'deny', reason }`, and `{ kind: 'ask', ... }`. `ask` opens a one-shot request through `ctx.approval`; deny when approval is absent or cannot answer. This waterfall is a reorderable policy layer for sandbox, permission, and planning plugins. Use `ctx.tools.guard()` when an invariant needs a final monotonic denial that later listeners cannot undo. Use `tools/execute` when a plugin must wrap actual dispatch lifecycle for timeouts, retries, or metrics and may replace only `exec.signal`. Use `tools/post-execute` for explicit result transformation, and `tools/result` for controlled observation of the immutable final result.
 
-## 规则
+## Rules
 
-- 通过 `ctx.on()` 注册的监听器是一项 effect：插件卸载时会自动移除。所有注册和释放都必须基于 effect。
-- 拦截和策略优先使用事件；直接能力调用优先使用服务方法。
-- 不要把部署策略写进工具。将策略放在钩子插件中，使其可重排序并覆盖多个工具家族，避免工具耦合到某个策略服务。
-- 有作用域的监听器会过滤分发。在 `agent.ctx` 上注册，将策略限定到单个 Agent。Agent 释放时，`agent.ctx` 贡献按照等待完成的清理顺序撤销。
-- 类型化事件通过目标 Cordis `Events` 接口的声明合并定义，并用 `@mode` 说明分发模式。Harness 事件名使用 `namespace/action`，例如 `tools/pre-execute`、`agent/request` 和 `agent/turn-stopping`。
+- A listener registered through `ctx.on()` is an effect and is removed automatically when the plugin unloads. Base every registration and cleanup on effects.
+- Prefer events for interception and policy. Prefer service methods for direct capability calls.
+- Do not embed deployment policy in tools. Put policy in hook plugins so it can be reordered and applied across tool families without coupling a tool to one policy service.
+- Scoped listeners filter dispatch. Register on `agent.ctx` to scope policy to one Agent. When the Agent is disposed, contributions from `agent.ctx` are revoked in awaitable cleanup order.
+- Define typed events through declaration merging on the target Cordis `Events` interface and document the dispatch mode with `@mode`. Harness event names use `namespace/action`, such as `tools/pre-execute`, `agent/request`, and `agent/turn-stopping`.
 
-## 验证
+## Validation
 
-对决策逻辑执行单元测试，覆盖每种决策类型、短路路径和委派路径。通过真实组合测试证明权限门确实会阻断调用，且被拒绝的调用不会产生副作用。只有引入回归时守卫测试确实失败，该守卫才有意义。当精确的目标合约要求无 `inject` 的打包或组合模块使用具名导出时，添加 `expect('default' in mod).toBe(false)` 和 `unwrapExports` 往返断言，并通过人为引入回归证明它会失败。不要对目标版本支持的默认插件对象或 `Service` 类应用该守卫。模型或用户可见行为变更必须在同一次变更中添加无密钥快照。
+Unit-test decision logic, covering every decision kind plus short-circuit and delegation paths. Use a real-composition test to prove that the permission gate actually blocks the call and that a denied call creates no side effects. A guard test is useful only if the regression truly makes it fail. When the exact target contract requires a bundled or composition module without `inject` to use named exports, add `expect('default' in mod).toBe(false)` and an `unwrapExports` round-trip assertion, then prove it fails when the regression is introduced. Do not apply this guard to default plugin objects or `Service` classes supported by the target version. Add a credential-free snapshot in the same change for model- or user-visible behavior.

--- a/skills/plugin-write/references/llm-adapter-plugin.md
+++ b/skills/plugin-write/references/llm-adapter-plugin.md
@@ -1,10 +1,10 @@
-# 大语言模型（LLM）适配器插件参考
+# Large Language Model (LLM) Adapter Plugin Reference
 
-通过实现 `LlmAdapter` 并在 `ctx.llm` 上注册，连接新的模型供应商。如果目标版本包含 `packages/llm/llm-deepseek` 和 `packages/llm/llm-pi-ai`，可将它们作为参考实现。
+Connect a new model provider by implementing `LlmAdapter` and registering it on `ctx.llm`. If the target version contains `packages/llm/llm-deepseek` and `packages/llm/llm-pi-ai`, use them as reference implementations.
 
-> 目标版本守卫：本文档是形态参考，不是版本迁移权威。必须根据精确的目标 Harness 检出版本验证适配器接口、流式语汇、请求字段、源码路径和供应商钩子。升级时，先按 [`version-adaptation.md`](version-adaptation.md) 建立迁移账本，再以实际观测到的目标行为为准。
+> Target-version guard: this document is a form reference, not version-migration authority. Verify adapter interfaces, streaming vocabulary, request fields, source paths, and provider hooks against the exact target Harness checkout. For an upgrade, build the migration ledger from [`version-adaptation.md`](version-adaptation.md) first, then follow the observed target behavior.
 
-## 形态
+## Shape
 
 ```ts ignore-check
 class MyAdapter extends LlmAdapter {
@@ -20,11 +20,11 @@ export function apply(ctx: Context, config: Config) {
 }
 ```
 
-注册基于 effect，且对 HMR 安全。每个供应商路由只能有一个适配器；重复注册会抛出异常，多路由注册要么全部成功，要么全部失败。`options.provider` 选择适配器，`options.model` 是供应商模型 ID，因此动态目录适配器无需重新配置生命周期，就能支持新模型。`registerAdapter()` 返回操作句柄：包含 disposer，以及为同一适配器实例原子替换路由集合的 `replace(providers)`。替换时允许空数组，初始注册时不允许；句柄释放后调用会抛出异常。密钥使用 Cordis 原生机制：在 Schemastery Config 中声明环境变量回退，再通过 `cordis.yml` 的 `!!js process.env.MY_KEY` 传入。绝不在代码中随意读取密钥文件。
+Registration is effect-based and HMR-safe. Only one adapter may own a provider route. Duplicate registration throws, and multi-route registration either succeeds for every route or fails for all of them. `options.provider` selects the adapter, while `options.model` is the provider model ID, so a dynamic-catalog adapter can support new models without reconfiguring its lifecycle. `registerAdapter()` returns an operation handle with a disposer and `replace(providers)`, which atomically replaces the route set for the same adapter instance. Replacement allows an empty array; initial registration does not. Calls after handle disposal throw. Handle credentials through native Cordis mechanisms: declare an environment-variable fallback in the Schemastery Config, then pass it through `cordis.yml` with `!!js process.env.MY_KEY`. Never read arbitrary credential files in code.
 
-## 流式语汇
+## Streaming Vocabulary
 
-`stream()` 发出一个封闭的 chunk 联合。对 `type` 的 switch 要以 `assertNever` 结尾，使新增变体会在每个必须处理它的消费者处导致编译失败：
+`stream()` emits a closed chunk union. End every switch on `type` with `assertNever` so a new variant causes a compile failure in every consumer that must handle it:
 
 ```ts
 type StreamChunk =
@@ -37,31 +37,31 @@ type StreamChunk =
   | { type: 'finish'; reason: FinishReason; replayState?: unknown }
 ```
 
-`TokenUsage` 的各项计数互不重叠：`inputTokens` 只包含未命中缓存的输入；缓存输入分别记在 `cacheReadTokens` 和 `cacheWriteTokens` 中，计费输入是三者之和。`reasoningTokens` 如果存在，只是已包含在 `outputTokens` 中的信息性细分；计算总量时不能再加一次。当供应商把缓存命中合并进单一提示词总量（如 DeepSeek 的 `prompt_tokens`）时，要从中减去缓存部分。
+`TokenUsage` counters do not overlap. `inputTokens` contains only uncached input. Cached input is reported separately as `cacheReadTokens` and `cacheWriteTokens`; billable input is the sum of all three. When present, `reasoningTokens` is only an informational subset already included in `outputTokens`; do not add it again when computing totals. When a provider merges cache hits into one prompt total, as DeepSeek does with `prompt_tokens`, subtract the cached portion.
 
-## 接收的请求
+## Accepted Request
 
-`GenerateOptions` 包含：`provider`（选择适配器的已注册路由）、`model`（供应商模型 ID）、`reasoningEffort?`（适配器所有的思考强度 ID）、`messages`（系统槽之后按顺序排列，与供应商实际所见完全一致的对话）、`system?`（系统提示词文本）、`tools?`（JSON Schema 工具说明）、`temperature?`、`maxTokens?`、`stop?`（停止序列）、`signal?`（AbortSignal，必须遵守）、`sessionId?`（由循环标记，用于重放路由；适配器忽略）和 `purpose?`（辅助调用使用 `'compaction' | 'session-title'`）。`packages/llm/llm/src/assembler.ts` 中的 `BlockAssembler` 将 chunk 流折叠回内容块、用量、结束原因和重放状态。消费者应使用它，不要重新实现折叠；适配器自身不进行组装。
+`GenerateOptions` contains `provider` for the registered route that selects the adapter; `model` for the provider model ID; optional `reasoningEffort` for an adapter-owned reasoning-effort ID; `messages` in the exact order seen by the provider after the system slot; optional `system` prompt text; optional JSON Schema `tools`; optional `temperature`, `maxTokens`, and stop-sequence `stop`; optional `signal`, which must be honored; optional `sessionId`, marked by the loop for replay routing and ignored by the adapter; and optional `purpose` for auxiliary calls with `'compaction' | 'session-title'`. `BlockAssembler` in `packages/llm/llm/src/assembler.ts` folds the chunk stream back into content blocks, usage, finish reason, and replay state. Consumers should use it instead of reimplementing the fold. The adapter itself does not assemble.
 
-## 协议义务
+## Protocol Obligations
 
-- 在 `finish` **之前**发出 `usage`；`finish` 之后不得再发出任何内容。在供应商的流结束标记到达前缓冲 finish 和 usage，然后一并刷出，避免尾部只含 usage 的 chunk 破坏顺序。
-- 工具调用 `arguments` 在端到端流程中始终保持原始 JSON 字符串，分片通过 `argumentsDelta` 传输。如果供应商返回已解析对象，在 `block-end` 时重新序列化。
-- 按内容块在流中首次出现的顺序分配 `index`；同一内容块的每个 delta 都复用同一个 index。
-- 错误只有两条允许的路径：传输和协议失败从 `stream()` 中抛出，使用带稳定错误码的 `LlmError`；供应商带内失败通过 `finish { kind: 'error' | 'aborted', failure }` 结束流。两条路径都要规范化为同一个可序列化的 `LlmFailure`：`message`（人类可读）、`code`（稳定、与供应商无关的机器路由码）、`status?`（HTTP 状态码）、`providerRetryAfterMs?`（经验证的供应商正数延迟要求，不是重试决策）和 `requestId?`（供应商签发的不透明诊断 ID）。消费者必须处理两条路径；按失败类型选择并写入文档。空完成是可重试错误，不是静默成功：将不含任何内容块的终止 `stop` finish 映射为带规范 `EMPTY_RESPONSE` 码的 `finish { kind: 'error' }`。
-- 遵守 `options.signal`，将它传给 fetch 或 SDK。
-- 如果供应商无法遵守某个 `GenerateOptions` 字段，例如不支持停止序列的供应商收到 `stop` 列表，应抛出 `LlmError(..., 'UNSUPPORTED')`，不能默默丢弃。
-- 如果供应商在后续调用中需要响应 ID、签名或其他原生元数据，将最小无损 JSON 投影发出为 `finish.replayState`，并在重建历史时验证。只有历史供应商路由和目标供应商路由当前归属于同一个适配器实例时，`LlmService` 才传递该状态。适配器自行决定是否允许同模型、跨模型或跨供应商恢复。状态缺失时，绝不根据供应商或模型名称推断原生重放。
-- 上下文溢出只有一个规范错误码：通过 `isContextWindowExceededError()` 对供应商的明确细节进行分类，并向上层提供 `CONTEXT_WINDOW_EXCEEDED`，无论失败是抛出的 `LlmError` 还是流内 finish 错误。
-- 供应商特定的思考模式开关保留在适配器 Config 中。精确模型元数据使用与供应商无关的能力接缝：实现 `resolveModel()`，提供供应商或模型标识，以及可选的 `context`（供应商所有的 `contextWindow`）和 `reasoning`（有序 `efforts`、可选 `defaultEffort`）。只有默认强度确实存在时才声明已配置的 `defaultEffort`。遵守解析器的可选 `AbortSignal`，实现必须在中止后迅速完成。思考强度是适配器映射到供应商请求的有序不透明 ID。保留适配器权威的可选列表，包括受支持时由适配器定义的 `off`；不要暴露最终线上拼写，也不要将不支持的值强行截断到范围内。
-- 每个供应商 HTTP 请求都要携带应用归属请求头：发送 `attributionHeaders()`，包含 `User-Agent` 基线和从包清单（manifest）读取的 `{ product, version, url }`，并用传输线级测试证明它已发送。
-- 一次适配器调用只对应一次供应商尝试：禁用库自带重试。Agent 级恢复会打开另一个持久化编号轮次；直接的 `ctx.llm.stream()` 调用方仍然只尝试一次。
-- 在传输层限制供应商停滞：暴露正数且有限的 `streamIdleTimeoutMs`（已发布适配器的默认值为五分钟），仅在迭代器 `next()` 尚未完成时计时，整个请求使用同一个稳定 signal，将自身过期映射为 `TIMEOUT`，并保留更早发生的调用方中止为 `ABORTED`。
+- Emit `usage` **before** `finish`, and emit nothing after `finish`. Buffer finish and usage until the provider's end-of-stream marker arrives, then flush them together so a trailing usage-only chunk cannot break ordering.
+- Keep tool-call `arguments` as the original JSON string end to end, carrying fragments through `argumentsDelta`. If the provider returns a parsed object, serialize it again at `block-end`.
+- Assign each content block's `index` by first appearance in the stream and reuse the same index for every delta belonging to that block.
+- There are only two allowed error paths. Transport and protocol failures throw from `stream()` as `LlmError` with a stable code. In-band provider failures end the stream with `finish { kind: 'error' | 'aborted', failure }`. Normalize both paths to the same serializable `LlmFailure`: human-readable `message`; stable provider-independent routing `code`; optional HTTP `status`; optional positive validated provider delay requirement `providerRetryAfterMs`, which is not a retry decision; and optional opaque provider-issued diagnostic `requestId`. Consumers must handle both paths. Choose and document the path by failure type. An empty completion is a retryable error, not silent success: map a terminal `stop` finish with no content blocks to `finish { kind: 'error' }` with canonical code `EMPTY_RESPONSE`.
+- Honor `options.signal` and pass it to fetch or the provider SDK.
+- If the provider cannot honor a `GenerateOptions` field, such as receiving a `stop` list when stop sequences are unsupported, throw `LlmError(..., 'UNSUPPORTED')` instead of silently dropping it.
+- If later calls require a response ID, signature, or other native provider metadata, emit the smallest lossless JSON projection as `finish.replayState` and validate it while rebuilding history. `LlmService` passes that state only when the historical provider route and current target route belong to the same adapter instance. The adapter decides whether replay is valid across the same model, different models, or different providers. When state is absent, never infer native replay from provider or model names.
+- Context overflow has one canonical error code. Classify explicit provider details with `isContextWindowExceededError()` and expose `CONTEXT_WINDOW_EXCEEDED` upstream, whether the failure is a thrown `LlmError` or an in-stream finish error.
+- Keep provider-specific reasoning-mode switches in adapter Config. Expose exact model metadata through the provider-independent capability seam: implement `resolveModel()` to return the provider or model identity and optional `context` with provider-owned `contextWindow`, plus optional `reasoning` with ordered `efforts` and optional `defaultEffort`. Declare the configured `defaultEffort` only when a real default exists. Honor the resolver's optional `AbortSignal`; implementations must settle promptly after abort. Reasoning efforts are ordered opaque IDs that the adapter maps to provider requests. Preserve the adapter-authoritative optional list, including adapter-defined `off` when supported. Do not expose final wire spelling or clamp unsupported values into range.
+- Send application-attribution headers on every provider HTTP request. `attributionHeaders()` must include the `User-Agent` baseline and `{ product, version, url }` read from the package manifest. Prove transmission with a wire-level test.
+- One adapter call equals one provider attempt. Disable retries built into client libraries. Agent-level recovery opens another persisted numbered turn; direct `ctx.llm.stream()` callers still receive one attempt.
+- Bound provider stalls in the transport layer. Expose a finite positive `streamIdleTimeoutMs`, with five minutes as the default for published adapters. Run the timer only while iterator `next()` is unresolved, use one stable signal for the whole request, map adapter-owned expiry to `TIMEOUT`, and preserve an earlier caller abort as `ABORTED`.
 
-## 实现结构
+## Implementation Structure
 
-将线上类型、请求序列化、传输解析、chunk 转换和适配器类分离为独立职责；`llm-deepseek` 是参考布局。可选触面包括：`providerRetryPolicy()`（每路由不可变策略，省略时使用常规默认值）、`providerInfo()` 和异步 `listModels()`（只是建议性选择器元数据，目录绝不是请求白名单），以及用于声明设置页可激活的休眠路由的 `registerConfigurableProviders()`。
+Separate wire types, request serialization, transport parsing, chunk conversion, and the adapter class into distinct responsibilities. `llm-deepseek` is the reference layout. Optional surfaces include `providerRetryPolicy()` for immutable per-route policy with ordinary defaults when omitted; `providerInfo()` and asynchronous `listModels()` for advisory selector metadata, never a request allowlist; and `registerConfigurableProviders()` for dormant routes that settings pages may activate.
 
-## 验证
+## Validation
 
-对 chunk 转换和错误分类执行单元测试；通过传输线级测试证明 `attributionHeaders()`；当供应商密钥已可用且已授权执行时，运行真实 API 端到端测试，无密钥时测试套件自动跳过；如果包发布运行时入口，执行构建入口烟雾测试。在 Harness 单仓内，满足其逐文件覆盖率门槛；在外部仓库中，满足所属仓库声明的覆盖率门槛，并报告无法覆盖的真实供应商边界。
+Unit-test chunk conversion and error classification. Prove `attributionHeaders()` with a wire-level test. When provider credentials are available and execution is authorized, run real-API end-to-end tests; otherwise let the suite skip itself. If the package publishes a runtime entry, run a built-entry smoke test. In the Harness monorepo, satisfy its per-file coverage gate. In an external repository, satisfy its declared coverage gate and report the real-provider boundary that remains untested.

--- a/skills/plugin-write/references/service-plugin.md
+++ b/skills/plugin-write/references/service-plugin.md
@@ -1,10 +1,10 @@
-# 服务插件参考
+# Service Plugin Reference
 
-服务是一个插件通过 `ctx` 暴露给其他插件的能力；`tools`、`llm` 和 `agents` 是常见示例。
+A service is a capability one plugin exposes to other plugins through `ctx`. `tools`, `llm`, and `agents` are common examples.
 
-> 目标版本守卫：本文档是形态参考，不是版本迁移权威。必须根据精确的目标 Harness 检出版本验证服务名称、生命周期行为、事件和 Agent 作用域。升级时，先按 [`version-adaptation.md`](version-adaptation.md) 建立迁移账本，再以实际观测到的目标行为为准。
+> Target-version guard: this document is a form reference, not version-migration authority. Verify service names, lifecycle behavior, events, and Agent scope against the exact target Harness checkout. For an upgrade, build the migration ledger from [`version-adaptation.md`](version-adaptation.md) first, then follow the observed target behavior.
 
-## 形态
+## Shape
 
 ```ts
 import { Service, type Context } from '@deepseek-ai/cordis'
@@ -16,25 +16,25 @@ declare module '@deepseek-ai/cordis' {
 }
 
 export default class MetricsService extends Service {
-  static inject = ['llm']  // 服务可以依赖其他服务。
+  static inject = ['llm']  // A service may depend on other services.
 
   constructor(ctx: Context) {
-    super(ctx, 'metrics')  // 'metrics' 是服务名。
+    super(ctx, 'metrics')  // 'metrics' is the service name.
   }
 
   record(event: string, value: number) { /* … */ }
 }
 ```
 
-加载后，消费者通过 `ctx.metrics` 访问服务；它们声明 `inject: ['metrics']`，并在 `apply` 中使用。插件向其他插件提供服务时使用类形态；只消费服务的插件使用函数形态即可。公开服务方法要使用 JSDoc `@param`/`@returns` 说明参数和非 void 返回值。服务名是传给 `super(ctx, ...)` 的字符串。生成的子系统页面会记录服务名、公开方法和源码位置；不要维护第二份静态列表。
+After loading, consumers access the service through `ctx.metrics`. They declare `inject: ['metrics']` and use it in `apply`. Use the class form when a plugin provides a service to other plugins. A plugin that only consumes services may use the function form. Document public service methods with JSDoc `@param` and `@returns` for parameters and non-void return values. The service name is the string passed to `super(ctx, ...)`. Generated subsystem pages record the service name, public methods, and source locations; do not maintain a second static list.
 
-## 依赖
+## Dependencies
 
-`inject` 列出必需服务。服务缺失时，插件不会加载，而是等待所有已声明服务就绪；因此在 `apply` 中，`ctx.tools` 已存在且就绪。可选依赖不声明 `inject`，而是在使用点通过 `ctx.get('name')` 查询，并对可能缺失的结果做保护。如果必需服务在运行时消失（提供方卸载），依赖插件会自动释放，服务恢复后再重新加载，从而避免调用不再存在的服务。`cordis.yml` 可以按插件分组隔离服务，例如在分组行上使用 `isolate: { bash: true }`，使不同插件分组看到同一服务的不同实例，且 effect 不跨组传播。
+`inject` lists required services. When a service is missing, the plugin waits for every declared service instead of loading, so `ctx.tools` already exists and is ready inside `apply`. Do not declare optional dependencies in `inject`; query them at the use site with `ctx.get('name')` and guard a missing result. If a required service disappears at runtime because its provider unloads, the dependent plugin is disposed automatically and reloads when the service returns, avoiding calls into a vanished service. `cordis.yml` may isolate services by plugin group, for example `isolate: { bash: true }` on a group row, so separate groups see different instances of the same service and effects do not cross groups.
 
-## 类型化事件
+## Typed Events
 
-事件是插件之间的松耦合扩展 API。通过精确目标 Cordis `Events` 接口的 TypeScript 声明合并定义，事件名使用 `namespace/action`，并用 `@mode` 说明分发模式：
+Events are loosely coupled extension APIs between plugins. Define them through TypeScript declaration merging on the exact target Cordis `Events` interface, use `namespace/action` event names, and document dispatch mode with `@mode`:
 
 ```ts
 import '@deepseek-ai/cordis'
@@ -48,20 +48,20 @@ declare module '@deepseek-ai/cordis' {
 }
 ```
 
-分发模式：`emit`（广播，所有监听器同步运行，忽略返回值）、`bail`（短路，监听器按顺序运行，第一个非 `undefined` 结果成为最终结果）、`serial`（顺序执行，第一个非空值会停止后续执行）、`waterfall`（管线，每个监听器可以包装下游结果，但必须调用 `next()` 才会委派；省略就会按设计短路）。通过 `ctx.on()` 注册的监听器是一项 effect，插件卸载时会自动移除。Harness 事件名使用 `namespace/action`，例如 `agent/step`、`agent/request`、`agent/request-error`、`tools/result` 和 `session/event`。`turn/*`、`step/*`、`tool/call`、`tool/result` 和 `compact/*` 是持久化会话事件类型，不是同名 Cordis 事件。如需观测它们，监听 `session/event` 并检查 `event.type`。
+Dispatch modes are `emit`, which broadcasts synchronously to every listener and ignores return values; `bail`, which runs listeners in order and uses the first non-`undefined` result; `serial`, which runs in order and stops after the first nonempty value; and `waterfall`, a pipeline in which each listener may wrap the downstream result but must call `next()` to delegate, with omission intentionally short-circuiting the chain. A listener registered through `ctx.on()` is an effect and is removed automatically when the plugin unloads. Harness event names use `namespace/action`, such as `agent/step`, `agent/request`, `agent/request-error`, `tools/result`, and `session/event`. `turn/*`, `step/*`, `tool/call`, `tool/result`, and `compact/*` are persisted session-event types, not same-named Cordis events. To observe them, listen to `session/event` and inspect `event.type`.
 
-## 生命周期
+## Lifecycle
 
-加载由依赖驱动。通过 `ctx` 注册的所有内容，包括事件监听器、工具和计时器，都会在插件卸载时清理，无需手动调用 `removeListener` 或 `clearInterval`。对需要显式拆除的资源，例如网络连接，通过 `ctx.effect()` 提供 disposer。如果拆除顺序很重要，将相关工作放在同一个 effect 中，使释放按预期顺序撤销。修改配置会热替换插件：框架卸载旧实例并撤销其注册，然后加载新实例。
+Loading is dependency-driven. Everything registered through `ctx`, including event listeners, tools, and timers, is cleaned up on plugin unload without manual `removeListener` or `clearInterval` calls. For resources that require explicit teardown, such as network connections, provide a disposer through `ctx.effect()`. When teardown order matters, keep the related work in one effect so disposal unwinds in the intended order. A configuration change hot-replaces the plugin: the framework unloads the old instance and revokes its registrations, then loads the new instance.
 
-## 智能体（Agent）作用域
+## Agent Scope
 
-每个 Agent 都有一个带作用域的 `agent.ctx`。在其上完成的注册会进入该 Agent 的层，并在 Agent 释放时按照等待完成的清理顺序撤销。有作用域的监听器会过滤分发，共享存储会在保留领域视图的同时，将其条目覆盖到全局注册表上。`CreateAgentOptions.setup(agentCtx)` 在发布前完成组装。如需将注册范围限定到单个 Agent，使用其 `agent.ctx` 而非根 Context。必须存活于 Agent 预设中的服务行需要 `isolate` realm。
+Every Agent has a scoped `agent.ctx`. Registrations made there enter that Agent's layer and are revoked in awaitable cleanup order when the Agent is disposed. Scoped listeners filter dispatch. Shared stores overlay their entries on the global registry while retaining domain views. `CreateAgentOptions.setup(agentCtx)` completes assembly before publication. To scope a registration to one Agent, use its `agent.ctx` instead of the root Context. Service rows that must survive inside an Agent preset require an `isolate` realm.
 
-## 能力接缝
+## Capability Seams
 
-可替换能力包含三个角色：服务定义（接口）、服务提供方（实现）和消费者（使用该服务的模型可见代码或集成代码）。只有这些角色会独立演进时，才将它们拆成多个包；bash 三包组（定义、提供方、消费者）是模板。单一用途服务保持一个包。只有三个角色都齐全，能力接缝才完整；只有角色确实独立演进时才拆包。
+A replaceable capability has three roles: service definition or interface, service provider or implementation, and consumer code that exposes the service to the model or integrates it elsewhere. Split them into separate packages only when those roles evolve independently. The three-package bash group of definition, provider, and consumer is the template. Keep a single-purpose service in one package. A capability seam is complete only when all three roles exist; split packages only when the roles truly evolve independently.
 
-## 验证
+## Validation
 
-执行单元测试，包括 HMR 安全性测试：释放贡献该注册的 fiber，并断言资源已清理。对用户可见插件，还要执行非单元级的真实组合测试：通过 Loader 启动 `cordis.yml`，并断言模型可见请求或日志、持久化状态或用户可见输出。在 Harness 单仓内，满足其逐文件覆盖率门槛；在外部仓库中，满足所属仓库声明的覆盖率门槛。模型、协议或用户可见行为变更，必须在同一次变更中添加无密钥快照。
+Run unit tests, including an HMR-safety test that disposes the fiber contributing a registration and asserts that the resource is removed. For a user-visible plugin, also run a non-unit real-composition test: start `cordis.yml` through the Loader and assert the model-visible request or log, persisted state, or user-visible output. In the Harness monorepo, satisfy its per-file coverage gate. In an external repository, satisfy its declared coverage gate. Add a credential-free snapshot in the same change for any model-, protocol-, or user-visible behavior change.

--- a/skills/plugin-write/references/tool-plugin.md
+++ b/skills/plugin-write/references/tool-plugin.md
@@ -1,10 +1,10 @@
-# 工具插件参考
+# Tool Plugin Reference
 
-工具是注册在 `ctx.tools` 上的模型可调用能力。在提供该合约的目标版本中，其 Schema 会自动加入系统提示词组装。如果目标版本包含 `packages/bash/tool-bash`，可将它作为参考实现。
+A tool is a model-callable capability registered on `ctx.tools`. In target versions that provide this contract, its Schema is added automatically to system-prompt assembly. If the target version contains `packages/bash/tool-bash`, use it as a reference implementation.
 
-> 目标版本守卫：本文档是形态参考，不是版本迁移权威。必须根据精确的目标 Harness 检出版本验证工具注册表、Schema、事件、渲染器和代码模式（Code Mode）桥接。升级时，先按 [`version-adaptation.md`](version-adaptation.md) 建立迁移账本，再以实际观测到的目标行为为准。
+> Target-version guard: this document is a form reference, not version-migration authority. Verify the tool registry, Schema, events, renderers, and Code Mode bridge against the exact target Harness checkout. For an upgrade, build the migration ledger from [`version-adaptation.md`](version-adaptation.md) first, then follow the observed target behavior.
 
-## 形态
+## Shape
 
 ```ts
 import { readFile } from 'node:fs/promises'
@@ -17,9 +17,9 @@ export const inject = ['tools']
 export function apply(ctx: Context) {
   ctx.tools.register(defineTool({
     name: 'read_file',
-    description: '从磁盘读取文件。',
+    description: 'Read a file from disk.',
     parameters: {
-      path: { type: 'string', required: true, description: '绝对路径' },
+      path: { type: 'string', required: true, description: 'Absolute path' },
       limit: { type: 'number' },
     },
     output: {
@@ -33,49 +33,49 @@ export function apply(ctx: Context) {
 }
 ```
 
-也可以直接接收原始 JSON Schema `ToolDefinition`，MCP 来源的工具就以这种方式进入。`defineTool` 是类型化辅助函数：它在 `execute` 运行前，根据统一参数 Schema 验证 `arguments`，并从 Schema 推导 `execute` 类型。
+The registry also accepts a raw JSON Schema `ToolDefinition`; MCP-origin tools enter this way. `defineTool` is the typed helper. Before `execute` runs, it validates `arguments` against the unified parameter Schema and derives the `execute` types from that Schema.
 
-## `execute()` 合约
+## The `execute()` Contract
 
-- **参数已代为验证。** `defineTool` 在 `execute` 运行前验证模型生成的 `arguments`，包括类型、必填键、字面量约束、精确单选联合和嵌套值，因此 `execute` 内的参数符合推导类型。仍要手动检查 DSL 无法表达的约束，例如非空字符串、正数和跨字段规则。直接注册的原始 JSON Schema 工具需要自行负责输入验证。
-- **注册借用只读定义。** 注册后不要修改 Schema 或替换回调。如需热替换工具，释放所属 effect，再注册替代项。回调闭包内的可变状态仍是普通插件状态。
-- **执行身份受保护。** 注册表将 `arguments` 实例化为独立的无损 JSON，在策略开始前冻结，并分配不透明的 `exec.token`。`callId`、`name`、`arguments`、`agent`、`token`、调用方必须拥有的 `signal` 和可选外层传输 `parent` token，在整个分发过程中都不可变。将 `args` 视为只读输入。只有环绕分发包装器能获得可变视图；它可以替换并恢复必需的 `exec.signal` 以施加截止时间，但不能移除。
-- **只声明并返回一个规范 JSON 值。** `output.schema` 使用值 Schema，根可以是对象、数组、标量或 null。`execute` 只返回推导出的值。注册表将其快照为无损 JSON，验证并冻结，再传给 `output.render(args, value)`。不要从主体返回内容块，也不要让调用方从散文中解析 ID 和字段。
-- **抛出异常或返回无效值都意味着 `isError`。** 注册表捕获异常，并在观测者运行前限制 Schema、渲染器、元数据投影器和无损 JSON 失败。基础设施失败应抛出异常。成功的领域结果使用规范值表示，即使渲染器需要说明非理想状态，例如进程非零退出。
-- **遵守 `exec.signal`。** signal 触发时取消进行中的工作。
-- **通过可选的 `output.presentationMeta` 投影持久化卡片数据。** 它从同一个规范值派生可重放 JSON。核心将其持久化到 `tool/result` 上并传给 `presentResult`，使需要结果阶段事实的卡片无需持久化规范值也能通过重放。
-- **异步通知使用 `exec.agent`。** `agent.inject({ content, source: { kind: 'plugin', plugin: '<name>' } })` 追加下一次模型请求才会看到的持久化上下文；它不会唤醒 Agent，空闲 Agent 仍然保持空闲。使用 try/catch 防护已释放的 Agent。
+- **Parameters are validated for you.** Before `execute` runs, `defineTool` validates model-generated `arguments`, including types, required keys, literal constraints, exact discriminated unions, and nested values, so the arguments inside `execute` satisfy the inferred type. Still check constraints that the DSL cannot express, such as nonempty strings, positive numbers, and cross-field rules. Raw JSON Schema tools registered directly own their input validation.
+- **Registration borrows a read-only definition.** Do not mutate the Schema or replace callbacks after registration. To hot-swap a tool, dispose the owning effect and register a replacement. Mutable state captured by callbacks remains ordinary plugin state.
+- **Execution identity is protected.** The registry materializes `arguments` as independent lossless JSON, freezes it before policy begins, and assigns an opaque `exec.token`. `callId`, `name`, `arguments`, `agent`, `token`, the caller-owned `signal`, and the optional outer transport `parent` token remain immutable throughout dispatch. Treat `args` as read-only input. Only around-dispatch wrappers receive a mutable view; they may replace and restore the required `exec.signal` to impose deadlines, but they cannot remove it.
+- **Declare and return one canonical JSON value.** `output.schema` is a value Schema whose root may be an object, array, scalar, or null. `execute` returns only the inferred value. The registry snapshots it into lossless JSON, validates and freezes it, and then passes it to `output.render(args, value)`. Do not return content blocks from the body or force callers to parse IDs and fields from prose.
+- **Throwing or returning an invalid value both produce `isError`.** The registry captures exceptions and bounds Schema, renderer, metadata-projector, and lossless-JSON failures before observers run. Throw infrastructure failures. Represent successful domain outcomes as canonical values, even when the renderer must explain an undesirable state such as a nonzero process exit.
+- **Honor `exec.signal`.** Cancel in-flight work when the signal aborts.
+- **Project persisted card data through optional `output.presentationMeta`.** It derives replayable JSON from the same canonical value. Core persists it on `tool/result` and passes it to `presentResult`, allowing cards that need result-stage facts to replay without persisting the canonical value itself.
+- **Use `exec.agent` for asynchronous notifications.** `agent.inject({ content, source: { kind: 'plugin', plugin: '<name>' } })` appends persistent context visible to the next model request. It does not wake the Agent; an idle Agent remains idle. Guard an already-disposed Agent with try/catch.
 
-## 长时间运行的工作
+## Long-Running Work
 
-使用提供方配置控制 `run_in_background`，然后通过 `ctx.tasks.start({ kind, label, owner: exec.agent, run })` 注册。在提供方主体运行前，注册表会拒绝预先中止的调用；运行时验证所有权和控制面可用性，再启动 `run()`，并提供 ID、会话栅栏、通用控制工具、通知和所有者清理。成功的后台分支返回类型化的规范句柄，例如 `{ kind: 'background', taskId }`。渲染器可以保留人类可读说明，但代码模式绝不能从该说明中解析 ID。提供方要提供同步 `cancel`、在资源清理后完成且永不被拒绝的 `done`，以及可选的消费型 `readOutput`，其输出必须有界。`ctx.tasks.start()` 发布 ID 后，使用任务所有的取消 signal，不再使用 `exec.signal`：此后外层调用取消只会停止等待，不会杀死已发布工作。`task_kill`、所有者释放和服务拆除负责该生命周期。前台工作仍与 `exec.signal` 绑定。
+Control `run_in_background` through provider configuration, then register work with `ctx.tasks.start({ kind, label, owner: exec.agent, run })`. Before the provider body runs, the registry rejects a pre-aborted call. At runtime it validates ownership and control-plane availability, starts `run()`, and provides an ID, session fence, generic control tools, notifications, and owner cleanup. A successful background branch returns a typed canonical handle such as `{ kind: 'background', taskId }`. The renderer may keep a human-readable explanation, but Code Mode must never parse the ID from that prose. The provider must expose synchronous `cancel`, a never-rejecting `done` that completes after cleanup, and optionally a consuming `readOutput` with bounded output. After `ctx.tasks.start()` publishes the ID, use the task-owned cancellation signal instead of `exec.signal`: outer-call cancellation then stops only the wait and does not kill published work. `task_kill`, owner disposal, and service teardown own that lifecycle. Foreground work remains bound to `exec.signal`.
 
-## 策略与观测
+## Policy and Observation
 
-优先不要把部署策略写进工具。选择规则：可扩展的允许、拒绝或询问策略使用 `tools/pre-execute`，返回类型化决策；`ask` 通过 `ctx.approval` 发起一次性询问，审批缺失或无法回答时一律拒绝。后续监听器无法撤销的最终单调拒绝使用 `ctx.tools.guard()`。使用 `tools/execute` 包装分发以添加截止时间、重试或指标采集。使用 `tools/post-execute` 替换展示内容或返回值、阻断结果或附加模型可见上下文。使用 `tools/result` 观测不可变的规范化结果。替换内容后，规范 `value` 的编程式访问仍保留；保密策略会阻断或替换值。执行顺序是：先运行 `tools/pre-execute` waterfall，再运行单调守卫，然后是 `tools/execute` 和 `tools/post-execute` waterfall；之后执行工具定义拥有的 `finalizeContent` 和 `tools/result`。
+Prefer not to embed deployment policy in tools. Selection rules: use `tools/pre-execute` for extensible allow, deny, or ask policy and return a typed decision. `ask` opens a one-shot request through `ctx.approval`; deny when approval is absent or cannot answer. Use `ctx.tools.guard()` for a final monotonic denial that later listeners cannot undo. Wrap dispatch with `tools/execute` to add deadlines, retries, or metrics. Use `tools/post-execute` to replace presentation content or the returned value, block the result, or append model-visible context. Observe the immutable normalized result with `tools/result`. Replacing content preserves programmatic access to the canonical `value`; confidentiality policy may block or replace the value. Execution order is `tools/pre-execute` waterfall, monotonic guards, `tools/execute` and `tools/post-execute` waterfalls, then the tool-owned `finalizeContent` and `tools/result`.
 
-## 用户界面（UI）渲染
+## User Interface Rendering
 
-UI 卡片与模型结果是两个独立关注点，通过纯展示投影声明。`presentCall(args)` 返回进行中卡片，`presentResult(args, { content, isError, meta? })` 返回已完成卡片。没有 UI 展示的工具回退到通用卡片：标题是工具名，原始参数是输入。卡片类型：
+UI cards and model results are separate concerns declared through pure presentation projections. `presentCall(args)` returns an in-progress card, while `presentResult(args, { content, isError, meta? })` returns a completed card. A tool without UI presentation falls back to a generic card whose title is the tool name and whose input is the raw arguments. Card types:
 
-- `{ card: 'generic', title, kind?, rawInput?, content?, locations? }` —— 默认类型。设置 `kind` 以选择图标，例如 `read` 或 `search`。对工具接触的每个文件设置 `locations: [{ path, line? }]`，使编辑器可以跟踪。
-- `{ card: 'terminal', title, description?, cwd? }` —— 调用本身就是 Shell 命令，`title` 是该命令。
-- `{ card: 'diff', title, diffs, locations? }` —— 调用会创建或修改文件。`diffs: [{ path, oldText, newText }]`；新文件使用 `oldText: null`，以内联差异渲染。
-- `search` —— 从持久化的 `result.meta` 重建的完成发现结果：可以是按文件分组的匹配（`shape: 'matches'`），也可以是平铺路径列表（`shape: 'paths'`）。还要包含 `truncated` 和 `total`，防止 UI 把被截断的结果展示为完整结果。`search` 没有调用视图；发现调用的进行中状态保持为通用卡片。
-- `web` —— 已完成的 Web 检索，通过 `kind: 'search' | 'fetch'` 区分，从 `result.meta` 派生，不携带正文副本。
+- `{ card: 'generic', title, kind?, rawInput?, content?, locations? }` — The default. Set `kind` to choose an icon such as `read` or `search`. Set `locations: [{ path, line? }]` for every file touched by the tool so editors can track them.
+- `{ card: 'terminal', title, description?, cwd? }` — The call itself is a Shell command, and `title` is that command.
+- `{ card: 'diff', title, diffs, locations? }` — The call creates or modifies files. Use `diffs: [{ path, oldText, newText }]`; for a new file, set `oldText: null` to render an inline diff.
+- `search` — A completed discovery result rebuilt from persisted `result.meta`. It may contain file-grouped matches with `shape: 'matches'` or a flat path list with `shape: 'paths'`. Include `truncated` and `total` so the UI cannot present truncated output as complete. `search` has no call view; an in-progress discovery call remains a generic card.
+- `web` — A completed Web lookup distinguished by `kind: 'search' | 'fetch'`, derived from `result.meta`, and carrying no duplicate body text.
 
-必须遵守的硬规则：
+Hard rules:
 
-- **纯函数性。** 这些投影会在实时流和会话日志重放中运行，因此必须是 `args`（加结果）的纯函数：不执行 I/O，不读取会话状态，不使用时钟或随机数。差异从参数派生；会话上下文由 UI 适配器提供，不由工具提供。
-- **UI 专用格式不能进入模型结果。** 仅为服务 UI，不要把带围栏的 `console` 块、差异或相对化路径放进规范值或 Native 内容。`output.render` 负责模型可见文本，`presentationMeta` 和卡片展示器负责可重放 UI 状态。
-- **`defineTool` 对展示路径实行软验证。** 当日志中的参数异常或来自旧版本时，包装器返回 `undefined` 以使用通用回退，而不是抛出异常。展示绝不能使重放崩溃。
+- **Pure functions.** These projections run during both live streaming and session-log replay, so they must be pure functions of `args` plus the result: no I/O, session-state reads, clock, or randomness. Derive diffs from arguments. The UI adapter supplies session context; the tool does not.
+- **UI-only formatting must not enter the model result.** Do not place fenced `console` blocks, diffs, or relativized paths intended only for the UI into the canonical value or native content. `output.render` owns model-visible text; `presentationMeta` and card presenters own replayable UI state.
+- **`defineTool` soft-validates presentation paths.** When logged arguments are malformed or come from an older version, the wrapper returns `undefined` and uses the generic fallback instead of throwing. Presentation must never crash replay.
 
-中立语汇位于 `dsh-tools`。工具绝不导入 UI 或传输类型。`dsh-tool-fs`（通用卡片和差异卡片）以及 `dsh-tool-bash`（终端卡片）是参考实现。
+Neutral vocabulary lives in `dsh-tools`. Tools never import UI or transport types. `dsh-tool-fs` with generic and diff cards, and `dsh-tool-bash` with terminal cards, are reference implementations.
 
-## 代码模式（Code Mode）
+## Code Mode
 
-在代码模式中，每个可见的已注册工具无需额外集成，即可通过 `await tools.<name>(args)` 调用。生成的 `ToolArgsMap` 和 `ToolOutputMap` 从同一组 Schema 派生精确参数类型和规范返回类型，调用会重新进入正常执行管线。成功调用在策略处理后解析为最终规范 JSON 值，而不是渲染后的 Native 内容。失败调用会以真实 `ToolCallError` 拒绝，程序只能检查其 `name`、`toolName` 和人类可读的 `message`。将 `output.schema` 设计为实用的编程 API：直接返回句柄和字段；当标量、数组或 null 是真实值时，允许其作为根；将人类说明保留在 `output.render` 中。
+In Code Mode, every visible registered tool is callable without extra integration as `await tools.<name>(args)`. Generated `ToolArgsMap` and `ToolOutputMap` types derive exact argument and canonical return types from the same Schemas, and calls re-enter the normal execution pipeline. After policy processing, a successful call resolves to the final canonical JSON value rather than rendered native content. A failed call rejects with a real `ToolCallError`; programs may inspect only its `name`, `toolName`, and human-readable `message`. Design `output.schema` as a useful programming API: return handles and fields directly; allow a scalar, array, or null at the root when that is the real value; and keep human explanation in `output.render`.
 
-## 验证
+## Validation
 
-对 execute 和 render 逻辑执行单元测试。对用户可见工具，执行通过 `cordis.yml` 启动插件的真实组合测试。当工具改变模型可见行为（提示词 Schema、工具输出）或 UI 可见行为（卡片）时，在同一次变更中添加无密钥快照。在 Harness 单仓内，满足其逐文件覆盖率门槛；在外部仓库中，满足所属仓库声明的覆盖率门槛。
+Unit-test `execute` and rendering logic. For a user-visible tool, run a real-composition test that starts the plugin through `cordis.yml`. When the tool changes model-visible behavior such as a prompt Schema or tool output, or UI-visible behavior such as cards, add a credential-free snapshot in the same change. In the Harness monorepo, satisfy its per-file coverage gate. In an external repository, satisfy the coverage gate declared by that repository.

--- a/skills/plugin-write/references/version-adaptation.md
+++ b/skills/plugin-write/references/version-adaptation.md
@@ -1,56 +1,50 @@
-# DSH 版本适配实施参考
+# DSH Version-Adaptation Implementation Reference
 
-在编写或修改插件时，用本文件独立完成 Harness 版本适配。不把历史示例当成
-目标合约；精确目标 tag 的源码、类型声明、发行说明和可复现运行行为才是依据。
+Use this file to adapt a Harness version while writing or modifying a plugin, without loading another Skill. Do not treat historical examples as the target contract. The exact target tag's source, type declarations, release notes, and reproducible runtime behavior are authoritative.
 
-## 1. 锁定基线与目标
+## 1. Lock the Baseline and Target
 
-1. 读取仓库规则，确认工作区、分支和未提交改动；不自动
-   stash、reset 或 clean。
-2. 记录精确的 from/to tag、当前解析版本、Node 版本、包管理器和 lockfile。
-3. 记录安装轨：registry、Git checkout、workspace/junction 或复制安装。
-4. 分开包清单、社区 manifest 与 Profile composition；不整对象回写未知字段。
+1. Read the repository rules and inspect the workspace, branch, and uncommitted changes. Do not automatically stash, reset, or clean.
+2. Record the exact from/to tags, resolved version, Node version, package manager, and lockfile.
+3. Record the installation track: registry, Git checkout, workspace or junction, or copied installation.
+4. Keep the package manifest, community manifest, and Profile composition separate. Never overwrite unknown fields by writing back a whole object.
 
-## 2. 建立版本迁移账本
+## 2. Build the Version-Migration Ledger
 
-按真实的版本先后关系逐边阅读发行说明和目标源码，禁止按文件名排序猜测。先读完
-全走廊，再折叠中间版本的删除、恢复和重命名，只实施目标版本的最终净状态。
+Read release notes and target source edge by edge in actual version order. Never infer order from filenames. Read the full corridor first, then fold intermediate removals, restorations, and renames so implementation targets only the final net state.
 
-| from → to | 类型 | 证据 | 触点 | 目标状态 | 验证 |
+| from → to | Type | Evidence | Touchpoint | Target state | Validation |
 |---|---|---|---|---|---|
-|  | `breaking` / `behavior` / `capability` | tag、源码或发行说明 | #1–#7 |  |  |
+|  | `breaking` / `behavior` / `capability` | tag, source, or release notes | #1–#7 |  |  |
 
-- `breaking`：必须改；用户尚未授权写入时，先展示计划、风险与回滚路径。
-- `behavior`：代码可能继续构建，但必须添加针对新语义的回归测试。
-- `capability`：只作建议，不自动引入新能力。
-- 任一版本边或 API 坐标缺失时，标记「待确认」，不凭记忆修改。
+- `breaking`: implementation is required. If the user has not authorized writes, present the plan, risk, and rollback path first.
+- `behavior`: the code may still build, but it needs a regression test for the new semantics.
+- `capability`: recommend it only; do not adopt it automatically.
+- When any version edge or API coordinate is missing, mark it "unverified" and do not modify from memory.
 
-## 3. 扫描七类触点
+## 3. Scan Seven Touchpoint Classes
 
-扫描受跟踪的源码、测试、脚本、CI 和根配置，排除生成物、vendor 和 `node_modules`。
+Scan tracked source, tests, scripts, CI, and root configuration. Exclude generated output, vendor directories, and `node_modules`.
 
-| 触点 | 关注内容 | 建议搜索 |
+| Touchpoint | What to inspect | Suggested search |
 |---|---|---|
-| #1 源码 patch | 宿主路径、monkey patch、补丁目标 | `cordis.patch.yml|patchedDependencies|patch-package|monkey` |
-| #2 事件 | 内部事件名、持久化、reload 和 transport | `SessionEvent|session/event|ctx.on|subscribe` |
-| #3 服务与 Remote | Host/Web Client/Plugin 不同 face 的包入口与错误语义 | `ctx.remote|ctx.get|@Remote|/internal` |
-| #4 宿主文件系统 | 直接读写 `DSH_HOME`、Profile 或会话数据 | `DSH_HOME|profiles|homedir|readFile|writeFile` |
-| #5 UI、命令与工具 | 注册入口、Schema、渲染器、卸载与 HMR | `registerCommand|registerView|ctx.tools|ctx.effect` |
-| #6 自建通道 | HTTP、WS、RPC、DOM/CSS 通道的认证、端口和 teardown | `createServer|WebSocket|MutationObserver|localhost` |
-| #7 子进程与输出 | argv、cwd、env、取消、退出码、stdout/stderr 归属 | `child_process|spawn|execa|headless|--profile` |
+| #1 Source patch | Host paths, monkey patches, and patch targets | `cordis.patch.yml|patchedDependencies|patch-package|monkey` |
+| #2 Events | Internal event names, persistence, reload, and transport | `SessionEvent|session/event|ctx.on|subscribe` |
+| #3 Services and Remote | Package entries and error semantics across Host, Web Client, and Plugin faces | `ctx.remote|ctx.get|@Remote|/internal` |
+| #4 Host filesystem | Direct access to `DSH_HOME`, Profiles, or session data | `DSH_HOME|profiles|homedir|readFile|writeFile` |
+| #5 UI, commands, and tools | Registration entries, Schemas, renderers, unload, and HMR | `registerCommand|registerView|ctx.tools|ctx.effect` |
+| #6 Custom channels | Authentication, ports, and teardown for HTTP, WS, RPC, and DOM/CSS channels | `createServer|WebSocket|MutationObserver|localhost` |
+| #7 Subprocesses and output | argv, cwd, env, cancellation, exit codes, and stdout/stderr ownership | `child_process|spawn|execa|headless|--profile` |
 
-另外单独检查权限/审批、打包/依赖以及隐私/数据出境。七类零命中只是启发式结果，
-仍要检查依赖与导入，并运行 build、真实挂载和功能烟雾测试。
+Inspect permissions and approvals, packaging and dependencies, and privacy or data egress separately. Zero hits across all seven classes is only a heuristic result. Still inspect dependencies and imports, then run build, real mounting, and a functional smoke test.
 
-## 4. 实施与验证
+## 4. Implement and Validate
 
-1. 按 seam 分组修改，每组记录命中文件、证据、目标行为和回归测试。
-2. 只修改插件拥有的路径；不修改 Harness core 来掩盖兼容问题。
-3. 核对依赖图和 lockfile，确保 DSH 包不混用 cohort。
-4. 运行 typecheck、build 和命中触点的回归测试。
-5. 将构建产物安装到隔离的精确目标版本 Profile，验证冷启动、entry activate、
-   Cordis service 不 pending，并完成一次消息→工具→回复或等价核心流程。
-6. 若声称跨 cohort 兼容，用同一份产物分别在每个声称版本上重复运行时验证。
+1. Group modifications by seam and record the affected files, evidence, target behavior, and regression test for each group.
+2. Modify only paths owned by the plugin. Do not change Harness core to hide a compatibility problem.
+3. Inspect the dependency graph and lockfile to ensure DSH packages do not mix cohorts.
+4. Run typecheck, build, and regressions for every affected touchpoint.
+5. Install the built artifact into an isolated Profile running the exact target version. Validate cold start, entry activation, and that Cordis services do not remain pending, then complete one message → tool → reply flow or an equivalent core flow.
+6. If claiming cross-cohort compatibility, repeat runtime validation with the same artifact on every claimed version.
 
-最终报告已完成、跳过项、未验证边界、回滚基线与残留风险；不把静态绿灯表述为
-精确目标版本已可运行。
+In the final report, separate completed work, skipped items, unverified boundaries, rollback baseline, and residual risk. Never describe static green checks as proof that the exact target version runs successfully.


### PR DESCRIPTION
## Summary

- translate every Markdown file under `skills/plugin-test/` and `skills/plugin-write/` to English, including frontmatter, workflows, tables, reference indexes, code comments, and example strings
- preserve filenames, links, APIs, commands, paths, technical identifiers, and the standalone reference routing introduced in #19
- keep the original implementation and validation semantics while tightening English phrasing for agent execution
- confirm both Skill directories contain no Han characters or CJK punctuation

## Validation

- `npm test`
  - `Validation OK: 3 skill, 2 card sets, 20 cards, 26 Markdown files, 7 touchpoint fixtures`
- `node scripts/validate-manifests.mjs`
  - 4 manifests valid; `plugin-test`, `plugin-upgrade`, and `plugin-write` discovered
- `node --check scripts/validate.mjs`
- Skill quick validation for both `skills/plugin-test` and `skills/plugin-write`
  - `Skill is valid!`
- `git diff --check origin/main...HEAD`
- English-only scan across both Skill directories
  - no Han characters or CJK punctuation found
- independent read-only forward tests for a configurable tool-plugin plan and a version-migration validation plan
  - both Skills produced complete standalone workflows with no internal instruction blocker

## Acknowledgements

This translation covers existing content originally synchronized from [omdsh-dev/dsh-plugin-skills](https://github.com/omdsh-dev/dsh-plugin-skills) plus the self-contained references added in [#19](https://github.com/oh-my-dsh/dsh-plugin-upgrade-skill/pull/19). It introduces no new version-specific migration claims.