### PR TITLE
feat(plugin-test): add Docker release smoke runner

### DIFF
--- a/skills/plugin-test/SKILL.md
+++ b/skills/plugin-test/SKILL.md
@@ -18,6 +18,12 @@ When adapting an existing plugin to a new DSH host version:
 
 The commands and repository paths below use test-level names from the official Harness monorepo. For external plugins, use equivalent scripts and paths from their own repositories. Do not add nonexistent Harness root commands or impose the monorepo layout on them.
 
+## Run a Docker Release Smoke Test
+
+For a pre-release external plugin check, read [`references/docker-release-smoke.md`](references/docker-release-smoke.md) and use the included runner on the packaged artifact. Pin one exact DSH version and a non-`latest` Node image, install the artifact into an isolated Profile, cold-start the real DSH entry, and add one argv-based functional probe when startup alone does not exercise the changed behavior.
+
+Treat the generated JSON and Markdown as narrow evidence for that artifact and target. Report skipped providers, browsers, operating systems, security checks, and additional versions as unverified; a passing Docker smoke test does not expand its own coverage. Keep generated reports, raw logs, temporary Profiles, and Docker cache outside the Skill directory.
+
 ## Test Levels
 
 | Level | Command | What it proves |

--- a/skills/plugin-test/references/README.md
+++ b/skills/plugin-test/references/README.md
@@ -3,6 +3,9 @@
 | File | When to read it |
 |---|---|
 | [version-migration-testing.md](version-migration-testing.md) | Test plugin compatibility with a new Harness version |
+| [docker-release-smoke.md](docker-release-smoke.md) | Run a packaged plugin against one exact DSH version in Docker before release |
 
 For ordinary plugin changes, select test levels directly from `SKILL.md`. Read
 `version-migration-testing.md` only when the task involves a Harness version migration.
+Read `docker-release-smoke.md` when Docker is available and the change needs repeatable
+published-artifact proof in an isolated Profile.

--- a/skills/plugin-test/references/docker-release-smoke.md
+++ b/skills/plugin-test/references/docker-release-smoke.md
@@ -1,0 +1,68 @@
+# Docker Release Smoke Test
+
+Use this runner to test a packaged plugin artifact against one exact DSH version in an isolated Docker container. It is a focused pre-release check, not a replacement for the plugin repository's unit, integration, browser, provider, or security tests.
+
+## Prerequisites
+
+- Docker Engine is running with Linux containers.
+- The selected image contains Node.js and `npm` and is pinned by a non-`latest` tag or a digest.
+- The plugin has already been built and packed as the artifact users will install, normally with `npm pack` or `pnpm pack`.
+- The container can reach the package registry while it installs the exact DSH and pnpm versions.
+
+Do not put registry credentials, provider keys, or other secrets in the JSON config. The runner redacts common token forms from final logs, but redaction is defense in depth rather than a credential-handling mechanism.
+
+## Configure One Target
+
+Create the config outside this Skill directory, preferably in the operating system's temporary directory:
+
+```json
+{
+  "schema": 1,
+  "image": "node:24-bookworm",
+  "dshVersion": "0.1.2-alpha.2",
+  "pnpmVersion": "11.24.0",
+  "profile": "web",
+  "startCommand": ["dsh", "web", "--no-open"],
+  "readyPattern": "dsh web:",
+  "timeoutSeconds": 60,
+  "shutdownGraceSeconds": 5,
+  "probeCommand": []
+}
+```
+
+All commands are argv arrays and run without a shell. `readyPattern` is a JavaScript regular expression matched against combined DSH stdout and stderr. `timeoutSeconds` is the cold-start readiness timeout. The optional `probeCommand` runs after readiness and must exit successfully; keep it empty when startup itself is the intended functional proof.
+
+## Run
+
+From this repository:
+
+```sh
+node skills/plugin-test/scripts/docker-release-smoke.mjs \
+  --config /path/to/smoke-config.json \
+  --plugin /path/to/plugin-package.tgz \
+  --report-dir /path/to/report
+```
+
+Omit `--report-dir` to create a retained report directory under the operating system's temporary directory. The command prints the exact paths. The runner writes only `report.json` and `report.md` to the report directory. Raw container logs and the isolated Profile are deleted after redaction and report generation.
+
+The process exits with `0` for a passed smoke test, `1` for a reported test failure, and `2` for invalid input or a runner error.
+
+## What It Proves
+
+The runner performs these operations in order:
+
+1. Starts a fresh named container and an isolated `HOME`.
+2. Installs the exact pnpm and `@deepseek-ai/dsh` versions.
+3. Reads installed package metadata and rejects a different resolved DSH version.
+4. Installs the packaged artifact with `dsh plugin --profile <profile> add`.
+5. Cold-starts the configured real DSH entry and waits for the readiness pattern.
+6. Runs the optional functional probe.
+7. Requests graceful shutdown, records the container exit, and removes the container.
+
+While the container runs, the host samples `docker stats --no-stream`. Both reports include elapsed time, peak sampled memory, peak sampled CPU, step results, the artifact SHA-256, redacted logs, and explicit unverified boundaries.
+
+## Interpret the Report
+
+Failure classes distinguish Docker/infrastructure errors, host setup, plugin installation, startup, probe, and teardown failures. A passing report proves only this artifact, image, DSH version, Profile, entry command, and optional probe. It does not prove real-provider behavior without credentials, browser behavior, comprehensive security, other operating systems, or other DSH versions.
+
+Keep generated reports out of the Skill repository unless they are deliberately reviewed evidence for a separate documentation change.

