### PR TITLE
feat(plugin-upgrade): add user-questions answerer waterfall card + preset/type-drift corridor notes

### DIFF
--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -224,7 +224,7 @@ for (const file of markdownFiles) {
 // The rollup is a current navigation document, not an unchecked historical snapshot.
 const rollupFile = join(referencesDir, 'rollup-0.1.2.md')
 const rollupText = await readFile(rollupFile, 'utf8')
-for (const required of ['（14 张）', '（6 张）', '#7 子进程']) {
+for (const required of ['（14 张）', '（7 张）', '#7 子进程']) {
   if (!rollupText.includes(required)) fail(rollupFile, `missing current rollup contract: ${required}`)
 }
 if (/Consumer.*永不 reject|#6 子进程|git checkout <tag> -- pnpm-lock\.yaml/.test(rollupText)) {

--- a/skills/plugin-upgrade/SKILL.md
+++ b/skills/plugin-upgrade/SKILL.md
@@ -105,7 +105,7 @@ description: 检查或升级已安装的 DSH（DeepSeek Harness）插件，或�
 | [references/README.md](references/README.md) | 版本走廊、卡片 schema 与维护规则 |
 | [references/pre-flight.md](references/pre-flight.md) | 七类触点自查与汇总模板 |
 | [references/v0.1.2-alpha.1.md](references/v0.1.2-alpha.1.md) | rc.2→alpha.1：14 张 curated 卡 |
-| [references/v0.1.2-alpha.2.md](references/v0.1.2-alpha.2.md) | alpha.1→alpha.2：6 张 curated 卡 |
+| [references/v0.1.2-alpha.2.md](references/v0.1.2-alpha.2.md) | alpha.1→alpha.2：7 张 curated 卡 |
 | [references/rollup-0.1.2.md](references/rollup-0.1.2.md) | 0.1.1 → 0.1.2 走廊（rollup）：跨 cohort 共存、未发布 cohort 安装、`RemoteResult` 错误流、分层验证清单；**基于 alpha.2，正式版需复核** |
 | [migration planner](../../docs/migration-planner.md) | 只读扫描目标仓库、连接卡片走廊并输出候选迁移计划 |
 | [examples/legacy-plugin/](examples/legacy-plugin/) | 七类触点静态夹具（不得执行） |

--- a/skills/plugin-upgrade/references/README.md
+++ b/skills/plugin-upgrade/references/README.md
@@ -11,7 +11,7 @@ alpha.1 删除、alpha.2 恢复时，不应先删再加。
 | 顺序 | 卡片文件 | from | to | 卡数 | 状态 / 覆盖 |
 |---|---|---|---|---:|---|
 | 1 | [v0.1.2-alpha.1.md](v0.1.2-alpha.1.md) | `dsh-v0.1.1-rc.2` | `dsh-v0.1.2-alpha.1` | 14 | reviewed / curated |
-| 2 | [v0.1.2-alpha.2.md](v0.1.2-alpha.2.md) | `dsh-v0.1.2-alpha.1` | `dsh-v0.1.2-alpha.2` | 6 | reviewed / curated |
+| 2 | [v0.1.2-alpha.2.md](v0.1.2-alpha.2.md) | `dsh-v0.1.2-alpha.1` | `dsh-v0.1.2-alpha.2` | 7 | reviewed / curated |
 | — | [rollup-0.1.2.md](rollup-0.1.2.md) | `dsh-v0.1.1-rc.2` → `dsh-v0.1.2-alpha.2` 全走廊 | rollup | 非卡片文件：走廊层增量（跨 cohort 共存、未发布 cohort 安装、`RemoteResult` 错误流、分层验证清单）；**基于 alpha.2，正式版需复核** |
 
 `curated` 表示只收录已识别的插件相关变化，**不表示完整 API diff**。走廊缺边时停止

--- a/skills/plugin-upgrade/references/api-migration-0.1.2-alpha.2.md
+++ b/skills/plugin-upgrade/references/api-migration-0.1.2-alpha.2.md
@@ -26,6 +26,8 @@
 | Headless process | `dsh headless`、`-p`、JSONL stdout、stderr 非空即失败 | argv 不被接受、JSON parse 失败、成功任务被误报 | `dsh --profile headless "task"`；stdout 是最终文本，stderr 是 reasoning/诊断，以退出码为准 |
 | Package subpath | 看到 `exports["./src/*"]` 就直接导入 | 发布包可能根本不含 `src`，运行时报 module not found | 同时核对 exports、`files` 和实际 packed artifact；优先 `.` / `/client` 等稳定入口 |
 | `cordis.patch.yml` | 按文件名当源码 patch | 误报并生成错误迁移任务 | 先按官方 Profile composition overlay 处理；只有真实替换宿主源码时才归源码 patch |
+| Structured questions answerer | `userQuestions.registerProvider({ ask })` | attach 抛 `TypeError`；提问无人 answer（`NO_PROVIDER`） | `ctx.on('user-questions/request', (req, next) => answer)`；不带 agent 的 `ask()` 在服务自身 ctx 派发，同 fiber 树其他 entry 的监听者收不到（详见 [DSH-0.1.2-A2-07](v0.1.2-alpha.2.md)） |
+| Type export drift | `CallId` / `JsonValue` / `collectSessionTitleMessages` / `todo/write` 类型声明 | typecheck 批量 TS2305 / TS2614 | 按 ledger 迁移：`ToolCallId`（dsh-llm 根导出）、`@deepseek-ai/dsh-util-values`、本地同语义折叠、本地 event-map 合并（详见 [rollup R-07](rollup-0.1.2.md)） |
 
 ## API-01 · APIProxy 迁到实际 `ctx.remote` projection
 

--- a/skills/plugin-upgrade/references/rollup-0.1.2.md
+++ b/skills/plugin-upgrade/references/rollup-0.1.2.md
@@ -7,7 +7,7 @@
 ## 怎么用这份 rollup
 
 1. 先按 [pre-flight.md](pre-flight.md) 测出命中的触点类；
-2. 按 `from → to` 读完整走廊并先计算净状态：[v0.1.2-alpha.1.md](v0.1.2-alpha.1.md)（14 张）→ [v0.1.2-alpha.2.md](v0.1.2-alpha.2.md)（6 张）；
+2. 按 `from → to` 读完整走廊并先计算净状态：[v0.1.2-alpha.1.md](v0.1.2-alpha.1.md)（14 张）→ [v0.1.2-alpha.2.md](v0.1.2-alpha.2.md)（7 张）；
 3. 回到本文件处理走廊层问题——这些跨越单版本，卡片里没有；
 4. 按本文件末尾的分层验证清单收工。
 
@@ -17,7 +17,7 @@
 |---|---|
 | #1 源码 patch | [DSH-0.1.2-A1-03](v0.1.2-alpha.1.md) |
 | #2 事件 / 持久事件 | [DSH-0.1.2-A1-02](v0.1.2-alpha.1.md) → [DSH-0.1.2-A2-01](v0.1.2-alpha.2.md)，另见 [DSH-0.1.2-A1-06](v0.1.2-alpha.1.md) |
-| #3 服务 / Remote | [DSH-0.1.2-A1-01](v0.1.2-alpha.1.md)、[DSH-0.1.2-A1-06](v0.1.2-alpha.1.md)、[DSH-0.1.2-A1-11](v0.1.2-alpha.1.md)、[DSH-0.1.2-A2-02](v0.1.2-alpha.2.md)、[DSH-0.1.2-A2-05](v0.1.2-alpha.2.md)、[DSH-0.1.2-A2-06](v0.1.2-alpha.2.md) |
+| #3 服务 / Remote | [DSH-0.1.2-A1-01](v0.1.2-alpha.1.md)、[DSH-0.1.2-A1-06](v0.1.2-alpha.1.md)、[DSH-0.1.2-A1-11](v0.1.2-alpha.1.md)、[DSH-0.1.2-A2-02](v0.1.2-alpha.2.md)、[DSH-0.1.2-A2-05](v0.1.2-alpha.2.md)、[DSH-0.1.2-A2-06](v0.1.2-alpha.2.md)、[DSH-0.1.2-A2-07](v0.1.2-alpha.2.md) |
 | #4 宿主目录读写 | [DSH-0.1.2-A1-04](v0.1.2-alpha.1.md)、[DSH-0.1.2-A1-13](v0.1.2-alpha.1.md) |
 | #5 UI / 命令 / 工具 | [DSH-0.1.2-A1-03](v0.1.2-alpha.1.md)、[DSH-0.1.2-A1-06](v0.1.2-alpha.1.md)、[DSH-0.1.2-A1-09](v0.1.2-alpha.1.md)、[DSH-0.1.2-A1-10](v0.1.2-alpha.1.md)、[DSH-0.1.2-A1-11](v0.1.2-alpha.1.md) |
 | #6 自建 HTTP/WS/RPC/DOM/CSS | [DSH-0.1.2-A1-08](v0.1.2-alpha.1.md) |
@@ -139,6 +139,39 @@ return result.value
 - **配方**: 迁移前先对全部插件跑一次「import 了哪些被删包」的盘点，把「必须退役」与「可迁移」分开排期，而不是边迁边发现。
 - **验证**: 盘点清单与实际迁移结果一致，无中途新增退役项。
 - **来源**: [#5120](https://github.com/deepseek-ai/deepseek-harness/discussions/5120) 第 10 条。
+
+### R-06 · base-only profile 挂 shipped preset 的新前置（Host scope 服务与同名遮蔽）
+
+- **类型**: behavior
+- **症状**: 仅组合 `dsh-base`（+ 自家 bundle）的 profile 上，挂 shipped `standard` preset 失败：`tool-subagent: modelSelectionSettings requires @deepseek-ai/dsh-tool-subagent/model-selection-settings in the Host scope`；用自定义 root 里同名空 preset 想遮蔽 shipped 时，遮蔽不生效——发现顺序 shipped 优先。
+- **配方**:
+  - Host composition（bundle 的 `cordis.patch.yml`）补一行 `@deepseek-ai/dsh-tool-subagent/model-selection-settings`（官方 web-app bundle 有此行，`dsh-base` 没有）：
+
+    ```yaml
+    - insert:
+        - id: subagent-model-selection-settings
+          name: '@deepseek-ai/dsh-tool-subagent/model-selection-settings'
+    ```
+
+  - 测试/受控面想用自己的同名 preset 时，agent-presets 配置加 `includeShippedRoot: false`，否则自定义 root 的同名行被 shipped 行遮蔽。
+- **验证**: base-only profile 冷启动无「启动默认预设未生效」警告且 `composedPreset` 返回 standard；`includeShippedRoot: false` 下自定义同名 preset 确实被挂载（而非 shipped 版本）。
+- **来源**: [alpha.2 discovery.ts 健康检查](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/preset/agent-presets/src/discovery.ts) · [alpha.2 standard preset 的 tool-subagent 行](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/preset/agent-presets/presets/standard/agent.cordis.yml) · [官方 web-app bundle 宿主行](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/bundle/web-app/cordis.patch.yml) · dsh-tui 实测（2026-08-30，cordis.patch.yml + preset-join composition 测试）
+
+### R-07 · 0.1.2 类型面导出漂移（未入 release notes 的 ledger）
+
+- **类型**: breaking（typecheck 面）
+- **症状**: rc.2 可直接导入的多个类型/函数在 alpha.2 移包或移出公开面，typecheck 批量 TS2305/TS2614；运行时不一定同步崩，属于「静态漂移」。
+- **配方**（ledger，2026-08-30 按 npm tarball 导出比对）:
+
+  | 旧 | 新 |
+  |---|---|
+  | `CallId` from `@deepseek-ai/dsh-llm` | `ToolCallId`（同包根导出，branded） |
+  | `JsonValue` from `@deepseek-ai/dsh-session` | `@deepseek-ai/dsh-util-values`（补直接依赖，见 [DSH-0.1.2-A2-03](v0.1.2-alpha.2.md)） |
+  | `collectSessionTitleMessages` from `@deepseek-ai/dsh-session-title` | 移出公开面——按 rc.2 同语义本地折叠（首条 `source.kind === 'user'` 的 `user/message` 文本）或走 `foldSessionTitle` |
+  | `'todo/write'` 的 `SessionEventMap` 类型声明 | 只在 `@deepseek-ai/dsh-tool-todo` 内合并；不依赖该包时本地按官方 `TodoItem` 结构补 `declare module '@deepseek-ai/dsh-session/types'`（runtime 事件词汇未变，`known-event-types` 仍收录） |
+
+- **验证**: typecheck 全绿且不靠 `@ts-ignore`；本地合并的声明与官方结构逐字段一致；运行时事件流与 rc.2 相同。
+- **来源**: 各包 `0.1.2-alpha.2` tarball 导出比对 + [alpha.2 todo 工具 types.ts](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/todo/tool-todo/src/types.ts) · dsh-tui 实测（2026-08-30）
 
 ## 分层验证清单
 

--- a/skills/plugin-upgrade/references/v0.1.2-alpha.2.md
+++ b/skills/plugin-upgrade/references/v0.1.2-alpha.2.md
@@ -5,7 +5,7 @@ from: dsh-v0.1.2-alpha.1
 to: dsh-v0.1.2-alpha.2
 status: reviewed
 coverage: curated
-cardCount: 6
+cardCount: 7
 idPrefix: DSH-0.1.2-A2
 verifiedAt: 2026-08-30
 ---
@@ -79,6 +79,7 @@ verifiedAt: 2026-08-30
 - **迁移配方**: 先按 lockfile 选择仓库现用的唯一包管理器；在隔离目录用 frozen lockfile/等价模式验证。检查插件实际 import 的类型/运行时包，补直接依赖；逐条证明 override 只为已裁剪 peer 服务后再删除，不切换包管理器、不重写另一套 lockfile。
 - **验证**: 安装与 typecheck 成功；没有新增与目标升级相关的 peer/缺包错误；依赖图和打包产物只出现预期变化。
 - **来源**: [alpha.2 release notes「问题修复」](https://github.com/deepseek-ai/deepseek-harness/releases/tag/dsh-v0.1.2-alpha.2)
+- **实战批注**（2026-08-30，dsh-tui 依赖树实测）: 两个会绕过常规「补直接依赖」检查的坑：① `legacy-peer-deps=true` 会让 npm 跳过 alpha.2 官方 CLI 的 peer `@deepseek-ai/cordis-plugin-group`（`dsh-app-boot` 顶层 import），npx 缓存树残缺、CLI 启动即 `ERR_MODULE_NOT_FOUND`——安装/重建 CLI 树必须用干净 npmrc；② `dsh-subagent` 把 `@deepseek-ai/dsh-util-time` 声明在 `optionalDependencies`，但 `lib/index.js` 顶层无条件 import——npm 跳过 optional 后运行时才崩，静态安装与 typecheck 均不报错。验证清单应加「依赖树冷启动」而不只是安装成功。
 
 ---
 
@@ -118,6 +119,33 @@ verifiedAt: 2026-08-30
 - **迁移配方**: alpha.2 读取 `ctx.remote.$host.home`（首个 ready 帧前可为 `undefined`）和 `ctx.remote.$host.isLoopback`。`$host` 不是 store、没有订阅或 generation counter；需要响应重连时监听 `connection/reset`，不要轮询它。
 - **验证**: ready 前后分别检查 `home`；loopback/非 loopback 连接核对布尔值；重连路径由 `connection/reset` 驱动。
 - **来源**: [alpha.2 API gateway README](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/api/gateway/README.md) · [alpha.2 APIProxy→Remote note](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/.agents/notes/implemented/architecture/2026-08-10-unary-apiproxy-remote-migration.md)
+
+### DSH-0.1.2-A2-07 · `userQuestions.registerProvider` 移除，answerer 迁到 `'user-questions/request'` waterfall
+
+- **类型**: breaking
+- **适用对象**: 注册结构化提问 answerer 的宿主 UI 插件（宿主内 TUI 类 answerer；官方 web client 经 Remote 桥接不受影响）
+- **影响触点**: #3
+- **操作级别**: required-if-hit
+- **症状**: `ctx.userQuestions.registerProvider(...)` 消失——attach/装配期抛 `TypeError: userQuestions.registerProvider is not a function`；提问无人 answer，调用方挂起或收到 `NO_PROVIDER`。
+- **迁移配方**: answerer 改为注册 Cordis waterfall 事件 `'user-questions/request'`（事件与词汇类型经 `@deepseek-ai/dsh-user-questions` 的 module augmentation 合并）：
+
+  ```typescript
+  // 旧（rc.2）：服务级 provider
+  const userQuestions = ctx.reflect.get('userQuestions', false)
+  if (userQuestions !== undefined) {
+    this.disposer = userQuestions.registerProvider({ ask: req => this.handle(req) })
+  }
+
+  // 新（alpha.2）：return answer 即 claim；需要让位给链上其他 answerer 才调 next()
+  this.disposer = ctx.on('user-questions/request', (request, next) => this.handle(request))
+  ```
+
+  claim/委托语义：返回 `AskUserQuestionAnswer` 即接管该请求；取消语义不变——挂起被取消时 reject `UserQuestionError('...', 'ASK_CANCELLED')`，不要 resolve 空 answer。
+
+  **scope 过滤的坑**：`ctx.userQuestions.ask()` 不带 `agent` 时在 userQuestions 服务**自身 ctx** 上派发，同一 fiber 树其他 entry（如 TUI runner）注册的监听者**收不到**；带 live `agent` 时经 `scopeTarget(agent, agent)` scope-filtered 派发，无 scope 标签的监听者必然被投递。迁移前先确认调用方按 wire 语义携带 agent——不要在未查证前把监听器注册到 `ctx.root` 来「修」收不到的问题。
+- **验证**: 真实 spine 下 `ask` 挂起 → 面板渲染 → 数字键结算 resolve；Esc 取消 reject `ASK_CANCELLED`；切会话/dispose 后挂起提问 fail-closed 且监听 disposer 已释放（重复 attach 不叠加）；不带 agent 的 ask 在同一 fiber 树其他 entry 的监听者处不可达（记录为已知语义而非回归）。
+- **来源**: [alpha.2 user-questions 服务](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/interaction/user-questions/src/index.ts) · [answerer waterfall 类型契约](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/interaction/user-questions/src/types.ts) · [官方 tripwire answerer fixture](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/test-support/session-snapshot/tests/fixtures/child-question-tripwire.ts)
+- **实战批注**（2026-08-30，dsh-tui@0.1.2-rc.28 → alpha.2）: 注册改为 waterfall 后，unscoped `ask()`（不带 agent）确实无法送达同 fiber 树其他 entry 的监听者——loader-composition 测试先按 rc.2 语义不带 agent 调用，面板不渲染；改按 wire 语义携带 live agent 后立即可达。
 
 ---
 


### PR DESCRIPTION
## 变更摘要

来自 [dsh-tui](https://github.com/huiliyi37/dsh-tianshu-tui)（@huiliyi37/dsh-tianshu-tui）从 `dsh-v0.1.1-rc.2` 到 `dsh-v0.1.2-alpha.2` 的真实迁移实测，补齐现有卡片未覆盖的三块内容：

1. **新卡 DSH-0.1.2-A2-07**（`v0.1.2-alpha.2.md`）：`userQuestions.registerProvider` 在 alpha.2 移除，answerer 迁到 `ctx.on('user-questions/request')` waterfall——含 claim/委托语义、`ASK_CANCELLED` 取消契约，以及实测发现的 scope 过滤坑：不带 `agent` 的 `ask()` 在服务自身 ctx 派发，同 fiber 树其他 entry 的监听者收不到，必须按 wire 语义携带 live agent。
2. **rollup R-06**：base-only profile（dsh-base + 自家 bundle）挂 shipped `standard` preset 的新前置——Host scope 需要 `@deepseek-ai/dsh-tool-subagent/model-selection-settings` 行（官方 web-app bundle 有、dsh-base 没有）；shipped preset 发现顺序先于自定义 root，同名空 preset 遮蔽失效（需 `includeShippedRoot: false`）。
3. **rollup R-07**：未入 release notes 的类型面导出漂移 ledger——`CallId`→`ToolCallId`、`JsonValue`→`@deepseek-ai/dsh-util-values`、`collectSessionTitleMessages` 移出公开面、`todo/write` 类型声明只在 `dsh-tool-todo` 合并。

另给 A2-03 补一条实战批注：`legacy-peer-deps=true` 会让 npm 跳过官方 CLI 的 peer `cordis-plugin-group`（CLI 启动即崩）、`dsh-subagent` 把 `dsh-util-time` 放 optionalDependencies 但顶层无条件 import——验证清单应加「依赖树冷启动」。

## 一手来源

- [alpha.2 user-questions 服务](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/interaction/user-questions/src/index.ts) / [waterfall 类型契约](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/interaction/user-questions/src/types.ts) / [官方 tripwire fixture](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/test-support/session-snapshot/tests/fixtures/child-question-tripwire.ts)
- [alpha.2 discovery.ts 健康检查](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/preset/agent-presets/src/discovery.ts) / [standard preset 的 tool-subagent 行](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/preset/agent-presets/presets/standard/agent.cordis.yml) / [web-app bundle 宿主行](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/bundle/web-app/cordis.patch.yml)
- 各包 `0.1.2-alpha.2` npm tarball 导出比对（R-07 ledger）

## 已运行验证

```
node scripts/validate.mjs        # Validation OK: 3 skill, 2 card sets, 21 cards, 30 Markdown files, 7 touchpoint fixtures, 2 face contracts, read-only planner
node scripts/validate-manifests.mjs  # 清单校验通过：4 个清单，版本 0.2.0
```

卡数 6→7 已同步 references 索引、SKILL.md 参考表与 validate.mjs 的 rollup 计数门。

## 致谢

- dsh-tui（@huiliyi37/dsh-tianshu-tui）0.1.2-rc.28 → alpha.2 迁移实测；相关测试：loader-composition / preset-join composition 真实 spine 装配。
- 上游仓库的卡 schema 与 rollup 走廊结构。