### PR TITLE
feat: add plugin-release skill, validate hardening, and plugin-upgrade evals

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ cp -r dsh-plugin-upgrade-skill/skills/* .cursor/skills/
 | [plugin-upgrade](skills/plugin-upgrade/) | 三模式安全升级：只读检查、已安装插件升级、DSH 宿主兼容迁移；含七类触点、版本卡片与回滚约束 | 0.1.1 → 0.1.2 |
 | [plugin-write](skills/plugin-write/) | 按目标 Harness 合约编写 DSH 插件，区分官方单仓包与外部可安装插件 | 按目标 Harness 版本 |
 | [plugin-test](skills/plugin-test/) | 为 DSH 插件变更选择最小充分测试层级，覆盖单元测试、覆盖率、真实 API、快照、Web 及真实发布入口 | 跨版本验证 |
+| [plugin-release](skills/plugin-release/) | 打包、发布与分发 DSH 插件：发布轨选择、未发布 cohort 安装、CI 门禁与回滚 | 跨版本 |
 
 ## 版本数据现状
 

--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -124,11 +124,21 @@ for (const file of cardFiles) {
   if (!['curated', 'complete'].includes(meta.coverage)) fail(file, `invalid coverage: ${meta.coverage}`)
   if (edges.has(meta.from)) fail(file, `duplicate corridor edge from ${meta.from}`)
   edges.set(meta.from, meta.to)
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(String(meta.verifiedAt))) fail(file, `verifiedAt must be an ISO date (YYYY-MM-DD), got: ${meta.verifiedAt}`)
 
   const headings = [...body.matchAll(/^###\s+([A-Za-z0-9.-]+)\s+·\s+.+$/gm)]
   if (headings.length !== meta.cardCount) fail(file, `cardCount=${meta.cardCount}, found ${headings.length}`)
   if (!indexText.includes(`](${basename(file)})`) || !indexText.includes(`| ${meta.cardCount} |`)) {
     fail(file, 'version index is missing this file or its card count')
+  }
+  let previousSuffix = 0
+  for (const heading of headings) {
+    const match = /-(\d{2})$/.exec(heading[1])
+    const suffix = match === null ? NaN : Number(match[1])
+    if (!Number.isInteger(suffix) || suffix <= previousSuffix) {
+      fail(file, `${heading[1]} must use a two-digit suffix strictly increasing from the previous card`)
+    }
+    previousSuffix = suffix
   }
 
   for (let index = 0; index < headings.length; index += 1) {
@@ -149,6 +159,12 @@ for (const file of cardFiles) {
     if (!allowedTypes.has(type)) fail(file, `${id} invalid type: ${type}`)
     if (!allowedActions.test(action ?? '')) fail(file, `${id} invalid action: ${action}`)
     if (!/^- \*\*来源\*\*:[\s\S]*?https:\/\//m.test(card)) fail(file, `${id} must cite a primary URL`)
+    const sourceLine = /^- \*\*来源\*\*:([^\r\n]+)/m.exec(card)?.[1] ?? ''
+    for (const match of sourceLine.matchAll(/https:\/\/[^ )]+/g)) {
+      if (/github\.com\/[^/]+\/[^/]+\/blob\/(main|master)([/?#]|$)/.test(match[0])) {
+        fail(file, `${id} source must pin a tag or commit, got an unpinned blob link: ${match[0]}`)
+      }
+    }
   }
 }
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -37,3 +37,4 @@ description: 一句话说明做什么、何时触发，以及重要的只读/写
 | [plugin-upgrade](plugin-upgrade/) | 只读检查、已安装插件升级、宿主兼容迁移；七类触点 + 版本卡片 + 安全回滚 | [@oh-my-dsh](https://github.com/oh-my-dsh) |
 | [plugin-write](plugin-write/) | 编写 DSH 插件，按目标 Harness 版本选择扩展形态，并区分官方单仓与外部插件规则 | [@omdsh-dev](https://github.com/omdsh-dev) |
 | [plugin-test](plugin-test/) | 为 DSH 插件变更选择测试层级，并覆盖真实组合、发布产物与目标版本产品入口 | [@omdsh-dev](https://github.com/omdsh-dev) |
+| [plugin-release](plugin-release/) | 打包、发布与分发 DSH 插件：发布轨选择、未发布 cohort 安装、CI 门禁与回滚 | [@omdsh-dev](https://github.com/omdsh-dev) |

--- a/skills/plugin-release/SKILL.md
+++ b/skills/plugin-release/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: plugin-release
+description: 打包、发布与分发 DeepSeek Harness（DSH）插件——包括 npm pack 产物校验、GitHub/npm/hub 发布轨选择、未发布 cohort（0.1.2-alpha.*）的 tarball overrides 安装、CI/发布门禁与回滚。当需要发布插件、给插件打 tarball、把插件接入 profile/hub、或处理“alpha 版本不在 npm 上怎么装”时使用；任何发布动作前必须先展示计划并取得用户确认。
+---
+
+# plugin-release
+
+把已开发、已测试的插件安全地发出去。发布是单向外发动作，**任何实际发布或推 tag 前必须先展示计划并确认**；本 Skill 不替你决定版本号，也不自动 bump 版本。
+
+## 第 0 步：确认目标版本与发布轨
+
+| 发布轨 | 适用 | 关键事实 |
+|---|---|---|
+| GitHub 直装 | `dsh plugin --profile <p> add github:owner/repo` | 消费者解析默认分支 HEAD；发布=推送到 main，**推前必须跑完整门禁** |
+| npm registry | `npm publish` | 仅正式发布线可用；`@deepseek-ai/*` 的 alpha/rc 前缀版本**不一定**在 npm 上，发布前先 `npm view <pkg> versions` 核实 |
+| hub 收录 | 在 hub catalog 登记 | 登记是独立动作，不代替打包验证 |
+| collection | 把成员插件 vendored 成 pack artifact | 见所属 collection 仓库的自有流程 |
+
+未发布 cohort（例如 0.1.2-alpha.* 只有 GitHub 来源）走 [references/publish-playbook.md](references/publish-playbook.md) 的 overrides 流程，**不要**在 npm 上找不存在的版本，也不要因此切换包管理器。
+
+## 第 1 步：打包与产物校验
+
+1. 用仓库唯一的包管理器与 lockfile（有 `package-lock.json` 用 npm，有 `pnpm-lock.yaml` 用 pnpm）；
+2. 跑完整门禁（见第 3 步），再 `npm pack` / `pnpm pack`；
+3. 解包校验：`files` 覆盖全部运行时相对导入与资产；产物里没有 `.ts` 残留；`cordis.patch.yml`/`dsh.plugin.json`/`SKILL.md` 等形态文件齐全；
+4. tarball 装入隔离 profile 做消费验证（`dsh --profile compat --dump-config` 出现本插件 row → 工具真实注册与执行）。
+
+## 第 2 步：版本依赖基线（alpha 时代）
+
+- devDependencies 使用 **npm 发布线**（当前 0.1.1-rc.2）作为类型基线，保证公开仓库在任何机器上 `npm install` 后 typecheck 可用；
+- peer 范围用宽范围（如 `<0.2.0`）覆盖未发布的 alpha/rc；
+- 代码需要兼容本地 harness（GitHub tag）与 npm 发布线两侧时，用**双兼容写法**：保留 npm 发布线类型要求的形态，同时在 alpha 运行时语义不变（见 playbook 的“双兼容写法”节）；
+- 不要把本机绝对路径（junction/file:）写进提交的 package.json。
+
+## 第 3 步：发布门禁（逐层，前层不过不进后层）
+
+1. 依赖解析：lockfile 只发生预期变化；无混合 cohort；
+2. 静态：typecheck + 插件测试 + build；
+3. 真实挂载：目标版本真实 DSH profile 冷启动，entry active、服务不停 pending；
+4. 行为：一条核心路径真实执行（工具插件=一次消息→工具→回复；或等价专用流程）；
+5. 包装器：核对退出码与 stdout/stderr 归属。
+
+## 第 4 步：发布与回滚
+
+- 发布前：干净提交 + 打 tag；记录 lockfile 与 composition 基线 hash；
+- 发布后：以消费者身份重装一次并冒烟；
+- 回滚：优先回退发布（删 tag/重新指向旧 commit），不发布“兼容两边”的补丁掩盖问题；
+- 未发布 cohort 的 CI 见 playbook 的“CI 与发布门禁”节（缓存 cohort store、`NPM_PUBLISH_ENABLED` 开关）。
+
+## 安全边界
+
+- 发布/推 tag/写 hub 登记前必须展示计划并确认；不自动 bump 版本；
+- 不发布含凭据、`.npmrc` 内容、会话日志或私有路径的产物；
+- 不切换包管理器、不重写另一套 lockfile；失败时只回滚本次拥有的路径并报告残留。
+
+## 参考材料
+
+| 文件 | 内容 |
+|---|---|
+| [references/publish-playbook.md](references/publish-playbook.md) | 未发布 cohort 安装、双兼容写法、CI/发布门禁、真实坑位清单与回滚配方 |

--- a/skills/plugin-release/SKILL.md
+++ b/skills/plugin-release/SKILL.md
@@ -36,11 +36,18 @@ description: 打包、发布与分发 DeepSeek Harness（DSH）插件——包�
 
 1. 依赖解析：lockfile 只发生预期变化；无混合 cohort；
 2. 静态：typecheck + 插件测试 + build；
-3. 真实挂载：目标版本真实 DSH profile 冷启动，entry active、服务不停 pending；
+3. 真实挂载：在**锁定精确 DSH tag**（禁止用可变的 master/main 冒名验收）的隔离 profile 上冷启动目标宿主，entry active、服务不停 pending。Web Client 插件还要验证：宿主公告资源（启动图/boot 名单中的 bundle 入口）可访问、bundle 注册成功、DOM 挂载完成、无 page error——只看 `--dump-config` 不算完成本层；
 4. 行为：一条核心路径真实执行（工具插件=一次消息→工具→回复；或等价专用流程）；
 5. 包装器：核对退出码与 stdout/stderr 归属。
 
-## 第 4 步：发布与回滚
+## 第 4 步：发布语义门禁（任一不满足即停止发布）
+
+1. GitHub Release tag 必须等于 `v${package.json.version}`；
+2. 版本号是否含 prerelease 后缀（`-` 之后、`+` build metadata 之前的段），必须与 GitHub Release 的 prerelease 状态一致；
+3. prerelease 只能发布到**项目声明的非 latest dist-tag**（名称由项目自定，如 `next`、`alpha`——不写死具体名字）；无后缀的 stable 版本才进入 `latest`；
+4. stable 发布前查询现有 `latest`（`npm view <pkg> dist-tags.latest`），semver 低于现有 latest 时拒绝发布，防止把 latest 回退到更低版本。
+
+## 第 5 步：发布与回滚
 
 - 发布前：干净提交 + 打 tag；记录 lockfile 与 composition 基线 hash；
 - 发布后：以消费者身份重装一次并冒烟；

--- a/skills/plugin-release/references/publish-playbook.md
+++ b/skills/plugin-release/references/publish-playbook.md
@@ -1,0 +1,77 @@
+# publish-playbook · 打包、发布与分发配方
+
+> 按需加载的实操配方，承接 [../SKILL.md](../SKILL.md) 的决策流程。
+> 所有结论来自 omdsh-dev 组织 17 个插件仓库两轮真实发布实践（rc.2 → alpha.1 → alpha.2），
+> 场景未覆盖时以一手来源为准并标注「待确认」。
+
+## 未发布 cohort 安装（R-01 配方）
+
+0.1.2-alpha.* 只在 GitHub 发布，npm 查询返回 404。消费者侧的隔离安装：
+
+```sh
+git clone https://github.com/deepseek-ai/deepseek-harness.git /tmp/dsh-build
+cd /tmp/dsh-build && git checkout dsh-v0.1.2-alpha.2
+pnpm install && pnpm run build
+mkdir -p ~/.dsh-cohorts/0.1.2-alpha.2
+pnpm -r exec pnpm pack --pack-destination ~/.dsh-cohorts/0.1.2-alpha.2
+```
+
+manifest 里 range 写 `^0.1.2-alpha.2`，并用 `overrides` 钉到 `file:` tarball；正式发版后删掉 overrides 即回到 registry 解析。
+
+> **待确认（单一实战报告，未复现）**：pnpm 11.9.0 对 file: tarball 的传递依赖在有第三方
+> peer 时会绕过 overrides 去 registry 找不存在的版本，报告称钉 `packageManager: pnpm@11.24.0`
+> 才解析正确。落地前先在目标仓库做最小复现，验证后回填结论。
+
+## 双兼容写法（alpha 时代核心策略）
+
+公开仓库的 devDependencies 用 npm 发布线（当前 0.1.1-rc.2）作为类型基线；代码同时要在
+GitHub tag 的本地 harness 上运行。对签名漂移的 API，按“npm 发布线类型为准、alpha 运行时
+语义不变”折中。真实案例：`rpc.handle` 第三参数在 0.1.2-alpha.1 起被移除（认证改由
+connection 统一处理），但 rc.2 类型仍要求它：
+
+```ts
+// devDependencies 基线是 npm 发布线（rc.2），其 handle() 类型要求第三参数；
+// harness 0.1.2-alpha.1 起的 handle() 忽略该参数。保留它使仓库对 rc.2 类型
+// 可 typecheck，同时 alpha 运行时行为不变。
+const dispose = connection.rpc.handle(
+  '/tariff',
+  handler,
+  { authority: 'loopback' },
+)
+```
+
+- 只对**签名漂移且运行时忽略多余参数**的 API 用此折中；语义变化的 API 必须按
+  [plugin-upgrade](../../plugin-upgrade/SKILL.md) 的版本卡片迁移，不做静默折中；
+- 类型导入（`import type`）编译期擦除，跨 cohort 无运行时负担；
+- 不要把本机 junction/file: 绝对路径写进提交的 manifest。
+
+## CI 与发布门禁（未发布 cohort）
+
+- cohort tarball 用 actions cache 物化（以 manifest hash 为 key），所有 pnpm 消费 job 共享，
+  避免 frozen lockfile 记录机器相关路径导致干净 runner 缺 store；
+- `pnpm/action-setup` 不写死 `version`，让 `packageManager` 成为唯一版本来源；
+- 发布 workflow 加 `NPM_PUBLISH_ENABLED` 开关：tag 触发仍跑全部门禁与 smoke，但跳过
+  npm publish，直到 cohort 正式发布。
+
+## 真实坑位清单（两轮实践）
+
+| 坑 | 症状 | 处置 |
+|---|---|---|
+| PATH 上没有 pnpm（只有 corepack） | 构建脚本里嵌套 `pnpm --filter …` 报 `'pnpm' is not recognized` | 生成 `pnpm.cmd` shim 转发 corepack，前置到 PATH；启动/构建包装器自举该 shim |
+| Windows PowerShell 5.1 调 `npm` 解析到 `npm.ps1` | 参数错乱（`Unknown command: "pm"`） | 包装脚本显式调用 `npm.cmd` / `pnpm.cmd` |
+| PowerShell 5.1 参数默认值里 `$PSScriptRoot` 为空（带 `[CmdletBinding()]` 时） | `Join-Path` 报空字符串 | 默认值移到脚本体内解析 |
+| PowerShell 的只读自动变量 `$Host` | 参数名 `-Host` 覆盖失败 | 改名 `-BindHost` 等 |
+| `git rebase --continue` 卡编辑器 | 无 TTY 时挂起 | `GIT_EDITOR=true`（或 `core.editor=true`）再继续 |
+| 远端前进导致推送被拒 | `[ahead 1, behind 1]` | `git pull --rebase` 后 `--force-with-lease` 重推，绝不裸 `--force` |
+
+## 回滚配方
+
+1. 发布前打 tag 并记录 lockfile/composition 基线 hash；
+2. GitHub 直装轨：删除/移动 tag，消费者按需重新指向旧 commit；
+3. 隔离工作区（branch/worktree）做迁移与发布，不与功能改动混在一个提交；
+4. 失败时只回滚本次拥有的路径（tag、lockfile、manifest），报告第三方安装脚本的残留副作用。
+
+## 待确认
+
+- 0.1.2 正式版 dist-tag 与 final tag 名发布后，复核“未发布 cohort”各条配方；
+- pnpm 版本敏感性（见上）来自单一实战报告，复现前标待确认。

--- a/skills/plugin-release/references/publish-playbook.md
+++ b/skills/plugin-release/references/publish-playbook.md
@@ -53,6 +53,36 @@ const dispose = connection.rpc.handle(
 - 发布 workflow 加 `NPM_PUBLISH_ENABLED` 开关：tag 触发仍跑全部门禁与 smoke，但跳过
   npm publish，直到 cohort 正式发布。
 
+## 发布语义门禁配方（release workflow）
+
+发布前按序跑以下检查，任一失败即停（SKILL 第 4 步的四条不变量）：
+
+```sh
+VERSION="$(node -p "require('./package.json').version")"
+# 1) GitHub Release tag 必须等于 v${VERSION}
+[ "$RELEASE_TAG" = "v$VERSION" ] || { echo "tag mismatch"; exit 1; }
+# 2) prerelease 状态一致（'-' 在 '+' build metadata 之前）
+V_PRERELEASE="$(node -e 'console.log(process.argv[1].split("+")[0].includes("-") ? "true" : "false")' "$VERSION")"
+[ "$RELEASE_PRERELEASE" = "$V_PRERELEASE" ] || { echo "prerelease state mismatch"; exit 1; }
+# 3) 分流 dist-tag：prerelease 只进项目声明的非 latest tag（NEXT_TAG 由项目自定），stable 才进 latest
+if [ "$RELEASE_PRERELEASE" = "true" ]; then NPM_TAG="$NEXT_TAG"; else NPM_TAG="latest"; fi
+# 4) stable 发布前拒绝把 latest 回退到更低版本（semver 比较）
+if [ "$NPM_TAG" = "latest" ]; then
+  CURRENT="$(npm view "$PKG" dist-tags.latest 2>/dev/null || echo 0.0.0)"
+  node -e "const semver=require('semver'); if (semver.lt(process.argv[1], process.argv[2])) { console.error('refusing to move latest backwards'); process.exit(1) }" "$VERSION" "$CURRENT"
+fi
+npm publish --access public --tag "$NPM_TAG"
+```
+
+- 宿主验收矩阵与发布通道一致：prerelease 通道锁 alpha 系 tag、stable 通道锁 rc 系 tag，
+  **绝不跟随 master/main 冒名验收**；
+- Web Client 插件的 publish 前 smoke 必须覆盖：宿主启动图（`window.__DSH_BOOT__`）公告的
+  bundle 入口可访问、bundle 注册成功、DOM 挂载完成、无 page error；`--dump-config` 只证明
+  row 存在，不代替本项；
+- 可复核实现参考：[dsh-genui#86](https://github.com/omdsh-dev/dsh-genui/pull/86)、
+  [dsh-annotation#40](https://github.com/omdsh-dev/dsh-annotation/pull/40)（两者实现了
+  第 1–3 条与双宿主 smoke；第 4 条 latest 回退防护为社区补充建议，参考实现中尚无）。
+
 ## 真实坑位清单（两轮实践）
 
 | 坑 | 症状 | 处置 |

--- a/skills/plugin-upgrade/evals/evals.json
+++ b/skills/plugin-upgrade/evals/evals.json
@@ -1,0 +1,23 @@
+{
+  "skill_name": "plugin-upgrade",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "以只读模式扫描 examples/legacy-plugin/ 这个夹具，输出七类触点体检表和命中的版本卡片。",
+      "expected_output": "七类触点（源码 patch、内部事件、服务/Remote、宿主目录、UI/命令、自建 HTTP 通道、子进程输出）全部命中；对应卡片映射到 A1-01/A1-02/A1-03/A1-04/A1-08（含 A2-01 回滚对）等；输出包含「未命中说明」与「必须验证」清单；全程不改文件。",
+      "files": []
+    },
+    {
+      "id": 2,
+      "prompt": "插件在 rc.2 上生产第三方 informational 持久事件（带 ignorable: true），现在要迁到 0.1.2-alpha.2。给出该触点的迁移步骤。",
+      "expected_output": "先读完整走廊折叠净状态：alpha.1 移除 ignorable、alpha.2 恢复（A1-02 → A2-01），因此不要“删了再加”；最终目标为 alpha.2 时保留/恢复 producer marker 并删除 alpha.1 时代的防御性删除；指出公开 Session.append 没有 ignorable 参数的能力缺口，不做 cast 假装已有公开入口；给出 reload/未知事件 fail-closed 的验证步骤。",
+      "files": []
+    },
+    {
+      "id": 3,
+      "prompt": "插件用 connection.rpc.handle('/x', handler, { authority: 'loopback' }) 注册自建通道，devDependencies 是 npm 0.1.1-rc.2，宿主将升到 0.1.2-alpha.2。怎么改？",
+      "expected_output": "识别签名漂移：alpha.1 起 handle() 移除第三参数且运行时忽略多余参数；由于 devDependencies 声明基线是 rc.2，采用双兼容写法保留第三参数（typecheck 对 rc.2 通过、alpha 运行时不变），并注明原因；同时提示自建通道必须经 connection 注册以获得统一认证（A1-08），不绕过 token；验证含真实冷启动与无认证 401。",
+      "files": []
+    }
+  ]
+}


### PR DESCRIPTION
### 1. 新增 `plugin-release` 技能
- `skills/plugin-release/SKILL.md`：发布轨选择（GitHub 直装 / npm / hub / collection）→ 打包与产物校验 → alpha 时代版本基线 → 分层发布门禁 → 发布与回滚；任何发布动作前强制展示计划并确认。
- `skills/plugin-release/references/publish-playbook.md`：未发布 cohort 的 tarball overrides 安装、双兼容写法（含 `rpc.handle` 真实案例）、CI/发布门禁、6 条真实坑位清单（pnpm 不在 PATH、npm.ps1 参数错乱等，来自插件仓库真实迁移案例）、回滚配方。

### 2. `validate.mjs` 三条新门禁
- 卡片「来源」禁止未 pin 的 `blob/main` / `blob/master`（必须 pin tag 或 commit）；
- `verifiedAt` 必须为 `YYYY-MM-DD`；
- 卡片 ID 两位后缀严格递增（允许删卡留间隙，拒绝乱序/重复/非数字）。
- 拒绝路径已自证（8 条断言全过），当前 main 上全绿。

### 3. `plugin-upgrade` 新增 evals
- `skills/plugin-upgrade/evals/evals.json`：3 个用例（legacy 夹具七触点扫描、`ignorable` 走廊净态推理、RPC 通道双兼容决策），格式与 #12 的 audit evals 一致。

## 验证
- `node scripts/validate.mjs`：Validation OK（4 skill, 2 card sets, 20 cards, 28 Markdown files）
- `node scripts/validate-manifests.mjs`：清单校验通过（4 个清单，4 skills）

## 与开放 PR 的关系
- 与 #13 / #14 / #17：无冲突、无内容重复；
- 与 #12：`skills/README.md` 索引表各加一行，存在一行级冲突（git 层面，非内容冲突）——任一先合并后，后合并方 rebase 补一行即可；
- 与 #18：#18 全文改写根 README，本 PR 在根 README 索引表加一行，同样一行级冲突，建议 #18 后合并或双方 rebase；
- 本 PR 的三块内容（发布生命周期、校验门禁、upgrade evals）均无其他 PR 覆盖。