--- a/skills/plugin-test/scripts/container-runner.mjs
+++ b/skills/plugin-test/scripts/container-runner.mjs
@@ -1,0 +1,307 @@
+#!/usr/bin/env node
+
+import { spawn } from 'node:child_process'
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { join, resolve } from 'node:path'
+
+const MAX_LOG_BYTES = 2 * 1024 * 1024
+const SETUP_TIMEOUT_MS = 5 * 60 * 1000
+
+class SmokeFailure extends Error {
+  constructor(phase, message, details = {}) {
+    super(message)
+    this.phase = phase
+    this.exitCode = details.exitCode ?? null
+    this.durationMs = details.durationMs ?? 0
+  }
+}
+
+class CappedLog {
+  constructor() {
+    this.chunks = []
+    this.bytes = 0
+    this.truncated = false
+  }
+
+  add(chunk) {
+    const buffer = Buffer.from(chunk)
+    const remaining = MAX_LOG_BYTES - this.bytes
+    if (remaining <= 0) {
+      this.truncated = true
+      return
+    }
+    const accepted = buffer.subarray(0, remaining)
+    this.chunks.push(accepted)
+    this.bytes += accepted.length
+    if (accepted.length < buffer.length) this.truncated = true
+  }
+
+  text() {
+    const suffix = this.truncated ? '\n[log truncated]\n' : ''
+    return Buffer.concat(this.chunks).toString('utf8') + suffix
+  }
+}
+
+function parseArguments(argv) {
+  const options = {}
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index]
+    if (!['--config', '--plugin', '--output'].includes(argument)) throw new Error(`unknown argument: ${argument}`)
+    const value = argv[++index]
+    if (!value) throw new Error(`missing value for ${argument}`)
+    options[argument.slice(2)] = value
+  }
+  for (const name of ['config', 'plugin', 'output']) {
+    if (!options[name]) throw new Error(`--${name} is required`)
+  }
+  return options
+}
+
+function createCommandRunner(logs) {
+  return (phase, command, args, options = {}) =>
+    new Promise((resolvePromise, rejectPromise) => {
+      const startedAt = Date.now()
+      logs.stdout.add(`\n[${phase}] $ ${[command, ...args].join(' ')}\n`)
+      const child = spawn(command, args, {
+        cwd: options.cwd,
+        env: options.env,
+        shell: false,
+      })
+      let stdout = ''
+      let stderr = ''
+      const timer = setTimeout(() => child.kill('SIGKILL'), options.timeoutMs ?? SETUP_TIMEOUT_MS)
+      child.stdout.on('data', (chunk) => {
+        stdout += chunk.toString('utf8')
+        logs.stdout.add(chunk)
+      })
+      child.stderr.on('data', (chunk) => {
+        stderr += chunk.toString('utf8')
+        logs.stderr.add(chunk)
+      })
+      child.once('error', (error) => {
+        clearTimeout(timer)
+        rejectPromise(
+          new SmokeFailure(phase, `${command} could not start: ${error.message}`, {
+            durationMs: Date.now() - startedAt,
+          }),
+        )
+      })
+      child.once('close', (exitCode, signal) => {
+        clearTimeout(timer)
+        const durationMs = Date.now() - startedAt
+        if (exitCode !== 0) {
+          const reason = signal ? `signal ${signal}` : `exit code ${exitCode}`
+          rejectPromise(new SmokeFailure(phase, `${command} failed with ${reason}`, { exitCode, durationMs }))
+          return
+        }
+        resolvePromise({
+          name: phase,
+          status: 'passed',
+          exitCode,
+          durationMs,
+          stdout,
+          stderr,
+        })
+      })
+    })
+}
+
+async function waitForExit(child, milliseconds) {
+  if (child.exitCode !== null || child.signalCode !== null) return true
+  return await new Promise((resolvePromise) => {
+    const timer = setTimeout(() => {
+      child.off('close', onClose)
+      resolvePromise(false)
+    }, milliseconds)
+    const onClose = () => {
+      clearTimeout(timer)
+      resolvePromise(true)
+    }
+    child.once('close', onClose)
+  })
+}
+
+async function coldStart(config, environment, logs) {
+  const phase = 'cold-start'
+  const startedAt = Date.now()
+  const ready = new RegExp(config.readyPattern)
+  const [command, ...args] = config.startCommand
+  logs.stdout.add(`\n[${phase}] $ ${config.startCommand.join(' ')}\n`)
+  const child = spawn(command, args, { env: environment, shell: false })
+  let tail = ''
+  let readyFound = false
+
+  const observe = (target) => (chunk) => {
+    target.add(chunk)
+    tail = `${tail}${chunk.toString('utf8')}`.slice(-64 * 1024)
+    if (ready.test(tail)) readyFound = true
+  }
+  child.stdout.on('data', observe(logs.stdout))
+  child.stderr.on('data', observe(logs.stderr))
+
+  let spawnError = null
+  child.once('error', (error) => {
+    spawnError = error
+  })
+  const deadline = Date.now() + config.timeoutSeconds * 1000
+  while (!readyFound && child.exitCode === null && child.signalCode === null && Date.now() < deadline) {
+    await new Promise((resolvePromise) => setTimeout(resolvePromise, 100))
+  }
+  if (spawnError) {
+    throw new SmokeFailure(phase, `${command} could not start: ${spawnError.message}`, {
+      durationMs: Date.now() - startedAt,
+    })
+  }
+  if (!readyFound) {
+    const reason = child.exitCode === null ? `readiness timeout after ${config.timeoutSeconds}s` : `exit code ${child.exitCode}`
+    if (child.exitCode === null && child.signalCode === null) {
+      child.kill('SIGTERM')
+      if (!(await waitForExit(child, config.shutdownGraceSeconds * 1000))) {
+        child.kill('SIGKILL')
+        await waitForExit(child, 5000)
+      }
+    }
+    throw new SmokeFailure(phase, `ready pattern was not observed: ${reason}`, {
+      exitCode: child.exitCode,
+      durationMs: Date.now() - startedAt,
+    })
+  }
+  return {
+    child,
+    step: { name: phase, status: 'passed', exitCode: null, durationMs: Date.now() - startedAt },
+  }
+}
+
+async function stopServer(child, graceSeconds) {
+  const startedAt = Date.now()
+  if (child.exitCode !== null || child.signalCode !== null) {
+    if (child.exitCode !== 0) {
+      const reason = child.signalCode ? `signal ${child.signalCode}` : `exit code ${child.exitCode}`
+      throw new SmokeFailure('teardown', `start process exited before teardown with ${reason}`, {
+        exitCode: child.exitCode,
+        durationMs: Date.now() - startedAt,
+      })
+    }
+    return { name: 'teardown', status: 'passed', exitCode: child.exitCode, durationMs: Date.now() - startedAt }
+  }
+  child.kill('SIGTERM')
+  if (await waitForExit(child, graceSeconds * 1000)) {
+    return { name: 'teardown', status: 'passed', exitCode: child.exitCode, durationMs: Date.now() - startedAt }
+  }
+  child.kill('SIGKILL')
+  await waitForExit(child, 5000)
+  throw new SmokeFailure('teardown', `start process did not stop within ${graceSeconds}s after SIGTERM`, {
+    exitCode: child.exitCode,
+    durationMs: Date.now() - startedAt,
+  })
+}
+
+async function run() {
+  const options = parseArguments(process.argv.slice(2))
+  const outputDirectory = resolve(options.output)
+  await mkdir(outputDirectory, { recursive: true })
+  const config = JSON.parse(await readFile(resolve(options.config), 'utf8'))
+  const pluginPath = resolve(options.plugin)
+  const home = process.env.HOME || '/workspace/home'
+  await mkdir(home, { recursive: true })
+  const environment = { ...process.env, HOME: home, CI: '1', NO_COLOR: '1' }
+  const logs = { stdout: new CappedLog(), stderr: new CappedLog() }
+  const steps = []
+  const runCommand = createCommandRunner(logs)
+  let server = null
+  let failure = null
+
+  try {
+    const toolchain = await runCommand(
+      'install-toolchain',
+      'npm',
+      ['install', '--global', `pnpm@${config.pnpmVersion}`, `@deepseek-ai/dsh@${config.dshVersion}`],
+      { env: environment },
+    )
+    steps.push(stripOutput(toolchain))
+
+    const npmRoot = await runCommand('verify-dsh-version', 'npm', ['root', '--global'], { env: environment })
+    const packagePath = join(npmRoot.stdout.trim(), '@deepseek-ai', 'dsh', 'package.json')
+    const installedPackage = JSON.parse(await readFile(packagePath, 'utf8'))
+    if (installedPackage.version !== config.dshVersion) {
+      throw new SmokeFailure(
+        'verify-dsh-version',
+        `resolved DSH ${installedPackage.version}, expected ${config.dshVersion}`,
+      )
+    }
+    steps.push(stripOutput(npmRoot))
+
+    const pluginInstall = await runCommand(
+      'install-plugin',
+      'dsh',
+      ['plugin', '--profile', config.profile, 'add', pluginPath],
+      { env: environment },
+    )
+    steps.push(stripOutput(pluginInstall))
+
+    const started = await coldStart(config, environment, logs)
+    server = started.child
+    steps.push(started.step)
+
+    if (config.probeCommand.length) {
+      const [probe, ...probeArgs] = config.probeCommand
+      const probeStep = await runCommand('probe', probe, probeArgs, {
+        env: environment,
+        timeoutMs: Math.min(config.timeoutSeconds, 60) * 1000,
+      })
+      steps.push(stripOutput(probeStep))
+    }
+
+    steps.push(await stopServer(server, config.shutdownGraceSeconds))
+    server = null
+  } catch (error) {
+    failure = {
+      phase: error.phase ?? 'container',
+      message: error.message,
+    }
+    steps.push({
+      name: failure.phase,
+      status: 'failed',
+      exitCode: error.exitCode ?? null,
+      durationMs: error.durationMs ?? 0,
+      message: failure.message,
+    })
+    if (server) {
+      try {
+        steps.push(await stopServer(server, config.shutdownGraceSeconds))
+      } catch (teardownError) {
+        steps.push({
+          name: 'teardown',
+          status: 'failed',
+          exitCode: null,
+          durationMs: 0,
+          message: teardownError.message,
+        })
+      }
+    }
+  } finally {
+    await writeFile(join(outputDirectory, 'stdout.log'), logs.stdout.text(), 'utf8')
+    await writeFile(join(outputDirectory, 'stderr.log'), logs.stderr.text(), 'utf8')
+    await writeFile(
+      join(outputDirectory, 'result.json'),
+      `${JSON.stringify({ schema: 1, status: failure ? 'failed' : 'passed', failure, steps }, null, 2)}\n`,
+      'utf8',
+    )
+  }
+  return failure ? 1 : 0
+}
+
+function stripOutput(step) {
+  const { stdout: _stdout, stderr: _stderr, ...result } = step
+  return result
+}
+
+run().then(
+  (exitCode) => {
+    process.exitCode = exitCode
+  },
+  (error) => {
+    console.error(`container runner failed: ${error.message}`)
+    process.exitCode = 2
+  },
+)

