### PR TITLE
fix(plugin-upgrade): 补齐 alpha.1 Web 插件启动图验收

### DIFF
--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -224,7 +224,7 @@ for (const file of markdownFiles) {
 // The rollup is a current navigation document, not an unchecked historical snapshot.
 const rollupFile = join(referencesDir, 'rollup-0.1.2.md')
 const rollupText = await readFile(rollupFile, 'utf8')
-for (const required of ['（14 张）', '（6 张）', '#7 子进程']) {
+for (const required of ['（15 张）', '（6 张）', '#7 子进程']) {
   if (!rollupText.includes(required)) fail(rollupFile, `missing current rollup contract: ${required}`)
 }
 if (/Consumer.*永不 reject|#6 子进程|git checkout <tag> -- pnpm-lock\.yaml/.test(rollupText)) {

--- a/skills/plugin-upgrade/SKILL.md
+++ b/skills/plugin-upgrade/SKILL.md
@@ -104,7 +104,7 @@ description: 检查或升级已安装的 DSH（DeepSeek Harness）插件，或�
 |---|---|
 | [references/README.md](references/README.md) | 版本走廊、卡片 schema 与维护规则 |
 | [references/pre-flight.md](references/pre-flight.md) | 七类触点自查与汇总模板 |
-| [references/v0.1.2-alpha.1.md](references/v0.1.2-alpha.1.md) | rc.2→alpha.1：14 张 curated 卡 |
+| [references/v0.1.2-alpha.1.md](references/v0.1.2-alpha.1.md) | rc.2→alpha.1：15 张 curated 卡 |
 | [references/v0.1.2-alpha.2.md](references/v0.1.2-alpha.2.md) | alpha.1→alpha.2：6 张 curated 卡 |
 | [references/rollup-0.1.2.md](references/rollup-0.1.2.md) | 0.1.1 → 0.1.2 走廊（rollup）：跨 cohort 共存、未发布 cohort 安装、`RemoteResult` 错误流、分层验证清单；**基于 alpha.2，正式版需复核** |
 | [migration planner](../../docs/migration-planner.md) | 只读扫描目标仓库、连接卡片走廊并输出候选迁移计划 |

--- a/skills/plugin-upgrade/references/README.md
+++ b/skills/plugin-upgrade/references/README.md
@@ -10,7 +10,7 @@ alpha.1 删除、alpha.2 恢复时，不应先删再加。
 
 | 顺序 | 卡片文件 | from | to | 卡数 | 状态 / 覆盖 |
 |---|---|---|---|---:|---|
-| 1 | [v0.1.2-alpha.1.md](v0.1.2-alpha.1.md) | `dsh-v0.1.1-rc.2` | `dsh-v0.1.2-alpha.1` | 14 | reviewed / curated |
+| 1 | [v0.1.2-alpha.1.md](v0.1.2-alpha.1.md) | `dsh-v0.1.1-rc.2` | `dsh-v0.1.2-alpha.1` | 15 | reviewed / curated |
 | 2 | [v0.1.2-alpha.2.md](v0.1.2-alpha.2.md) | `dsh-v0.1.2-alpha.1` | `dsh-v0.1.2-alpha.2` | 6 | reviewed / curated |
 | — | [rollup-0.1.2.md](rollup-0.1.2.md) | `dsh-v0.1.1-rc.2` → `dsh-v0.1.2-alpha.2` 全走廊 | rollup | 非卡片文件：走廊层增量（跨 cohort 共存、未发布 cohort 安装、`RemoteResult` 错误流、分层验证清单）；**基于 alpha.2，正式版需复核** |
 

--- a/skills/plugin-upgrade/references/rollup-0.1.2.md
+++ b/skills/plugin-upgrade/references/rollup-0.1.2.md
@@ -7,7 +7,7 @@
 ## 怎么用这份 rollup
 
 1. 先按 [pre-flight.md](pre-flight.md) 测出命中的触点类；
-2. 按 `from → to` 读完整走廊并先计算净状态：[v0.1.2-alpha.1.md](v0.1.2-alpha.1.md)（14 张）→ [v0.1.2-alpha.2.md](v0.1.2-alpha.2.md)（6 张）；
+2. 按 `from → to` 读完整走廊并先计算净状态：[v0.1.2-alpha.1.md](v0.1.2-alpha.1.md)（15 张）→ [v0.1.2-alpha.2.md](v0.1.2-alpha.2.md)（6 张）；
 3. 回到本文件处理走廊层问题——这些跨越单版本，卡片里没有；
 4. 按本文件末尾的分层验证清单收工。
 
@@ -22,6 +22,7 @@
 | #5 UI / 命令 / 工具 | [DSH-0.1.2-A1-03](v0.1.2-alpha.1.md)、[DSH-0.1.2-A1-06](v0.1.2-alpha.1.md)、[DSH-0.1.2-A1-09](v0.1.2-alpha.1.md)、[DSH-0.1.2-A1-10](v0.1.2-alpha.1.md)、[DSH-0.1.2-A1-11](v0.1.2-alpha.1.md) |
 | #6 自建 HTTP/WS/RPC/DOM/CSS | [DSH-0.1.2-A1-08](v0.1.2-alpha.1.md) |
 | #7 子进程 / stdout / stderr | [DSH-0.1.2-A1-04](v0.1.2-alpha.1.md)、[DSH-0.1.2-A1-05](v0.1.2-alpha.1.md)、[DSH-0.1.2-A1-06](v0.1.2-alpha.1.md)、[DSH-0.1.2-A1-13](v0.1.2-alpha.1.md)、[DSH-0.1.2-A2-04](v0.1.2-alpha.2.md) |
+| #6/#7 Web 启动与验收 | [DSH-0.1.2-A1-19](v0.1.2-alpha.1.md)（认证 URL、启动图资源发现与真实挂载） |
 | 特殊面 | 权限 [DSH-0.1.2-A1-07](v0.1.2-alpha.1.md)；隐私 [DSH-0.1.2-A1-12](v0.1.2-alpha.1.md) / [DSH-0.1.2-A1-14](v0.1.2-alpha.1.md)；打包 [DSH-0.1.2-A2-03](v0.1.2-alpha.2.md) |
 
 > **跨版本回滚型变更先读完整走廊再动手**：字段或语义在中间版本删除、后续版本又恢复
@@ -147,7 +148,7 @@ return result.value
 1. **依赖解析**: `pnpm list --depth 0 | grep @deepseek-ai` 版本一致；lockfile 无混合 cohort。
 2. **静态**: typecheck + build。注意静态全绿证明不了 wire 契约正确——描述符层的参数漂移在这一层是静默的（[DSH-0.1.2-A1-01](v0.1.2-alpha.1.md)）。
 3. **卡片级单测**: 每个命中触点至少一条断言。Remote 调用点覆盖 `ok: false` 的已知业务码、未知码兜底，以及 gateway 层 catch 分支；测试替身编码同一套描述符表，多/缺 key 就 fail，让漂移变成测试失败事件。
-4. **真实冷启动**: 完整一轮对话（发消息 → 工具调用 → 回复）。观察日志无 `missed the module table`、无 `service-unavailable` 循环、无入口 `pending`。
+4. **真实冷启动**: 完整一轮对话（发消息 → 工具调用 → 回复）。观察日志无 `missed the module table`、无 `service-unavailable` 循环、无入口 `pending`。Web Client 插件另按 [DSH-0.1.2-A1-19](v0.1.2-alpha.1.md) 验证宿主公告资源、bundle 注册、真实挂载与 page error。
 5. **跨 cohort**（若做了 R-02）: 旧宿主与新宿主各跑一次第 4 步。
 6. **headless**（若命中 #7）: 比对退出码及 stdout/stderr 内容分类（[DSH-0.1.2-A1-05](v0.1.2-alpha.1.md)）。
 

--- a/skills/plugin-upgrade/references/v0.1.2-alpha.1.md
+++ b/skills/plugin-upgrade/references/v0.1.2-alpha.1.md
@@ -5,7 +5,7 @@ from: dsh-v0.1.1-rc.2
 to: dsh-v0.1.2-alpha.1
 status: reviewed
 coverage: curated
-cardCount: 14
+cardCount: 15
 idPrefix: DSH-0.1.2-A1
 verifiedAt: 2026-08-30
 ---
@@ -249,6 +249,34 @@ verifiedAt: 2026-08-30
 - **迁移配方**: 仅在部署明确同意日志出境后启用。每次从该 Session 的已接受 watermark 后发送连续 suffix；HTTP 2xx 后追加 `session-log-deepseek/delivery-accepted` watermark。非 2xx/传输失败不推进水位，后续会重发不确定区间；崩溃窗口是 at-least-once，可能重复、不应漏序列。该插件没有独立请求大小上限，provider 拒绝时保持水位不变。
 - **验证**: 关闭时无 `dsh_session_log` 字段且无 acceptance event；开启时只对 live、非空 Session 发 suffix；2xx 推进 watermark，非 2xx 不推进。诊断不得打印日志正文。
 - **来源**: [alpha.1 session-log-deepseek README](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/packages/session/session-log-deepseek/README.md) · [alpha.1 release notes](https://github.com/deepseek-ai/deepseek-harness/releases/tag/dsh-v0.1.2-alpha.1)
+
+---
+
+### DSH-0.1.2-A1-19 · Web 插件验收改读宿主启动图与认证 URL
+
+- **类型**: behavior
+- **适用对象**: 硬编码 Web 根地址、插件 bundle 路径或启动日志格式的浏览器验收脚本与包装器
+- **影响触点**: #6、#7
+- **操作级别**: required-if-hit
+- **症状**: alpha.1 的 `dsh web` 根 URL 带进程级 token，客户端 bundle 又由宿主通过
+  `window.__DSH_BOOT__` 公告带 revision 的单资源或组合 URL。继续拼接无 revision 的
+  `/plugins/<id>/client.js`，或只检查 HTTP 200，会把 401/404、未注册 bundle 和未挂载 UI
+  误判为插件兼容。
+- **迁移配方**: 在隔离 profile 上以精确目标 tag 启动 `dsh web --no-open`，保留并访问
+  `dsh web:` 打印的完整 URL，让根路径 token 交换得到 Cookie。随后从真实页面读取
+  `window.__DSH_BOOT__.entries`，按插件 `package.json#name` 找 entry，并请求宿主公告的
+  `url` 或所属 batch URL；不要自行推导资源路径。若同一产物声明兼容 rc 与 alpha，脚本应
+  同时接受旧宿主的裸根 URL 和 alpha 的 token URL，但每条 lane 都只按该宿主实际公告的
+  资源地址验收。
+- **验证**: 公告资源返回 200；bundle 以目标包名完成 `__ModuleLoader__.load` 注册；等待一个
+  插件拥有的 DOM 标记或等价核心行为；收集并拒绝 page error。资源 200、启动日志出现 URL、
+  或 `entries` 中出现 id，任一单项都不能独立证明插件可用。
+- **来源**: [alpha.1 Web App 启动 URL](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/packages/bundle/web-app/README.md) · [alpha.1 client modules 启动图与 bundle URL](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/packages/client/modules/README.md) · [alpha.1 boot manifest 解析](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/packages/client/modules/src/client/manifest.ts)
+- **实战批注**（2026-08，GenUI 0.9.6 与 Annotation 1.4.5）: 两个插件用同一份发布产物分别在
+  `dsh-v0.1.1-rc.2` 与 `dsh-v0.1.2-alpha.1` 通过真实 Web smoke；脚本兼容裸 URL 与 token
+  URL，并验证 boot entry、资源 200、插件 DOM 挂载和 page error。见
+  [GenUI PR #86](https://github.com/omdsh-dev/dsh-genui/pull/86) 与
+  [Annotation PR #40](https://github.com/omdsh-dev/dsh-annotation/pull/40)。
 
 ---
 


### PR DESCRIPTION
## 结论

补齐 `dsh-v0.1.1-rc.2 → dsh-v0.1.2-alpha.1` 迁移中 Web 插件验收脚本的行为变化：alpha.1 需要使用 `dsh web:` 公告的认证 URL，并从 `window.__DSH_BOOT__` 读取宿主实际发布的 bundle URL，不能继续拼接无 revision 的固定路径。

卡片使用 `A1-19`，为开放 PR #27 正在新增的 `A1-15`～`A1-18` 预留编号；两者内容不重复。

## 变更

- 新增 `DSH-0.1.2-A1-19`，覆盖认证 URL、启动图资源发现、bundle 注册、插件真实挂载和 page error。
- 更新 alpha.1 卡片数量、版本索引与走廊触点索引。
- 在真实冷启动门禁中补充 Web Client 专用验收要求。

## 实战依据

- GenUI PR #86：同一产物在 rc.2 / alpha.1 上验证资源、挂载与页面异常。
- Annotation PR #40：同样覆盖裸 URL 与 token URL 两种宿主协议。
- DSH 官方 alpha.1 标签中的 Web App、client-modules README 与 boot manifest 源码。

## 复用检查

- DSH 本体提供启动图、认证 URL 与 bundle 路由的底层事实，但没有外部插件升级卡片。
- dsh-external 目录没有同等升级流程；本 PR 扩展现有 `plugin-upgrade`，没有新增平行技能。

## 验证

- `node scripts/validate.mjs`
- `node scripts/validate-manifests.mjs`
- `git diff --check`