--- a/skills/plugin-test/scripts/docker-release-smoke.mjs
+++ b/skills/plugin-test/scripts/docker-release-smoke.mjs
@@ -1,0 +1,496 @@
+#!/usr/bin/env node
+
+import { createHash } from 'node:crypto'
+import { spawn } from 'node:child_process'
+import { createReadStream } from 'node:fs'
+import { access, mkdir, mkdtemp, readFile, realpath, rm, stat, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { basename, dirname, join, resolve } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url))
+const containerRunner = join(scriptDirectory, 'container-runner.mjs')
+const exactVersion = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/
+const profileName = /^[A-Za-z0-9._-]+$/
+
+export function validateConfig(input) {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) throw new Error('config must be a JSON object')
+  if (input.schema !== 1) throw new Error('config.schema must be 1')
+
+  const config = {
+    schema: 1,
+    image: requireString(input.image, 'config.image'),
+    dshVersion: requireString(input.dshVersion, 'config.dshVersion'),
+    pnpmVersion: requireString(input.pnpmVersion, 'config.pnpmVersion'),
+    profile: requireString(input.profile, 'config.profile'),
+    startCommand: requireCommand(input.startCommand, 'config.startCommand', false),
+    readyPattern: requireString(input.readyPattern, 'config.readyPattern'),
+    timeoutSeconds: requireInteger(input.timeoutSeconds, 'config.timeoutSeconds', 1, 1800),
+    shutdownGraceSeconds: requireInteger(
+      input.shutdownGraceSeconds,
+      'config.shutdownGraceSeconds',
+      1,
+      60,
+    ),
+    probeCommand: requireCommand(input.probeCommand ?? [], 'config.probeCommand', true),
+  }
+
+  if (!exactVersion.test(config.dshVersion)) throw new Error('config.dshVersion must be an exact version')
+  if (!exactVersion.test(config.pnpmVersion)) throw new Error('config.pnpmVersion must be an exact version')
+  if (!profileName.test(config.profile)) throw new Error('config.profile contains unsupported characters')
+  if (config.readyPattern.length > 512) throw new Error('config.readyPattern must be at most 512 characters')
+  try {
+    new RegExp(config.readyPattern)
+  } catch (error) {
+    throw new Error(`config.readyPattern is not a valid regular expression: ${error.message}`)
+  }
+
+  const imageTail = config.image.slice(config.image.lastIndexOf('/') + 1)
+  if (!imageTail.includes(':') && !config.image.includes('@sha256:')) {
+    throw new Error('config.image must include a tag or sha256 digest')
+  }
+  if (/:latest$/i.test(config.image)) throw new Error('config.image must not use the mutable latest tag')
+  return config
+}
+
+function requireString(value, name) {
+  if (typeof value !== 'string' || !value.trim()) throw new Error(`${name} must be a non-empty string`)
+  if (value.includes('\0')) throw new Error(`${name} must not contain NUL characters`)
+  return value
+}
+
+function requireCommand(value, name, allowEmpty) {
+  if (!Array.isArray(value) || (!allowEmpty && value.length === 0)) {
+    throw new Error(`${name} must be ${allowEmpty ? 'an' : 'a non-empty'} argv array`)
+  }
+  return value.map((part, index) => requireString(part, `${name}[${index}]`))
+}
+
+function requireInteger(value, name, minimum, maximum) {
+  if (!Number.isInteger(value) || value < minimum || value > maximum) {
+    throw new Error(`${name} must be an integer from ${minimum} to ${maximum}`)
+  }
+  return value
+}
+
+export function parseMemoryBytes(value) {
+  if (typeof value !== 'string') return null
+  const firstValue = value.split('/', 1)[0].trim()
+  const match = /^(\d+(?:\.\d+)?)\s*([KMGT]?i?B)$/i.exec(firstValue)
+  if (!match) return null
+  const units = {
+    B: 1,
+    KB: 1000,
+    MB: 1000 ** 2,
+    GB: 1000 ** 3,
+    TB: 1000 ** 4,
+    KIB: 1024,
+    MIB: 1024 ** 2,
+    GIB: 1024 ** 3,
+    TIB: 1024 ** 4,
+  }
+  return Math.round(Number(match[1]) * units[match[2].toUpperCase()])
+}
+
+export function redactLogs(value) {
+  let text = String(value ?? '')
+  let redactions = 0
+  const replace = (pattern, replacement) => {
+    text = text.replace(pattern, (...args) => {
+      redactions += 1
+      return typeof replacement === 'function' ? replacement(...args) : replacement
+    })
+  }
+
+  replace(/\bBearer\s+[^\s,;]+/gi, 'Bearer [REDACTED]')
+  replace(
+    /(["']?(?:_authToken|(?=[A-Za-z_][A-Za-z0-9_]*["']?\s*[:=])(?=[A-Za-z0-9_]*(?:TOKEN|KEY|SECRET|PASSWORD))[A-Za-z_][A-Za-z0-9_]*)["']?\s*[:=]\s*)(["']?)([^\s,"';}]+)(\2)/gi,
+    (_match, prefix, quote) => `${prefix}${quote}[REDACTED]${quote}`,
+  )
+  replace(/((?:--?(?:token|api-key|secret|password))\s+)([^\s]+)/gi, '$1[REDACTED]')
+  return { text, redactions }
+}
+
+export function classifyFailure(containerResult, containerExitCode, infrastructureError) {
+  if (infrastructureError) return 'infrastructure'
+  if (!containerResult) return containerExitCode === 0 ? 'result' : 'container'
+  if (containerResult.status === 'passed' && containerExitCode === 0) return null
+  const phase = containerResult.failure?.phase
+  if (['install-toolchain', 'verify-dsh-version'].includes(phase)) return 'host-setup'
+  if (phase === 'install-plugin') return 'plugin-install'
+  if (phase === 'cold-start') return 'startup'
+  if (phase === 'probe') return 'probe'
+  if (phase === 'teardown') return 'teardown'
+  return 'container'
+}
+
+export function buildReport(input) {
+  const stdout = redactLogs(input.stdout)
+  const stderr = redactLogs(input.stderr)
+  const classification = classifyFailure(
+    input.containerResult,
+    input.containerExitCode,
+    input.infrastructureError,
+  )
+  const passed = classification === null
+  const failureMessage = input.infrastructureError?.message ?? input.containerResult?.failure?.message ?? 'Smoke test failed'
+  return {
+    schema: 1,
+    generatedAt: new Date().toISOString(),
+    status: passed ? 'passed' : 'failed',
+    failureClassification: classification,
+    failureMessage: passed ? null : redactLogs(failureMessage).text,
+    target: {
+      image: input.config.image,
+      dshVersion: input.config.dshVersion,
+      pnpmVersion: input.config.pnpmVersion,
+      profile: input.config.profile,
+      startCommand: redactCommand(input.config.startCommand),
+      readyPattern: input.config.readyPattern,
+      probeCommand: redactCommand(input.config.probeCommand),
+    },
+    artifact: input.artifact,
+    runtime: {
+      dockerServerVersion: input.dockerServerVersion ?? null,
+      containerImageId: input.containerImageId ?? null,
+      containerExitCode: input.containerExitCode ?? null,
+    },
+    measurements: {
+      elapsedMs: input.elapsedMs,
+      peakMemoryBytes: input.peakMemoryBytes,
+      peakCpuPercent: input.peakCpuPercent,
+      resourceSamples: input.resourceSamples,
+    },
+    steps: (input.containerResult?.steps ?? []).map((step) => ({
+      ...step,
+      ...(step.message ? { message: redactLogs(step.message).text } : {}),
+    })),
+    logs: {
+      stdout: stdout.text,
+      stderr: stderr.text,
+      redactionCount: stdout.redactions + stderr.redactions,
+    },
+    unverifiedBoundaries: [
+      'provider-backed flows unless the optional probe covers them',
+      'browser behavior',
+      'comprehensive security scanning',
+      'cross-platform and multi-version compatibility',
+    ],
+  }
+}
+
+function redactCommand(command) {
+  return command.map((part, index) => {
+    if (index > 0 && /^--?(?:token|api-key|secret|password)$/i.test(command[index - 1])) return '[REDACTED]'
+    return redactLogs(part).text
+  })
+}
+
+export function renderMarkdown(report) {
+  const result = report.status === 'passed' ? 'PASS' : 'FAIL'
+  const lines = [
+    '# DSH Plugin Docker Release Smoke Report',
+    '',
+    `- Result: **${result}**`,
+    `- DSH: \`${report.target.dshVersion}\``,
+    `- Image: \`${report.target.image}\``,
+    `- Profile: \`${report.target.profile}\``,
+    `- Artifact: \`${report.artifact.name}\` (SHA-256 \`${report.artifact.sha256}\`)`,
+    `- Elapsed: ${report.measurements.elapsedMs} ms`,
+    `- Peak memory: ${formatBytes(report.measurements.peakMemoryBytes)}`,
+    `- Peak CPU sample: ${report.measurements.peakCpuPercent ?? 'not sampled'}${report.measurements.peakCpuPercent == null ? '' : '%'}`,
+  ]
+  if (report.failureClassification) {
+    lines.push(`- Failure class: \`${report.failureClassification}\``, `- Failure: ${escapeMarkdown(report.failureMessage)}`)
+  }
+  lines.push('', '## Steps', '')
+  if (report.steps.length === 0) lines.push('_No container step result was produced._')
+  else {
+    lines.push('| Step | Status | Exit | Duration |', '|---|---|---:|---:|')
+    for (const step of report.steps) {
+      lines.push(
+        `| ${escapeTable(step.name)} | ${escapeTable(step.status)} | ${step.exitCode ?? ''} | ${step.durationMs} ms |`,
+      )
+    }
+  }
+  lines.push('', '## Redacted Logs', '', `Redactions applied: ${report.logs.redactionCount}.`)
+  lines.push('', '### stdout', '', fencedText(report.logs.stdout || '(empty)'))
+  lines.push('', '### stderr', '', fencedText(report.logs.stderr || '(empty)'))
+  lines.push('', '## Unverified Boundaries', '')
+  for (const boundary of report.unverifiedBoundaries) lines.push(`- ${boundary}`)
+  lines.push('')
+  return lines.join('\n')
+}
+
+function formatBytes(value) {
+  if (value == null) return 'not sampled'
+  return `${(value / 1024 / 1024).toFixed(2)} MiB (${value} bytes)`
+}
+
+function escapeMarkdown(value) {
+  return String(value ?? '').replaceAll('\n', ' ')
+}
+
+function escapeTable(value) {
+  return String(value ?? '').replaceAll('|', '\\|').replaceAll('\n', ' ')
+}
+
+function fencedText(value) {
+  const longest = Math.max(2, ...[...String(value).matchAll(/`+/g)].map((match) => match[0].length))
+  const fence = '`'.repeat(longest + 1)
+  return `${fence}text\n${value}\n${fence}`
+}
+
+async function hashFile(path) {
+  const hash = createHash('sha256')
+  for await (const chunk of createReadStream(path)) hash.update(chunk)
+  return hash.digest('hex')
+}
+
+function runProcess(command, args, options = {}) {
+  const child = spawn(command, args, {
+    cwd: options.cwd,
+    env: options.env,
+    windowsHide: true,
+    shell: false,
+  })
+  let stdout = ''
+  let stderr = ''
+  child.stdout?.on('data', (chunk) => {
+    stdout += chunk.toString('utf8')
+  })
+  child.stderr?.on('data', (chunk) => {
+    stderr += chunk.toString('utf8')
+  })
+  const done = new Promise((resolvePromise) => {
+    child.once('error', (error) => resolvePromise({ exitCode: null, stdout, stderr, error }))
+    child.once('close', (exitCode, signal) => resolvePromise({ exitCode, signal, stdout, stderr }))
+  })
+  return { child, done }
+}
+
+async function checkedProcess(command, args) {
+  const result = await runProcess(command, args).done
+  if (result.error) throw result.error
+  if (result.exitCode !== 0) {
+    const detail = result.stderr.trim() || result.stdout.trim() || `exit code ${result.exitCode}`
+    throw new Error(`${command} ${args[0] ?? ''} failed: ${detail}`)
+  }
+  return result
+}
+
+function delay(milliseconds) {
+  return new Promise((resolvePromise) => setTimeout(resolvePromise, milliseconds))
+}
+
+async function sampleContainer(name) {
+  const result = await runProcess('docker', ['stats', '--no-stream', '--format', '{{json .}}', name]).done
+  if (result.exitCode !== 0) return null
+  try {
+    const data = JSON.parse(result.stdout.trim().split(/\r?\n/).at(-1))
+    return {
+      capturedAt: new Date().toISOString(),
+      memoryBytes: parseMemoryBytes(data.MemUsage),
+      cpuPercent: Number.parseFloat(String(data.CPUPerc ?? '').replace('%', '')) || 0,
+    }
+  } catch {
+    return null
+  }
+}
+
+async function loadContainerResult(directory) {
+  try {
+    return JSON.parse(await readFile(join(directory, 'result.json'), 'utf8'))
+  } catch {
+    return null
+  }
+}
+
+async function loadRawLog(directory, name) {
+  try {
+    return await readFile(join(directory, name), 'utf8')
+  } catch {
+    return ''
+  }
+}
+
+function bindMount(source, target, readOnly = false) {
+  if (source.includes(',')) throw new Error(`Docker bind source must not contain a comma: ${source}`)
+  return `type=bind,source=${source},target=${target}${readOnly ? ',readonly' : ''}`
+}
+
+export async function runDockerSmoke({ config, pluginPath, reportDirectory }) {
+  const validatedConfig = validateConfig(config)
+  const artifactPath = await realpath(resolve(pluginPath))
+  await access(artifactPath)
+  const artifactStat = await stat(artifactPath)
+  if (!artifactStat.isFile()) throw new Error('plugin path must point to a packaged artifact file')
+
+  const runDirectory = await mkdtemp(join(tmpdir(), 'dsh-plugin-smoke-run-'))
+  const outputDirectory = join(runDirectory, 'output')
+  const finalReportDirectory = reportDirectory
+    ? resolve(reportDirectory)
+    : await mkdtemp(join(tmpdir(), 'dsh-plugin-smoke-report-'))
+  await mkdir(outputDirectory, { recursive: true })
+  await mkdir(finalReportDirectory, { recursive: true })
+  const configPath = join(runDirectory, 'config.json')
+  await writeFile(configPath, `${JSON.stringify(validatedConfig, null, 2)}\n`, 'utf8')
+
+  const artifact = {
+    name: basename(artifactPath),
+    sizeBytes: artifactStat.size,
+    sha256: await hashFile(artifactPath),
+  }
+  const containerName = `dsh-plugin-smoke-${process.pid}-${Date.now()}`
+  const startedAt = Date.now()
+  const samples = []
+  let containerCreated = false
+  let dockerServerVersion = null
+  let containerImageId = null
+  let containerExitCode = null
+  let attachedStdout = ''
+  let attachedStderr = ''
+  let infrastructureError = null
+  let containerResult = null
+
+  try {
+    dockerServerVersion = (
+      await checkedProcess('docker', ['version', '--format', '{{.Server.Version}}'])
+    ).stdout.trim()
+    await checkedProcess('docker', [
+      'create',
+      '--name',
+      containerName,
+      '--init',
+      '--workdir',
+      '/workspace',
+      '--env',
+      'HOME=/workspace/home',
+      '--mount',
+      bindMount(artifactPath, '/workspace/plugin.tgz', true),
+      '--mount',
+      bindMount(configPath, '/workspace/config.json', true),
+      '--mount',
+      bindMount(await realpath(containerRunner), '/runner/container-runner.mjs', true),
+      '--mount',
+      bindMount(outputDirectory, '/workspace/output'),
+      validatedConfig.image,
+      'node',
+      '/runner/container-runner.mjs',
+      '--config',
+      '/workspace/config.json',
+      '--plugin',
+      '/workspace/plugin.tgz',
+      '--output',
+      '/workspace/output',
+    ])
+    containerCreated = true
+    const inspectImage = await checkedProcess('docker', ['inspect', '--format', '{{.Image}}', containerName])
+    containerImageId = inspectImage.stdout.trim()
+
+    const attached = runProcess('docker', ['start', '--attach', containerName])
+    let finished = false
+    attached.done.then(() => {
+      finished = true
+    })
+    while (!finished) {
+      await delay(750)
+      if (finished) break
+      const sample = await sampleContainer(containerName)
+      if (sample) samples.push(sample)
+    }
+    const attachResult = await attached.done
+    attachedStdout = attachResult.stdout
+    attachedStderr = attachResult.stderr
+    const inspectState = await checkedProcess('docker', [
+      'inspect',
+      '--format',
+      '{{.State.ExitCode}}',
+      containerName,
+    ])
+    containerExitCode = Number.parseInt(inspectState.stdout.trim(), 10)
+    containerResult = await loadContainerResult(outputDirectory)
+  } catch (error) {
+    infrastructureError = error
+  } finally {
+    if (containerCreated) {
+      await runProcess('docker', ['rm', '--force', containerName]).done
+    }
+  }
+
+  const rawStdout = `${await loadRawLog(outputDirectory, 'stdout.log')}${attachedStdout}`
+  const rawStderr = `${await loadRawLog(outputDirectory, 'stderr.log')}${attachedStderr}`
+  const report = buildReport({
+    config: validatedConfig,
+    artifact,
+    dockerServerVersion,
+    containerImageId,
+    containerExitCode,
+    containerResult,
+    infrastructureError,
+    elapsedMs: Date.now() - startedAt,
+    peakMemoryBytes: samples.reduce((peak, sample) => Math.max(peak, sample.memoryBytes ?? 0), 0) || null,
+    peakCpuPercent: samples.length ? Math.max(...samples.map((sample) => sample.cpuPercent)) : null,
+    resourceSamples: samples.length,
+    stdout: rawStdout,
+    stderr: rawStderr,
+  })
+
+  const jsonPath = join(finalReportDirectory, 'report.json')
+  const markdownPath = join(finalReportDirectory, 'report.md')
+  try {
+    await writeFile(jsonPath, `${JSON.stringify(report, null, 2)}\n`, 'utf8')
+    await writeFile(markdownPath, renderMarkdown(report), 'utf8')
+  } finally {
+    await rm(runDirectory, { recursive: true, force: true })
+  }
+  return { report, jsonPath, markdownPath }
+}
+
+function parseArguments(argv) {
+  const options = {}
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index]
+    if (argument === '--help' || argument === '-h') return { help: true }
+    if (!['--config', '--plugin', '--report-dir'].includes(argument)) throw new Error(`unknown argument: ${argument}`)
+    const value = argv[++index]
+    if (!value) throw new Error(`missing value for ${argument}`)
+    options[argument.slice(2)] = value
+  }
+  if (!options.config || !options.plugin) throw new Error('--config and --plugin are required')
+  return options
+}
+
+function printUsage() {
+  console.log('Usage: node docker-release-smoke.mjs --config <config.json> --plugin <plugin.tgz> [--report-dir <dir>]')
+}
+
+export async function main(argv = process.argv.slice(2)) {
+  const options = parseArguments(argv)
+  if (options.help) {
+    printUsage()
+    return 0
+  }
+  const config = JSON.parse(await readFile(resolve(options.config), 'utf8'))
+  const result = await runDockerSmoke({
+    config,
+    pluginPath: options.plugin,
+    reportDirectory: options['report-dir'],
+  })
+  console.log(`JSON report: ${result.jsonPath}`)
+  console.log(`Markdown report: ${result.markdownPath}`)
+  console.log(`Result: ${result.report.status.toUpperCase()}`)
+  return result.report.status === 'passed' ? 0 : 1
+}
+
+if (process.argv[1] && pathToFileURL(resolve(process.argv[1])).href === import.meta.url) {
+  main().then(
+    (exitCode) => {
+      process.exitCode = exitCode
+    },
+    (error) => {
+      console.error(`Docker release smoke failed: ${error.message}`)
+      process.exitCode = 2
+    },
+  )
+}

--- a/skills/plugin-test/scripts/docker-release-smoke.test.mjs
+++ b/skills/plugin-test/scripts/docker-release-smoke.test.mjs
@@ -1,0 +1,92 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  buildReport,
+  classifyFailure,
+  parseMemoryBytes,
+  redactLogs,
+  renderMarkdown,
+  validateConfig,
+} from './docker-release-smoke.mjs'
+
+const validConfig = {
+  schema: 1,
+  image: 'node:24-bookworm',
+  dshVersion: '0.1.2-alpha.2',
+  pnpmVersion: '11.24.0',
+  profile: 'web',
+  startCommand: ['dsh', 'web', '--no-open'],
+  readyPattern: 'dsh web:',
+  timeoutSeconds: 60,
+  shutdownGraceSeconds: 5,
+  probeCommand: [],
+}
+
+test('validateConfig accepts a pinned smoke configuration', () => {
+  assert.deepEqual(validateConfig(validConfig), validConfig)
+})
+
+test('validateConfig rejects mutable and ranged targets', () => {
+  assert.throws(() => validateConfig({ ...validConfig, image: 'node:latest' }), /latest/)
+  assert.throws(() => validateConfig({ ...validConfig, dshVersion: '^0.1.2' }), /exact version/)
+  assert.throws(() => validateConfig({ ...validConfig, startCommand: 'dsh web' }), /argv array/)
+})
+
+test('parseMemoryBytes handles Docker binary and decimal units', () => {
+  assert.equal(parseMemoryBytes('12.5MiB / 1GiB'), 13_107_200)
+  assert.equal(parseMemoryBytes('2 GB / 4 GB'), 2_000_000_000)
+  assert.equal(parseMemoryBytes('not available'), null)
+})
+
+test('redactLogs removes common credential forms', () => {
+  const source = [
+    'Authorization: Bearer abc.def',
+    '_authToken="npm-secret"',
+    'DEEPSEEK_API_KEY=provider-secret',
+    '{"accessToken": "json-secret"}',
+    'dbPassword: hunter2',
+    '--token command-secret',
+  ].join('\n')
+  const result = redactLogs(source)
+  assert.equal(result.redactions, 6)
+  for (const secret of ['abc.def', 'npm-secret', 'provider-secret', 'json-secret', 'hunter2', 'command-secret']) {
+    assert.equal(result.text.includes(secret), false)
+  }
+})
+
+test('classifyFailure maps setup, install, startup, probe, and infrastructure failures', () => {
+  assert.equal(classifyFailure({ status: 'failed', failure: { phase: 'install-toolchain' } }, 1), 'host-setup')
+  assert.equal(classifyFailure({ status: 'failed', failure: { phase: 'install-plugin' } }, 1), 'plugin-install')
+  assert.equal(classifyFailure({ status: 'failed', failure: { phase: 'cold-start' } }, 1), 'startup')
+  assert.equal(classifyFailure({ status: 'failed', failure: { phase: 'probe' } }, 1), 'probe')
+  assert.equal(classifyFailure(null, null, new Error('Docker unavailable')), 'infrastructure')
+  assert.equal(classifyFailure({ status: 'passed' }, 0), null)
+})
+
+test('buildReport and renderMarkdown include metrics but not command secrets', () => {
+  const report = buildReport({
+    config: { ...validConfig, probeCommand: ['curl', '--token', 'probe-secret'] },
+    artifact: { name: 'plugin.tgz', sizeBytes: 42, sha256: 'abc123' },
+    dockerServerVersion: '29.6.1',
+    containerImageId: 'sha256:image',
+    containerExitCode: 0,
+    containerResult: {
+      status: 'passed',
+      steps: [{ name: 'cold-start', status: 'passed', exitCode: null, durationMs: 123 }],
+    },
+    elapsedMs: 456,
+    peakMemoryBytes: 1024 * 1024,
+    peakCpuPercent: 3.5,
+    resourceSamples: 2,
+    stdout: 'ready TOKEN=log-secret',
+    stderr: '',
+  })
+  const markdown = renderMarkdown(report)
+  assert.equal(report.status, 'passed')
+  assert.deepEqual(report.target.probeCommand, ['curl', '--token', '[REDACTED]'])
+  assert.equal(JSON.stringify(report).includes('probe-secret'), false)
+  assert.equal(markdown.includes('log-secret'), false)
+  assert.match(markdown, /Peak memory: 1\.00 MiB/)
+  assert.match(markdown, /cold-start/)
+})


### PR DESCRIPTION
# 中文

## 摘要

### 为什么设计这个功能

`plugin-test` 已经要求发布前使用打包产物、精确 DSH 版本、隔离 Profile 和真实入口做冷启动验证，但仓库里只有规则和一次性 Docker 复现记录，没有可重复执行的工具。插件维护者仍需手工拼装容器命令，也缺少统一的退出状态、资源数据、脱敏日志和报告格式，因此同一次升级在不同机器上的验证证据很难比较。

这个 PR 补齐最小的执行层：用一个命令把插件 tarball 放进全新容器，在精确 DSH 版本上安装、启动、探测、退出并生成报告。它不扩展成完整发布平台，也不包含安全扫描、浏览器测试或多版本矩阵。

### 能带来什么效果

- 把“打包产物能否在目标 DSH 上真实启动”从手工步骤变成可重复执行的冒烟测试。
- 通过隔离 HOME 和 Profile 避免本机配置及上一次运行残留影响结果。
- 自动记录插件包 SHA-256、容器退出码、步骤耗时、峰值内存、峰值 CPU 样本和失败分类。
- 自动生成 JSON 与 Markdown 报告，并对常见 token、key、secret、password 和 Bearer 凭据做脱敏。
- 默认把运行目录和报告放在操作系统临时目录；原始日志与临时 Profile 在报告生成后删除，不向 Skill 目录写入缓存或测试产物。

## 关联 Issue

没有需要自动关闭的 Issue。本 PR 是一个独立的 `plugin-test` 能力补充，并且没有修改当前开放 PR 正在修改的文件。

## 复现

基础版本 `e0dd21295ee91386d9a573643b529dadb0fe015f` 中，`plugin-test` 描述了精确版本、打包产物、隔离 Profile 和冷启动要求，但不存在 Dockerfile、Compose 文件、可复用 runner、资源采集器或自动报告生成器。现有 `docs/validation-report-2026-08-30.md` 只能提供一次性的手工 Docker 命令。

实测环境为 Windows 主机、Docker Desktop 4.80.0、Docker Engine 29.6.1、Linux `amd64` 容器。测试插件在系统临时目录中打包，不属于本 PR 文件。

## 根因

现有 Skill 拥有测试规则，但没有负责执行这些规则的标准化边界：宿主侧没有管理临时目录、容器生命周期、资源采样和报告；容器侧没有统一完成精确 DSH 安装、版本核对、插件安装、冷启动、探针和退出。结果是规范可以指导人工验证，却不能产出结构一致、可机器读取的证据。

## 修复

- 新增宿主侧 `docker-release-smoke.mjs`，校验结构化 JSON 配置和精确版本，计算插件包 SHA-256，以只读方式挂载输入，采样 `docker stats`，脱敏日志并生成两种报告。
- 新增容器侧 `container-runner.mjs`，安装精确 pnpm 与 `@deepseek-ai/dsh`，读取包元数据核对解析版本，通过真实 `dsh plugin --profile ... add` 安装 tarball，冷启动配置的 DSH 入口，执行可选 argv 探针并验证退出清理。
- 所有命令都通过 argv 执行，不经过 shell 字符串插值；容器、原始日志和隔离 Profile 在 `finally` 路径清理。
- 新增配置校验、Docker 内存单位解析、日志脱敏、失败分类和报告生成的单元测试。
- 在 `plugin-test` 和引用索引中加入该能力的使用入口、适用范围与限制。

## 验证

以下命令均已实际运行并通过：

```text
node --check skills/plugin-test/scripts/docker-release-smoke.mjs
node --check skills/plugin-test/scripts/container-runner.mjs
node --check skills/plugin-test/scripts/docker-release-smoke.test.mjs
node --test skills/plugin-test/scripts/docker-release-smoke.test.mjs
npm test
git diff origin/main...HEAD --check
```

单元测试结果为 6 项通过、0 项失败。

最终真实 Docker 验证使用 `node:24-bookworm`、pnpm `11.24.0` 和 `@deepseek-ai/dsh@0.1.2-alpha.2`。临时插件 tarball 经真实插件命令安装并成功激活，`dsh web --no-open` 冷启动成功，TCP 功能探针通过，SIGTERM 清理通过，容器退出码为 0。总耗时 94113 毫秒，45 次资源采样中的峰值内存为 517262541 字节，峰值 CPU 样本为 185.12%。

验证过程中还执行过一次未携带 DSH 页面 token 的 HTTP 探针；runner 正确将其分类为 `probe` 失败，并将启动 URL 中的 token 替换为 `[REDACTED]`。随后只调整系统临时目录中的测试探针为 TCP 连通性检查，最终回归通过。

## 证据

- 实现 commit：`945006e050b66ba2b1c55b0c2096c1b3804b876a`
- 基础 commit：`e0dd21295ee91386d9a573643b529dadb0fe015f`
- 实测容器镜像 ID：`sha256:be23f54a88d34e8824c741b19b91064094f92c1c97b194144bfc8b50d67258e2`
- 临时插件包 SHA-256：`d2474a40a652a85de4ee1f6c54131a1a4cd2a152f02951cf62666e1f11444c6f`
- 最终脱敏 JSON 报告 SHA-256：`e752c0e87ecf95d9a160c92a79ec4a6a1c4b65455f117a50e24049f3ffb6b1c8`

脱敏报告保留在本机系统临时目录，没有提交到仓库，避免把运行产物混入 Skill。

## 限制与剩余风险

- 未运行真实供应商凭据流程、浏览器测试、全面安全扫描、完整性能基准、多操作系统或多 DSH 版本矩阵。
- 本次实测使用带版本标签的 Node 镜像，并记录了实际镜像 ID；要求完全不可变的复现时应在配置中使用镜像 digest。
- 资源数据来自 `docker stats --no-stream` 的离散采样，只用于发现明显异常，不代表性能基准结论。
- 容器安装 DSH 时需要访问包注册表；私有依赖的凭据注入不在本 PR 范围内。

## 发布说明

`plugin-test` 现在包含一个基础 Docker 发布冒烟 runner，可在隔离环境中验证打包插件对精确 DSH 版本的安装、冷启动、可选功能探针和退出，并输出脱敏的 JSON 与 Markdown 报告。

## 致谢

该实现沿用了现有 `plugin-test` 的真实入口测试要求，并参考了 `docs/validation-report-2026-08-30.md` 中的一次性 Docker 验证经验。

---

# English

## Summary

### Why This Feature Is Needed

`plugin-test` already requires pre-release checks to use the packaged artifact, an exact DSH version, an isolated Profile, and a cold start through the real entry point. The repository, however, had only the rules and a one-off Docker reproduction record. Plugin maintainers still had to assemble container commands manually, with no common format for exit status, resource measurements, redacted logs, or reports. Evidence from the same upgrade was therefore difficult to compare across machines.

This PR adds the smallest missing execution layer: one command takes a plugin tarball into a fresh container, installs it on an exact DSH version, starts it, optionally probes it, shuts it down, and writes reports. It intentionally does not grow into a complete release platform and does not add security scanning, browser testing, or a version matrix.

### What It Enables

- Turns packaged-artifact startup validation from manual instructions into a repeatable smoke test.
- Isolates HOME and the DSH Profile so local configuration and previous runs cannot affect the result.
- Records the artifact SHA-256, container exit code, step durations, peak sampled memory and CPU, and a failure classification.
- Generates JSON and Markdown reports while redacting common token, key, secret, password, and Bearer credential forms.
- Uses operating-system temporary directories by default. Raw logs and the temporary Profile are removed after report generation, so caches and generated evidence are not written into the Skill directory.

## Related Issue

There is no Issue to close automatically. This PR is an independent `plugin-test` capability and does not modify files touched by currently open PRs.

## Reproduction

At base commit `e0dd21295ee91386d9a573643b529dadb0fe015f`, `plugin-test` documented exact-version, packaged-artifact, isolated-Profile, and cold-start requirements, but it provided no Dockerfile, Compose file, reusable runner, resource collector, or automatic report generator. The existing `docs/validation-report-2026-08-30.md` offered only one-off manual Docker commands.

The real test environment used a Windows host, Docker Desktop 4.80.0, Docker Engine 29.6.1, and Linux `amd64` containers. The test plugin was packed under the operating system temporary directory and is not part of this PR.

## Root Cause

The Skill owned the testing rules but had no standardized execution boundary for them. The host side did not manage temporary storage, container lifecycle, resource sampling, and reports; the container side did not consistently perform exact DSH installation, resolved-version verification, plugin installation, cold start, probe, and teardown. The guidance could support a manual test, but it could not produce structurally consistent, machine-readable evidence.

## Fix

- Add host-side `docker-release-smoke.mjs` to validate structured JSON configuration and exact versions, hash the artifact, mount inputs read-only, sample `docker stats`, redact logs, and generate both report formats.
- Add container-side `container-runner.mjs` to install exact pnpm and `@deepseek-ai/dsh` versions, verify package metadata, install the tarball through the real `dsh plugin --profile ... add` command, cold-start the configured DSH entry, run an optional argv probe, and verify teardown.
- Execute commands as argv without shell interpolation, and clean the container, raw logs, and isolated Profile through `finally` paths.
- Add unit coverage for configuration validation, Docker memory-unit parsing, log redaction, failure classification, and report generation.
- Add a focused usage entry and documented boundaries to `plugin-test` and its reference index.

## Verification

The following commands were actually run and passed:

```text
node --check skills/plugin-test/scripts/docker-release-smoke.mjs
node --check skills/plugin-test/scripts/container-runner.mjs
node --check skills/plugin-test/scripts/docker-release-smoke.test.mjs
node --test skills/plugin-test/scripts/docker-release-smoke.test.mjs
npm test
git diff origin/main...HEAD --check
```

The unit suite passed 6 tests with 0 failures.

The final real Docker run used `node:24-bookworm`, pnpm `11.24.0`, and `@deepseek-ai/dsh@0.1.2-alpha.2`. A temporary plugin tarball was installed through the real plugin command and activated successfully. `dsh web --no-open` cold-started, the TCP functional probe passed, SIGTERM teardown passed, and the container exited with code 0. The run took 94113 ms; 45 resource samples recorded peak memory of 517262541 bytes and a peak CPU sample of 185.12%.

During validation, an earlier HTTP probe without the generated DSH page token was also run. The runner correctly classified it as a `probe` failure and replaced the startup URL token with `[REDACTED]`. Only the temporary test probe was then changed to a TCP connectivity check, after which the final regression passed.

## Evidence

- Implementation commit: `945006e050b66ba2b1c55b0c2096c1b3804b876a`
- Base commit: `e0dd21295ee91386d9a573643b529dadb0fe015f`
- Tested container image ID: `sha256:be23f54a88d34e8824c741b19b91064094f92c1c97b194144bfc8b50d67258e2`
- Temporary plugin artifact SHA-256: `d2474a40a652a85de4ee1f6c54131a1a4cd2a152f02951cf62666e1f11444c6f`
- Final redacted JSON report SHA-256: `e752c0e87ecf95d9a160c92a79ec4a6a1c4b65455f117a50e24049f3ffb6b1c8`

The redacted report remains in the local operating-system temporary directory and was intentionally not committed, keeping runtime output out of the Skill.

## Limits And Residual Risk

- Real provider credential flows, browser tests, comprehensive security scanning, full performance benchmarking, and multi-operating-system or multi-DSH-version matrices were not run.
- This run used a version-tagged Node image and recorded its resolved image ID. Use an image digest in the config when fully immutable reproduction is required.
- Resource values are discrete `docker stats --no-stream` samples intended to reveal obvious anomalies, not performance benchmark results.
- Installing DSH requires package-registry access. Credential injection for private dependencies is outside this PR.

## Release Notes

`plugin-test` now includes a basic Docker release smoke runner that validates packaged-plugin installation, cold start, an optional functional probe, and teardown against an exact DSH version in isolation, then emits redacted JSON and Markdown reports.

## Acknowledgements

This implementation follows the existing real-entry testing requirements in `plugin-test` and builds on the one-off Docker validation experience documented in `docs/validation-report-2026-08-30.md`.
