### PR TITLE
feat(plugin-write): add naming policy and central registry checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Claude Code 中按名字调用 skill（插件安装后带命名空间）：
 | Skill | 说明 | 版本覆盖 |
 | --- | --- | --- |
 | [plugin-upgrade](skills/plugin-upgrade/) | 三模式安全升级：只读检查、已安装插件升级、DSH 宿主兼容迁移；含七类触点、版本卡片与回滚约束 | 0.1.1 → 0.1.2 |
-| [plugin-write](skills/plugin-write/) | 按目标 Harness 合约编写 DSH 插件，区分官方单仓包与外部可安装插件 | 按目标 Harness 版本 |
+| [plugin-write](skills/plugin-write/) | 按目标 Harness 合约编写 DSH 插件，分离本地命名校验与可选中央注册冲突查询 | 按目标 Harness 版本 |
 | [plugin-test](skills/plugin-test/) | 为 DSH 插件变更选择最小充分测试层级，覆盖单元测试、覆盖率、真实 API、快照、Web 及真实发布入口 | 跨版本验证 |
 | [plugin-release](skills/plugin-release/) | 打包、发布与分发 DSH 插件：发布轨选择、未发布 cohort 安装、CI 门禁与回滚 | 跨版本 |
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "test": "npm run validate",
     "validate": "node scripts/validate.mjs && node scripts/validate-manifests.mjs",
     "validate:skills": "node scripts/validate.mjs",
-    "validate:manifests": "node scripts/validate-manifests.mjs"
+    "validate:manifests": "node scripts/validate-manifests.mjs",
+    "validate:naming": "node skills/plugin-write/scripts/validate-names.check.mjs"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "validate": "node scripts/validate.mjs && node scripts/validate-manifests.mjs",
     "validate:skills": "node scripts/validate.mjs",
     "validate:manifests": "node scripts/validate-manifests.mjs",
-    "validate:naming": "node skills/plugin-write/scripts/validate-names.check.mjs"
+    "validate:naming": "node skills/plugin-write/scripts/validate-names.check.mjs",
+    "validate:registry": "node skills/plugin-write/scripts/query-registry.check.mjs"
   }
 }

--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -267,10 +267,19 @@ try {
   fail(namingCheckFile, `naming validator check failed: ${error.stack ?? error.message}`)
 }
 
+// The online phase must consume only registry v2, preserve offline validation, and distinguish unavailable from free.
+const registryCheckFile = join(root, 'skills', 'plugin-write', 'scripts', 'query-registry.check.mjs')
+try {
+  const { runRegistryQueryChecks } = await import(pathToFileURL(registryCheckFile).href)
+  await runRegistryQueryChecks()
+} catch (error) {
+  fail(registryCheckFile, `registry query check failed: ${error.stack ?? error.message}`)
+}
+
 if (failures.length) {
   console.error(`Validation failed (${failures.length}):`)
   for (const failure of failures) console.error(`- ${failure}`)
   process.exit(1)
 }
 
-console.log(`Validation OK: ${skillEntries.length} skill, ${cardFiles.length} card sets, ${totalCards} cards, ${markdownFiles.length} Markdown files, 7 touchpoint fixtures, 2 face contracts, read-only planner, offline naming validator`)
+console.log(`Validation OK: ${skillEntries.length} skill, ${cardFiles.length} card sets, ${totalCards} cards, ${markdownFiles.length} Markdown files, 7 touchpoint fixtures, 2 face contracts, read-only planner, offline naming validator, read-only registry v2 query`)

--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -258,10 +258,19 @@ try {
   fail(plannerCheckFile, `migration planner check failed: ${error.stack ?? error.message}`)
 }
 
+// Official compatibility, community recommendations, collision semantics, and CLI behavior must agree.
+const namingCheckFile = join(root, 'skills', 'plugin-write', 'scripts', 'validate-names.check.mjs')
+try {
+  const { runNamingValidatorChecks } = await import(pathToFileURL(namingCheckFile).href)
+  await runNamingValidatorChecks()
+} catch (error) {
+  fail(namingCheckFile, `naming validator check failed: ${error.stack ?? error.message}`)
+}
+
 if (failures.length) {
   console.error(`Validation failed (${failures.length}):`)
   for (const failure of failures) console.error(`- ${failure}`)
   process.exit(1)
 }
 
-console.log(`Validation OK: ${skillEntries.length} skill, ${cardFiles.length} card sets, ${totalCards} cards, ${markdownFiles.length} Markdown files, 7 touchpoint fixtures, 2 face contracts, read-only planner`)
+console.log(`Validation OK: ${skillEntries.length} skill, ${cardFiles.length} card sets, ${totalCards} cards, ${markdownFiles.length} Markdown files, 7 touchpoint fixtures, 2 face contracts, read-only planner, offline naming validator`)

--- a/skills/plugin-write/SKILL.md
+++ b/skills/plugin-write/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: plugin-write
-description: Use when creating a DeepSeek Harness plugin, choosing public names for a new external DSH plugin, validating a dsh-plugin.naming.json manifest, or creating a workspace package inside the deepseek-harness repository. Covers the full workflow from repository-mode and plugin-form selection through offline naming checks and package validation. Routes tool, LLM adapter, hook, service, and configuration forms to their corresponding references while separating upstream-monorepo rules from external-package rules. For an existing plugin crossing Harness versions, use this Skill's built-in version-adaptation workflow before implementing against the exact target contract.
+description: Use when creating a DeepSeek Harness plugin, choosing public names for a new external DSH plugin, validating a dsh-plugin.naming.json manifest, checking reviewed central registrations for known conflicts, or creating a workspace package inside the deepseek-harness repository. Covers the full workflow from repository-mode and plugin-form selection through separate offline naming validation, optional online registry lookup, and package validation. Routes tool, LLM adapter, hook, service, and configuration forms to their corresponding references while separating upstream-monorepo rules from external-package rules. For an existing plugin crossing Harness versions, use this Skill's built-in version-adaptation workflow before implementing against the exact target contract.
 ---
 
 # Write DeepSeek Harness Plugins
@@ -18,6 +18,8 @@ Create a plugin package. First classify the repository mode and plugin form, the
 Derive Cordis, Schemastery, and DSH package names and version ranges from the manifest of the exact target version. Current examples use scoped `@deepseek-ai/*` identifiers. Older targets may differ and must follow their own published contracts.
 
 For every new external plugin, read [`references/naming-conventions.md`](references/naming-conventions.md) before choosing public identifiers. Create `dsh-plugin.naming.json` at the plugin repository root and run the bundled read-only validator before final package validation. Treat compatibility errors as target-contract failures and prefix warnings as community recommendations; use `--strict` only when the plugin adopts the collision-resistant profile. This is not an official Harness manifest or a global reservation. For an existing external plugin, report naming deviations but preserve published names unless the user explicitly authorizes a compatibility-breaking rename. Packages inside the official monorepo follow the exact target checkout instead of this external naming profile.
+
+After the offline declaration passes, read [`references/registry-check.md`](references/registry-check.md) and run the separate central lookup when public network access is available. Supply the exact target Harness version. Treat a completed no-match result only as “no reviewed match”; treat timeout, malformed data, unsupported contract, or network failure as “unknown/not checked.” Never let the online lookup modify the local manifest, automatically rename a published surface, or turn an automated discovery candidate into a reservation. A formal reservation exists only after a source-backed entry is reviewed and merged in the central registry.
 
 ## Then Classify the Plugin Form
 
@@ -90,7 +92,7 @@ A plugin may combine forms freely, such as a configurable tool plugin or a servi
    - **Consumer-visible gap** — State the exact missing operation or condition, its consequence, and any maintainer constraint.
    ````
 
-6. **Validate** — For a new external plugin, first run `node <plugin-write-skill>/scripts/validate-names.mjs --manifest ./dsh-plugin.naming.json`; add `--strict` only for the collision-resistant community profile. Then run the applicable validation block below, focused checks, and coverage gate required by the changed behavior.
+6. **Validate** — For a new external plugin, first run `node <plugin-write-skill>/scripts/validate-names.mjs --manifest ./dsh-plugin.naming.json`; add `--strict` only for the collision-resistant community profile. After it passes, run `node <plugin-write-skill>/scripts/query-registry.mjs --manifest ./dsh-plugin.naming.json --harness-version <exact-semver>` when network access is available, and report an unavailable query as unknown rather than available. Then run the applicable validation block below, focused checks, and coverage gate required by the changed behavior.
 
 ## Rules While Writing
 

--- a/skills/plugin-write/SKILL.md
+++ b/skills/plugin-write/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: plugin-write
-description: Use when creating a DeepSeek Harness plugin, an external DSH plugin package, or a workspace package inside the deepseek-harness repository. Covers the full workflow from plugin-form selection through validation. Routes tool, LLM adapter, hook, service, and configuration forms to their corresponding references while separating upstream-monorepo rules from external-package rules. For an existing plugin crossing Harness versions, use this Skill's built-in version-adaptation workflow before implementing against the exact target contract.
+description: Use when creating a DeepSeek Harness plugin, choosing public names for a new external DSH plugin, validating a dsh-plugin.naming.json manifest, or creating a workspace package inside the deepseek-harness repository. Covers the full workflow from repository-mode and plugin-form selection through offline naming checks and package validation. Routes tool, LLM adapter, hook, service, and configuration forms to their corresponding references while separating upstream-monorepo rules from external-package rules. For an existing plugin crossing Harness versions, use this Skill's built-in version-adaptation workflow before implementing against the exact target contract.
 ---
 
 # Write DeepSeek Harness Plugins
@@ -16,6 +16,8 @@ Create a plugin package. First classify the repository mode and plugin form, the
 | An existing plugin being adapted to a new DSH host | Read [`references/version-adaptation.md`](references/version-adaptation.md), build the complete version corridor, and run the seven-class touchpoint preflight. If a change is `breaking` and the user has not yet authorized implementation, present the migration plan and wait for confirmation. After authorization, complete the version adaptation before using this Skill's form references. Form examples must never override target source, type declarations, or release notes. |
 
 Derive Cordis, Schemastery, and DSH package names and version ranges from the manifest of the exact target version. Current examples use scoped `@deepseek-ai/*` identifiers. Older targets may differ and must follow their own published contracts.
+
+For every new external plugin, read [`references/naming-conventions.md`](references/naming-conventions.md) before choosing public identifiers. Create `dsh-plugin.naming.json` at the plugin repository root and run the bundled read-only validator before final package validation. Treat compatibility errors as target-contract failures and prefix warnings as community recommendations; use `--strict` only when the plugin adopts the collision-resistant profile. This is not an official Harness manifest or a global reservation. For an existing external plugin, report naming deviations but preserve published names unless the user explicitly authorizes a compatibility-breaking rename. Packages inside the official monorepo follow the exact target checkout instead of this external naming profile.
 
 ## Then Classify the Plugin Form
 
@@ -54,7 +56,7 @@ A plugin may combine forms freely, such as a configurable tool plugin or a servi
 
 2. **Register an in-repository package** — Only in the official monorepo, add the package to the Host or Client aggregate exactly as required by the development guide in the target checkout. A normal package belongs to one aggregate only. Do not copy historical exceptions or file lists without checking the target version. External plugins must never modify Harness root configuration.
 
-3. **Create an external package** — Preserve the existing package manager and build system. Keep `main`, `types`, `exports`, `files`, optional `bin`, packaged-composition or Profile metadata, and the packed tarball consistent. Declare every runtime dependency explicitly and mirror the DSH peer dependencies needed for compilation in development dependencies. Do not make a publishable external plugin `private` or give it workspace version ranges merely because an in-repository template does so.
+3. **Create an external package** — Preserve the existing package manager and build system. For a new plugin, apply the external naming policy and include a validated `dsh-plugin.naming.json`; for an existing plugin, do not silently rename public surfaces. Keep `main`, `types`, `exports`, `files`, optional `bin`, packaged-composition or Profile metadata, and the packed tarball consistent. Declare every runtime dependency explicitly and mirror the DSH peer dependencies needed for compilation in development dependencies. Do not make a publishable external plugin `private` or give it workspace version ranges merely because an in-repository template does so.
 
 4. **Choose the package topology** — For a replaceable capability, split service definition, provider, and consumer into separate packages only when they will evolve independently. Keep a single-purpose plugin in one package.
 
@@ -88,7 +90,7 @@ A plugin may combine forms freely, such as a configurable tool plugin or a servi
    - **Consumer-visible gap** — State the exact missing operation or condition, its consequence, and any maintainer constraint.
    ````
 
-6. **Validate** — Run the applicable validation block below, then run the focused checks and coverage gate required by the changed behavior.
+6. **Validate** — For a new external plugin, first run `node <plugin-write-skill>/scripts/validate-names.mjs --manifest ./dsh-plugin.naming.json`; add `--strict` only for the collision-resistant community profile. Then run the applicable validation block below, focused checks, and coverage gate required by the changed behavior.
 
 ## Rules While Writing
 

--- a/skills/plugin-write/references/README.md
+++ b/skills/plugin-write/references/README.md
@@ -4,6 +4,7 @@ Read only the file needed for the task:
 
 | File | When to read it |
 |---|---|
+| [naming-conventions.md](naming-conventions.md) | Check official naming compatibility and optional community collision recommendations |
 | [version-adaptation.md](version-adaptation.md) | Adapt an existing plugin to a new Harness version |
 | [tool-plugin.md](tool-plugin.md) | Write a model-callable tool |
 | [llm-adapter-plugin.md](llm-adapter-plugin.md) | Connect a model provider |
@@ -11,5 +12,5 @@ Read only the file needed for the task:
 | [service-plugin.md](service-plugin.md) | Expose a service to other plugins |
 | [config-plugin.md](config-plugin.md) | Define configurable plugin behavior |
 
-For a new plugin, read the matching form reference directly. For a version adaptation, read
-`version-adaptation.md` first and then the matching form reference.
+For a new external plugin, read `naming-conventions.md` and the matching form reference. For a
+version adaptation, read `version-adaptation.md` first and then the matching form reference.

--- a/skills/plugin-write/references/README.md
+++ b/skills/plugin-write/references/README.md
@@ -5,6 +5,7 @@ Read only the file needed for the task:
 | File | When to read it |
 |---|---|
 | [naming-conventions.md](naming-conventions.md) | Check official naming compatibility and optional community collision recommendations |
+| [registry-check.md](registry-check.md) | Query reviewed central registrations after offline naming validation and prepare a contextual registration |
 | [version-adaptation.md](version-adaptation.md) | Adapt an existing plugin to a new Harness version |
 | [tool-plugin.md](tool-plugin.md) | Write a model-callable tool |
 | [llm-adapter-plugin.md](llm-adapter-plugin.md) | Connect a model provider |
@@ -12,5 +13,6 @@ Read only the file needed for the task:
 | [service-plugin.md](service-plugin.md) | Expose a service to other plugins |
 | [config-plugin.md](config-plugin.md) | Define configurable plugin behavior |
 
-For a new external plugin, read `naming-conventions.md` and the matching form reference. For a
-version adaptation, read `version-adaptation.md` first and then the matching form reference.
+For a new external plugin, read `naming-conventions.md`, then `registry-check.md` when a central lookup
+or registration is needed, plus the matching form reference. For a version adaptation, read
+`version-adaptation.md` first and then the matching form reference.

--- a/skills/plugin-write/references/naming-conventions.md
+++ b/skills/plugin-write/references/naming-conventions.md
@@ -1,0 +1,101 @@
+# External Plugin Naming Compatibility
+
+This is a community compatibility profile, not an official DeepSeek Harness naming standard. It was verified on 2026-08-31 against [`dsh-v0.1.2-alpha.2`](https://github.com/deepseek-ai/deepseek-harness/tree/0a53fb55bea101816fa226bb964ae2bed71c343b). Recheck the exact target Harness version before treating an upstream grammar or collision rule as current.
+
+The profile has two layers:
+
+- **Compatibility errors** identify malformed declarations or names rejected by the verified Harness or npm grammar.
+- **Collision recommendations** add publisher-aware prefixes for a new community plugin. They are warnings because official short names such as `greet`, `metrics`, `hello`, and `my-plugin` remain valid.
+
+Do not rename an existing public name merely to clear a recommendation. A tool, command, service, Skill, settings namespace, event, or route rename is a compatibility change.
+
+## Official baseline and community additions
+
+Official Harness uses several independent identities rather than one universal plugin ID:
+
+| Surface | Verified Harness behavior | This profile adds |
+|---|---|---|
+| Package | A bundle is declared by `package.json#dsh.bundle`; the official tutorial uses `dsh-hello-plugin` | Accept unscoped `dsh-*` and scoped `@scope/dsh-*` packages |
+| Plugin module name | A plugin exports `name`, for example `hello-plugin` | Declare every exported plugin name in `pluginNames` |
+| Loader row ID | The row `id` is a stable composition key; later patch layers may intentionally override it | Declare IDs, but never treat every duplicate as a global conflict |
+| Service key | A service is a `ctx` key; Cordis isolation can host multiple instances in separate realms | Recommend a publisher-aware lower-camel prefix |
+| Tool name | Same-scope duplicates fail; an Agent scope can provide a nearer definition | Recommend a publisher-aware snake-case prefix |
+| Command name | Official grammar is `^[a-z][a-z0-9_-]*$`; same-scope duplicates fail and an Agent scope can shadow a global | Recommend a publisher-aware lowercase prefix |
+| Skill name | Official grammar is kebab-case; scopes, rank, provider order, and local order select a winner | Recommend a publisher-aware kebab prefix |
+| Skill provider | Same-scope provider names must be unique; `runtime` is officially reserved | Declare providers separately from Skill names |
+| Event | Official custom events follow `namespace/action`; events are shared channels, not exclusive registrations | Recommend a publisher-aware namespace without claiming ownership of the channel |
+| Settings namespace | Official grammar is `^[a-z][a-z0-9-]*$`; duplicate registration fails | Recommend a publisher-aware kebab prefix |
+| Web route | HTTP routes collide only for the same `kind` and `path`; exact, prefix, and upgrade registrations are distinct | Record `{ kind, path }` instead of losing the route kind |
+
+Primary sources: [first plugin](https://github.com/deepseek-ai/deepseek-harness/blob/0a53fb55bea101816fa226bb964ae2bed71c343b/docs/user/develop/basic/index.zh.md), [bundle publishing and Loader layers](https://github.com/deepseek-ai/deepseek-harness/blob/0a53fb55bea101816fa226bb964ae2bed71c343b/docs/user/develop/basic/publish.zh.md), [services and isolation](https://github.com/deepseek-ai/deepseek-harness/blob/0a53fb55bea101816fa226bb964ae2bed71c343b/docs/user/develop/framework/service.zh.md), [commands](https://github.com/deepseek-ai/deepseek-harness/blob/0a53fb55bea101816fa226bb964ae2bed71c343b/packages/interaction/commands/README.zh.md), [Skills](https://github.com/deepseek-ai/deepseek-harness/blob/0a53fb55bea101816fa226bb964ae2bed71c343b/packages/skill/skill/README.zh.md), [settings](https://github.com/deepseek-ai/deepseek-harness/blob/0a53fb55bea101816fa226bb964ae2bed71c343b/packages/settings/settings/src/index.ts), and [Web routes](https://github.com/deepseek-ai/deepseek-harness/blob/0a53fb55bea101816fa226bb964ae2bed71c343b/packages/host/webserver/src/index.ts).
+
+## Community coordinate and recommendations
+
+Choose a publisher namespace and plugin name in kebab-case. The community coordinate is `<namespace>/<plugin>`. It exists for future registry lookup and does not replace any official Harness field.
+
+For namespace `alice` and plugin `web-search`, the collision-resistant projections are:
+
+| Surface | Recommendation | Example |
+|---|---|---|
+| Coordinate | `<namespace>/<plugin>` | `alice/web-search` |
+| npm package | Official unscoped or npm-scoped DSH package | `@alice/dsh-web-search` |
+| Plugin module name | Stable kebab name | `web-search` |
+| Loader row | Coordinate base, optional suffix | `alice-web-search` |
+| Cordis service | Lower-camel coordinate base, optional suffix | `aliceWebSearchIndex` |
+| Tool | Snake coordinate base, optional suffix | `alice_web_search_query` |
+| Command | Kebab coordinate base, optional suffix | `alice-web-search-refresh` |
+| Skill | Kebab coordinate base, optional suffix | `alice-web-search` |
+| Skill provider | Kebab coordinate base, provider suffix | `alice-web-search-filesystem` |
+| Event | Coordinate base plus action | `alice-web-search/ready` |
+| Settings namespace | Coordinate base, optional suffix | `alice-web-search` |
+| HTTP route | Coordinate-owned subtree | `/api/plugins/alice-web-search/query` |
+
+The prefix rules are recommendations because long model-visible tool names and user-facing commands have a usability and token cost. The local validator reports them as warnings; `--strict` turns those warnings into a nonzero result for teams that choose the collision-resistant profile.
+
+## Local declaration
+
+Create `dsh-plugin.naming.json` at the external plugin repository root:
+
+```json
+{
+  "schemaVersion": 1,
+  "policy": "dsh-plugin-naming/v1",
+  "plugin": {
+    "namespace": "alice",
+    "name": "web-search",
+    "coordinate": "alice/web-search",
+    "packageName": "@alice/dsh-web-search"
+  },
+  "names": {
+    "pluginNames": ["web-search"],
+    "loaderIds": ["alice-web-search"],
+    "services": ["aliceWebSearchIndex"],
+    "tools": ["alice_web_search_query"],
+    "commands": ["alice-web-search-refresh"],
+    "skills": ["alice-web-search"],
+    "skillProviders": ["alice-web-search-filesystem"],
+    "events": ["alice-web-search/ready"],
+    "settingsNamespaces": ["alice-web-search"],
+    "routes": [
+      { "kind": "exact", "path": "/api/plugins/alice-web-search/query" }
+    ]
+  }
+}
+```
+
+Keep every array, including empty arrays, and declare at least one plugin module name and Loader row ID. The optional `$schema` field may point to a resolvable local copy of `plugin-naming.schema.json`. This declaration supplements `package.json`, bundle patches, and Profile composition; it neither proves source usage nor reserves a name.
+
+## Validate
+
+Run the bundled read-only validator with Node 20 or newer:
+
+```sh
+node <plugin-write-skill>/scripts/validate-names.mjs \
+  --manifest ./dsh-plugin.naming.json
+```
+
+For a new plugin that adopts every community recommendation, add `--strict`. Use `--format json` for CI. Exit status `0` means compatible, `1` means errors or strict-mode warnings, and `2` means invalid arguments, unreadable input, or malformed JSON. The validator performs no network requests and writes no files.
+
+## Registry boundary
+
+A future registry must not compare strings without context. It needs the target Harness version, registration scope, Loader patch layer and override intent, Skill provider/rank, and Web route kind. Events are shared channels and should be checked for incompatible schemas, not rejected merely because two plugins use the same event name. Ports belong to deployment configuration and require a composition-time check rather than a naming reservation.

--- a/skills/plugin-write/references/naming-conventions.md
+++ b/skills/plugin-write/references/naming-conventions.md
@@ -31,7 +31,7 @@ Primary sources: [first plugin](https://github.com/deepseek-ai/deepseek-harness/
 
 ## Community coordinate and recommendations
 
-Choose a publisher namespace and plugin name in kebab-case. The community coordinate is `<namespace>/<plugin>`. It exists for future registry lookup and does not replace any official Harness field.
+Choose a publisher namespace and plugin name in kebab-case. The community coordinate is `<namespace>/<plugin>`. It is the lookup key used by the optional community registry and does not replace any official Harness field.
 
 For namespace `alice` and plugin `web-search`, the collision-resistant projections are:
 
@@ -98,4 +98,6 @@ For a new plugin that adopts every community recommendation, add `--strict`. Use
 
 ## Registry boundary
 
-A future registry must not compare strings without context. It needs the target Harness version, registration scope, Loader patch layer and override intent, Skill provider/rank, and Web route kind. Events are shared channels and should be checked for incompatible schemas, not rejected merely because two plugins use the same event name. Ports belong to deployment configuration and require a composition-time check rather than a naming reservation.
+The optional central registry uses the local declaration only as phase-one source evidence. Its v2 entry separately records the target Harness range, registration scope, Loader patch layer and override intent, Skill provider/rank, event publisher/schema, and Web route kind. Events remain shared channels and are checked for incompatible publisher schemas instead of being rejected merely for the same name. Ports remain deployment configuration and require a composition-time check rather than a naming reservation.
+
+Read [`registry-check.md`](registry-check.md) after this offline validator passes. Keep a missing central match, an unavailable query, an automated discovery candidate, and a reviewed formal registration as four distinct states.

--- a/skills/plugin-write/references/naming-policy.v1.json
+++ b/skills/plugin-write/references/naming-policy.v1.json
@@ -11,6 +11,11 @@
     "commit": "0a53fb55bea101816fa226bb964ae2bed71c343b",
     "verifiedAt": "2026-08-31"
   },
+  "centralRegistry": {
+    "repository": "https://github.com/oh-my-dsh/dsh-plugin-registry",
+    "contract": "dsh-plugin-registry/v2",
+    "defaultIndexUrl": "https://raw.githubusercontent.com/oh-my-dsh/dsh-plugin-registry/main/registry/index.json"
+  },
   "reservedNamespacePrefixes": [
     "core",
     "deepseek",

--- a/skills/plugin-write/references/naming-policy.v1.json
+++ b/skills/plugin-write/references/naming-policy.v1.json
@@ -1,0 +1,121 @@
+{
+  "kind": "dsh-plugin-naming-policy",
+  "id": "dsh-plugin-naming/v1",
+  "schemaVersion": 1,
+  "status": "community-compatibility-profile",
+  "manifestFile": "dsh-plugin.naming.json",
+  "appliesTo": "external-community-plugin",
+  "officialBaseline": {
+    "repository": "https://github.com/deepseek-ai/deepseek-harness",
+    "ref": "dsh-v0.1.2-alpha.2",
+    "commit": "0a53fb55bea101816fa226bb964ae2bed71c343b",
+    "verifiedAt": "2026-08-31"
+  },
+  "reservedNamespacePrefixes": [
+    "core",
+    "deepseek",
+    "dsh",
+    "internal",
+    "official",
+    "runtime",
+    "system"
+  ],
+  "reservedExactNames": {
+    "skillProviders": [
+      "runtime"
+    ]
+  },
+  "knownBuiltInExactNames": {
+    "tools": [
+      "run_code"
+    ]
+  },
+  "collisionSemantics": {
+    "pluginNames": "module-metadata-not-a-global-registry",
+    "loaderIds": "composition-key-later-layers-may-override",
+    "services": "context-key-isolatable-by-cordis-realm",
+    "tools": "same-scope-reject-nearer-agent-scope-may-shadow",
+    "commands": "same-scope-reject-nearer-agent-scope-may-shadow",
+    "skills": "scope-rank-and-provider-order-select-a-winner",
+    "skillProviders": "same-scope-reject-runtime-is-reserved",
+    "events": "shared-channel-not-an-exclusive-registration",
+    "settingsNamespaces": "duplicate-registration-rejects",
+    "routes": "same-kind-and-path-rejects"
+  },
+  "surfaces": {
+    "namespace": {
+      "style": "community-coordinate-segment",
+      "pattern": "^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$",
+      "maxLength": 63
+    },
+    "pluginName": {
+      "style": "kebab-case",
+      "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$",
+      "maxLength": 63
+    },
+    "packageName": {
+      "style": "npm-package-name",
+      "pattern": "^(?:@[a-z0-9][a-z0-9._-]*/)?[a-z0-9][a-z0-9._-]*$",
+      "maxLength": 214,
+      "recommendedPattern": "^(?:dsh-[a-z0-9]+(?:-[a-z0-9]+)*|@[a-z0-9]+(?:-[a-z0-9]+)*/dsh-[a-z0-9]+(?:-[a-z0-9]+)*)$"
+    },
+    "pluginNames": {
+      "style": "non-whitespace-module-name",
+      "pattern": "^\\S+$",
+      "recommendedPattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$",
+      "recommendedMaxLength": 128
+    },
+    "loaderIds": {
+      "style": "non-whitespace-composition-key",
+      "pattern": "^\\S+$",
+      "recommendedPattern": "^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$",
+      "recommendedMaxLength": 128
+    },
+    "services": {
+      "style": "non-whitespace-context-key",
+      "pattern": "^\\S+$",
+      "recommendedPattern": "^[a-z][A-Za-z0-9]*$",
+      "recommendedMaxLength": 128
+    },
+    "tools": {
+      "style": "model-tool-compatible-name",
+      "pattern": "^[A-Za-z0-9_-]+$",
+      "recommendedPattern": "^[a-z][a-z0-9]*(?:_[a-z0-9]+)*$",
+      "recommendedMaxLength": 128
+    },
+    "commands": {
+      "style": "official-lowercase-command-grammar",
+      "pattern": "^[a-z][a-z0-9_-]*$",
+      "recommendedPattern": "^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$",
+      "recommendedMaxLength": 128
+    },
+    "skills": {
+      "style": "official-kebab-case-skill-grammar",
+      "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+    },
+    "skillProviders": {
+      "style": "non-whitespace-provider-name",
+      "pattern": "^\\S+$",
+      "recommendedPattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$",
+      "recommendedMaxLength": 128
+    },
+    "events": {
+      "style": "official-namespace/action-convention",
+      "pattern": "^[^/\\s]+/[^/\\s]+$",
+      "recommendedPattern": "^[a-z0-9]+(?:-[a-z0-9]+)*/[a-z][a-z0-9]*(?:-[a-z0-9]+)*$",
+      "recommendedMaxLength": 192
+    },
+    "settingsNamespaces": {
+      "style": "official-lowercase-hyphenated-grammar",
+      "pattern": "^[a-z][a-z0-9-]*$",
+      "recommendedPattern": "^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$",
+      "recommendedMaxLength": 128
+    },
+    "routes": {
+      "style": "official-absolute-path-without-trailing-slash",
+      "pattern": "^/[^?#\\s]*[^/?#\\s]$",
+      "recommendedPattern": "^/(?:[A-Za-z0-9._~:@%+-]+/)*[A-Za-z0-9._~:@%+-]+$",
+      "recommendedMaxLength": 256
+    }
+  }
+}

--- a/skills/plugin-write/references/plugin-naming.schema.json
+++ b/skills/plugin-write/references/plugin-naming.schema.json
@@ -1,0 +1,207 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:dsh:plugin-naming:v1",
+  "title": "DSH external plugin naming declaration",
+  "description": "Community compatibility declaration for one external DSH plugin. It supplements package.json and does not reserve names globally.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "policy",
+    "plugin",
+    "names"
+  ],
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "minLength": 1
+    },
+    "schemaVersion": {
+      "const": 1
+    },
+    "policy": {
+      "const": "dsh-plugin-naming/v1"
+    },
+    "plugin": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "namespace",
+        "name",
+        "coordinate",
+        "packageName"
+      ],
+      "properties": {
+        "namespace": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$",
+          "maxLength": 63
+        },
+        "name": {
+          "type": "string",
+          "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$",
+          "maxLength": 63
+        },
+        "coordinate": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9]*(?:-[a-z0-9]+)*/[a-z0-9]+(?:-[a-z0-9]+)*$",
+          "maxLength": 127
+        },
+        "packageName": {
+          "type": "string",
+          "pattern": "^(?:@[a-z0-9][a-z0-9._-]*/)?[a-z0-9][a-z0-9._-]*$",
+          "maxLength": 214
+        }
+      }
+    },
+    "names": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "pluginNames",
+        "loaderIds",
+        "services",
+        "tools",
+        "commands",
+        "skills",
+        "skillProviders",
+        "events",
+        "settingsNamespaces",
+        "routes"
+      ],
+      "properties": {
+        "pluginNames": {
+          "$ref": "#/$defs/nonEmptyPluginNameList"
+        },
+        "loaderIds": {
+          "$ref": "#/$defs/nonEmptyLoaderIdList"
+        },
+        "services": {
+          "$ref": "#/$defs/serviceList"
+        },
+        "tools": {
+          "$ref": "#/$defs/toolList"
+        },
+        "commands": {
+          "$ref": "#/$defs/commandList"
+        },
+        "skills": {
+          "$ref": "#/$defs/skillList"
+        },
+        "skillProviders": {
+          "$ref": "#/$defs/skillProviderList"
+        },
+        "events": {
+          "$ref": "#/$defs/eventList"
+        },
+        "settingsNamespaces": {
+          "$ref": "#/$defs/settingsNamespaceList"
+        },
+        "routes": {
+          "$ref": "#/$defs/routeList"
+        }
+      }
+    }
+  },
+  "$defs": {
+    "nonEmptyPluginNameList": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^\\S+$"
+      }
+    },
+    "nonEmptyLoaderIdList": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^\\S+$"
+      }
+    },
+    "serviceList": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^\\S+$"
+      }
+    },
+    "toolList": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^[A-Za-z0-9_-]+$"
+      }
+    },
+    "commandList": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^[a-z][a-z0-9_-]*$"
+      }
+    },
+    "skillList": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+      }
+    },
+    "skillProviderList": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^\\S+$"
+      }
+    },
+    "eventList": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^[^/\\s]+/[^/\\s]+$"
+      }
+    },
+    "settingsNamespaceList": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^[a-z][a-z0-9-]*$"
+      }
+    },
+    "routeList": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "kind",
+          "path"
+        ],
+        "properties": {
+          "kind": {
+            "enum": [
+              "exact",
+              "prefix",
+              "upgrade"
+            ]
+          },
+          "path": {
+            "type": "string",
+            "pattern": "^/[^?#\\s]*[^/?#\\s]$"
+          }
+        }
+      }
+    }
+  }
+}

--- a/skills/plugin-write/references/registry-check.md
+++ b/skills/plugin-write/references/registry-check.md
@@ -17,7 +17,7 @@ node <plugin-write-skill>/scripts/query-registry.mjs \
 The default index is:
 
 ```text
-https://raw.githubusercontent.com/zp-home/dsh-plugin-registry/main/registry/index.json
+https://raw.githubusercontent.com/oh-my-dsh/dsh-plugin-registry/main/registry/index.json
 ```
 
 Use `--format json` for automation, `--strict` to fail on contextual warnings, `--registry-url` for an
@@ -51,7 +51,7 @@ The local naming declaration does not reserve anything. To request a formal regi
 
 1. Commit the validated `dsh-plugin.naming.json` to the public plugin repository.
 2. Open the central registry example and v2 Schema from
-   `https://github.com/zp-home/dsh-plugin-registry`.
+   `https://github.com/oh-my-dsh/dsh-plugin-registry`.
 3. Pin `source.commit` to the 40-character plugin repository commit containing the naming declaration.
 4. Add Harness `min`/`maxExclusive`, per-surface scope, Loader layer/intent, Skill provider/rank, event
    role/schema, and route kind/path.

--- a/skills/plugin-write/references/registry-check.md
+++ b/skills/plugin-write/references/registry-check.md
@@ -1,0 +1,61 @@
+# Central Registry Check
+
+Use this optional phase-two check only after `dsh-plugin.naming.json` passes the offline validator. The
+central registry is a reviewed coordination service, not an official DeepSeek Harness authority and not
+a global lock.
+
+## Query
+
+Run the bundled read-only client and supply the exact target Harness version when known:
+
+```sh
+node <plugin-write-skill>/scripts/query-registry.mjs \
+  --manifest ./dsh-plugin.naming.json \
+  --harness-version 0.1.2-alpha.2
+```
+
+The default index is:
+
+```text
+https://raw.githubusercontent.com/zp-home/dsh-plugin-registry/main/registry/index.json
+```
+
+Use `--format json` for automation, `--strict` to fail on contextual warnings, `--registry-url` for an
+approved mirror, or `--index` for an offline snapshot. The client accepts only
+`dsh-plugin-registry/v2`, limits the response to 5 MiB, times out after 10 seconds, performs no writes,
+and never executes registry or plugin code.
+
+Exit status `0` means the query completed and no always-blocking registration mismatch was found.
+Ordinary contextual matches remain advisory unless `--strict` is used. Status `1` means a registered
+identity mismatch or strict-mode warning. Status `2` means invalid local input, unsupported index,
+unreadable data, timeout, or network failure. Treat `2` as **unknown/not checked**, never as available.
+
+## Interpret Results
+
+- No match means only that the reviewed index has no matching declaration. It is not a global uniqueness
+  proof and does not cover unregistered or dynamic plugins.
+- A Plugin module name match is informational because module metadata is not a global registry.
+- A Loader match needs composition, patch layer, and replacement intent.
+- Service, Tool, Command, provider, settings, and route matches need runtime scope.
+- A Skill match needs scope, provider, rank, and local order.
+- An event match is informational until publisher roles and schemas are incompatible; events are shared
+  channels, not exclusive registrations.
+- Ports are deployment-composition concerns and are absent from the central naming registry.
+
+Do not rename an already published surface automatically. Report the match, determine the actual target
+composition, and request explicit authorization before a compatibility-breaking rename.
+
+## Register
+
+The local naming declaration does not reserve anything. To request a formal registration:
+
+1. Commit the validated `dsh-plugin.naming.json` to the public plugin repository.
+2. Open the central registry example and v2 Schema from
+   `https://github.com/zp-home/dsh-plugin-registry`.
+3. Pin `source.commit` to the 40-character plugin repository commit containing the naming declaration.
+4. Add Harness `min`/`maxExclusive`, per-surface scope, Loader layer/intent, Skill provider/rank, event
+   role/schema, and route kind/path.
+5. Submit `registry/entries/<github-owner>/<plugin-slug>.json` through a reviewed PR.
+
+GitHub discovery candidates in that repository never reserve IDs. Only a reviewed entry merged to
+`main` participates in conflict checks.

--- a/skills/plugin-write/scripts/query-registry.check.mjs
+++ b/skills/plugin-write/scripts/query-registry.check.mjs
@@ -4,7 +4,9 @@ import { mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
+import { loadNamingPolicy } from './validate-names.mjs'
 import {
+  DEFAULT_REGISTRY_URL,
   REGISTRY_CONTRACT,
   RegistryQueryInputError,
   checkNamingAgainstIndex,
@@ -102,6 +104,11 @@ function runCli(args) {
 }
 
 export async function runRegistryQueryChecks() {
+  const policy = await loadNamingPolicy()
+  assert.equal(policy.centralRegistry?.repository, 'https://github.com/oh-my-dsh/dsh-plugin-registry')
+  assert.equal(policy.centralRegistry?.contract, REGISTRY_CONTRACT)
+  assert.equal(policy.centralRegistry?.defaultIndexUrl, DEFAULT_REGISTRY_URL)
+
   const alice = registration('alice')
   const candidate = namingManifest('bob')
   candidate.names.pluginNames = ['web-search']

--- a/skills/plugin-write/scripts/query-registry.check.mjs
+++ b/skills/plugin-write/scripts/query-registry.check.mjs
@@ -1,0 +1,179 @@
+import assert from 'node:assert/strict'
+import { spawn } from 'node:child_process'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+import {
+  REGISTRY_CONTRACT,
+  RegistryQueryInputError,
+  checkNamingAgainstIndex,
+  queryManifestFile,
+  readRegistryIndex,
+  renderRegistryQuery,
+} from './query-registry.mjs'
+
+function namingManifest(namespace = 'bob') {
+  const base = `${namespace}-web-search`
+  return {
+    schemaVersion: 1,
+    policy: 'dsh-plugin-naming/v1',
+    plugin: {
+      namespace,
+      name: 'web-search',
+      coordinate: `${namespace}/web-search`,
+      packageName: `@${namespace}/dsh-web-search`,
+    },
+    names: {
+      pluginNames: ['web-search'],
+      loaderIds: [base],
+      services: [`${namespace}WebSearchIndex`],
+      tools: [`${namespace}_web_search_query`],
+      commands: [`${base}-refresh`],
+      skills: [base],
+      skillProviders: [`${base}-filesystem`],
+      events: [`${base}/ready`],
+      settingsNamespaces: [base],
+      routes: [{ kind: 'exact', path: `/api/plugins/${base}/query` }],
+    },
+  }
+}
+
+function registration(namespace = 'alice', overrides = {}) {
+  const naming = namingManifest(namespace)
+  const base = `${namespace}-web-search`
+  const value = {
+    schemaVersion: 2,
+    plugin: {
+      id: `${namespace}/web-search`,
+      repository: `https://github.com/${namespace}/dsh-web-search`,
+      package: naming.plugin.packageName,
+      status: 'active',
+    },
+    source: {
+      commit: '0123456789abcdef0123456789abcdef01234567',
+      namingManifest: 'dsh-plugin.naming.json',
+    },
+    compatibility: { harness: { min: '0.1.2-alpha.2', maxExclusive: '0.2.0' } },
+    claims: {
+      pluginNames: naming.names.pluginNames,
+      loaderIds: [{ name: base, composition: 'root', layer: 0, overrideIntent: 'none' }],
+      services: [{ name: naming.names.services[0], scope: 'root' }],
+      tools: [{ name: naming.names.tools[0], scope: 'agent' }],
+      commands: [{ name: naming.names.commands[0], scope: 'root' }],
+      skills: [{ name: naming.names.skills[0], scope: 'root', provider: naming.names.skillProviders[0], rank: 0 }],
+      skillProviders: [{ name: naming.names.skillProviders[0], scope: 'root' }],
+      events: [{ name: naming.names.events[0], scope: 'root', role: 'publisher', schema: `urn:${base}:ready:v1` }],
+      settingsNamespaces: [{ name: naming.names.settingsNamespaces[0], scope: 'root' }],
+      routes: [{ ...naming.names.routes[0], scope: 'root' }],
+    },
+    manifestPath: `registry/entries/${namespace}/web-search.json`,
+  }
+  return {
+    ...value,
+    ...overrides,
+    plugin: { ...value.plugin, ...(overrides.plugin ?? {}) },
+    compatibility: {
+      ...value.compatibility,
+      ...(overrides.compatibility ?? {}),
+      harness: { ...value.compatibility.harness, ...(overrides.compatibility?.harness ?? {}) },
+    },
+    claims: { ...value.claims, ...(overrides.claims ?? {}) },
+  }
+}
+
+function index(plugins) {
+  return { schemaVersion: 2, contract: REGISTRY_CONTRACT, source: 'registry/entries', plugins }
+}
+
+function runCli(args) {
+  const script = fileURLToPath(new URL('./query-registry.mjs', import.meta.url))
+  return new Promise((resolvePromise, reject) => {
+    const child = spawn(process.execPath, [script, ...args], { stdio: ['ignore', 'pipe', 'pipe'] })
+    let stdout = ''
+    let stderr = ''
+    child.stdout.setEncoding('utf8')
+    child.stderr.setEncoding('utf8')
+    child.stdout.on('data', (chunk) => { stdout += chunk })
+    child.stderr.on('data', (chunk) => { stderr += chunk })
+    child.on('error', reject)
+    child.on('close', (code, signal) => resolvePromise({ code, signal, stdout, stderr }))
+  })
+}
+
+export async function runRegistryQueryChecks() {
+  const alice = registration('alice')
+  const candidate = namingManifest('bob')
+  candidate.names.pluginNames = ['web-search']
+  candidate.names.tools = ['alice_web_search_query']
+  candidate.names.events = ['alice-web-search/ready']
+  candidate.names.routes = [{ kind: 'exact', path: '/api/plugins/alice-web-search/query' }]
+  const report = checkNamingAgainstIndex(candidate, index([alice]), { harnessVersion: '0.1.2-alpha.2' })
+  assert.equal(report.status, 'checked')
+  assert.equal(report.registration, null)
+  assert(report.matches.some((match) => match.kind === 'tools' && match.severity === 'warning'))
+  assert(report.matches.some((match) => match.kind === 'routes' && match.severity === 'warning'))
+  assert(report.matches.some((match) => match.kind === 'pluginNames' && match.severity === 'notice'))
+  assert(report.matches.some((match) => match.kind === 'events' && match.severity === 'notice'))
+  assert.match(renderRegistryQuery(report, 'fixture-index.json'), /not a global uniqueness proof|WARNING/)
+
+  const futureOnly = checkNamingAgainstIndex(candidate, index([alice]), { harnessVersion: '0.2.0' })
+  assert.equal(futureOnly.matches.length, 0)
+
+  const self = checkNamingAgainstIndex(namingManifest('alice'), index([alice]), { harnessVersion: '0.1.2-alpha.2' })
+  assert.equal(self.registration.id, 'alice/web-search')
+  assert.equal(self.matches.length, 0)
+
+  const stale = namingManifest('alice')
+  stale.names.tools = ['alice_web_search_v2']
+  const staleReport = checkNamingAgainstIndex(stale, index([alice]))
+  assert(staleReport.matches.some((match) => match.reason.includes('stale')))
+
+  const wrongPackage = namingManifest('alice')
+  wrongPackage.plugin.packageName = '@alice/dsh-web-search-next'
+  const wrongPackageReport = checkNamingAgainstIndex(wrongPackage, index([alice]))
+  assert.equal(wrongPackageReport.summary.errors, 1)
+
+  await assert.rejects(
+    readRegistryIndex({ fetchImpl: async () => new Response('unavailable', { status: 503 }) }),
+    (error) => error instanceof RegistryQueryInputError && /HTTP 503/.test(error.message),
+  )
+  await assert.rejects(
+    readRegistryIndex({ fetchImpl: async () => new Response('{"schemaVersion":1}', { status: 200 }) }),
+    (error) => error instanceof RegistryQueryInputError && /dsh-plugin-registry\/v2/.test(error.message),
+  )
+
+  const root = await mkdtemp(join(tmpdir(), 'dsh-registry-query-'))
+  try {
+    const manifestPath = join(root, 'dsh-plugin.naming.json')
+    const indexPath = join(root, 'index.json')
+    await writeFile(manifestPath, `${JSON.stringify(candidate, null, 2)}\n`)
+    await writeFile(indexPath, `${JSON.stringify(index([alice]), null, 2)}\n`)
+    const fileReport = await queryManifestFile({ manifestPath, indexPath, harnessVersion: '0.1.2-alpha.2' })
+    assert.equal(fileReport.summary.warnings, 2)
+
+    const ordinary = await runCli(['--manifest', manifestPath, '--index', indexPath, '--harness-version', '0.1.2-alpha.2'])
+    assert.equal(ordinary.code, 0, ordinary.stderr)
+    assert.match(ordinary.stdout, /Registry checked/)
+    const strict = await runCli(['--manifest', manifestPath, '--index', indexPath, '--harness-version', '0.1.2-alpha.2', '--strict'])
+    assert.equal(strict.code, 1)
+    const unavailable = await runCli(['--manifest', manifestPath, '--registry-url', 'http://127.0.0.1:1/index.json', '--format', 'json'])
+    assert.equal(unavailable.code, 2)
+    assert.match(unavailable.stderr, /"status":"unavailable"/)
+
+    const invalid = namingManifest('bob')
+    invalid.names.loaderIds = ['has space']
+    await writeFile(manifestPath, `${JSON.stringify(invalid, null, 2)}\n`)
+    const invalidResult = await runCli(['--manifest', manifestPath, '--index', indexPath])
+    assert.equal(invalidResult.code, 2)
+    assert.match(invalidResult.stderr, /local naming validation failed/)
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+}
+
+const invokedPath = process.argv[1] ? pathToFileURL(resolve(process.argv[1])).href : undefined
+if (invokedPath === import.meta.url) {
+  await runRegistryQueryChecks()
+  console.log('Registry query checks OK: v2 contract, local validation gate, version filtering, contextual matches, shared-event notices, stale registration, offline fixture, CLI exits 0/1/2')
+}

--- a/skills/plugin-write/scripts/query-registry.mjs
+++ b/skills/plugin-write/scripts/query-registry.mjs
@@ -1,0 +1,376 @@
+#!/usr/bin/env node
+
+import { readFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
+import { loadNamingPolicy, validateNamingManifest } from './validate-names.mjs'
+
+export const DEFAULT_REGISTRY_URL = 'https://raw.githubusercontent.com/zp-home/dsh-plugin-registry/main/registry/index.json'
+export const REGISTRY_CONTRACT = 'dsh-plugin-registry/v2'
+
+const MAX_INDEX_BYTES = 5 * 1024 * 1024
+const semverPattern = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/
+const scopedKinds = ['services', 'tools', 'commands', 'skillProviders', 'settingsNamespaces']
+const requiredClaimKinds = [
+  'pluginNames',
+  'loaderIds',
+  ...scopedKinds,
+  'skills',
+  'events',
+  'routes',
+]
+
+export class RegistryQueryInputError extends Error {
+  constructor(message, options) {
+    super(message, options)
+    this.name = 'RegistryQueryInputError'
+  }
+}
+
+function isObject(value) {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function parseSemver(value) {
+  const match = semverPattern.exec(value)
+  if (!match) return undefined
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+    prerelease: match[4] ? match[4].split('.') : [],
+  }
+}
+
+function comparePrerelease(left, right) {
+  if (!left.length && !right.length) return 0
+  if (!left.length) return 1
+  if (!right.length) return -1
+  const length = Math.max(left.length, right.length)
+  for (let index = 0; index < length; index += 1) {
+    if (left[index] === undefined) return -1
+    if (right[index] === undefined) return 1
+    const leftNumber = /^\d+$/.test(left[index]) ? Number(left[index]) : undefined
+    const rightNumber = /^\d+$/.test(right[index]) ? Number(right[index]) : undefined
+    if (leftNumber !== undefined && rightNumber !== undefined && leftNumber !== rightNumber) {
+      return leftNumber < rightNumber ? -1 : 1
+    }
+    if (leftNumber !== undefined && rightNumber === undefined) return -1
+    if (leftNumber === undefined && rightNumber !== undefined) return 1
+    if (left[index] !== right[index]) return left[index] < right[index] ? -1 : 1
+  }
+  return 0
+}
+
+function compareSemver(leftValue, rightValue) {
+  const left = parseSemver(leftValue)
+  const right = parseSemver(rightValue)
+  if (!left || !right) throw new RegistryQueryInputError('registry contains an invalid Harness semantic version')
+  for (const field of ['major', 'minor', 'patch']) {
+    if (left[field] !== right[field]) return left[field] < right[field] ? -1 : 1
+  }
+  return comparePrerelease(left.prerelease, right.prerelease)
+}
+
+function supportsHarnessVersion(plugin, version) {
+  if (!version) return true
+  const range = plugin.compatibility.harness
+  return compareSemver(range.min, version) <= 0 && (!range.maxExclusive || compareSemver(version, range.maxExclusive) < 0)
+}
+
+function validateIndex(index) {
+  if (!isObject(index) || index.schemaVersion !== 2 || index.contract !== REGISTRY_CONTRACT || !Array.isArray(index.plugins)) {
+    throw new RegistryQueryInputError(`registry index must use ${REGISTRY_CONTRACT}`)
+  }
+  for (let offset = 0; offset < index.plugins.length; offset += 1) {
+    const plugin = index.plugins[offset]
+    const path = `index.plugins[${offset}]`
+    if (!isObject(plugin?.plugin) || typeof plugin.plugin.id !== 'string' || typeof plugin.plugin.repository !== 'string'
+      || typeof plugin.plugin.package !== 'string' || typeof plugin.plugin.status !== 'string') {
+      throw new RegistryQueryInputError(`${path}.plugin is invalid`)
+    }
+    if (!isObject(plugin.compatibility?.harness) || !parseSemver(plugin.compatibility.harness.min)
+      || (plugin.compatibility.harness.maxExclusive !== undefined && !parseSemver(plugin.compatibility.harness.maxExclusive))) {
+      throw new RegistryQueryInputError(`${path}.compatibility.harness is invalid`)
+    }
+    if (plugin.compatibility.harness.maxExclusive
+      && compareSemver(plugin.compatibility.harness.min, plugin.compatibility.harness.maxExclusive) >= 0) {
+      throw new RegistryQueryInputError(`${path}.compatibility.harness is empty`)
+    }
+    if (!isObject(plugin.claims)) throw new RegistryQueryInputError(`${path}.claims is invalid`)
+    for (const kind of requiredClaimKinds) {
+      if (!Array.isArray(plugin.claims[kind])) throw new RegistryQueryInputError(`${path}.claims.${kind} must be an array`)
+    }
+    if (!plugin.claims.loaderIds.every((claim) => isObject(claim) && typeof claim.name === 'string')) {
+      throw new RegistryQueryInputError(`${path}.claims.loaderIds is invalid`)
+    }
+    for (const kind of [...scopedKinds, 'skills', 'events']) {
+      if (!plugin.claims[kind].every((claim) => isObject(claim) && typeof claim.name === 'string')) {
+        throw new RegistryQueryInputError(`${path}.claims.${kind} is invalid`)
+      }
+    }
+    if (!plugin.claims.routes.every((claim) => isObject(claim) && typeof claim.kind === 'string' && typeof claim.path === 'string')) {
+      throw new RegistryQueryInputError(`${path}.claims.routes is invalid`)
+    }
+  }
+  return index
+}
+
+async function readBoundedResponse(response) {
+  const length = Number(response.headers.get('content-length'))
+  if (Number.isFinite(length) && length > MAX_INDEX_BYTES) throw new RegistryQueryInputError('registry index is too large')
+  const text = await response.text()
+  if (Buffer.byteLength(text, 'utf8') > MAX_INDEX_BYTES) throw new RegistryQueryInputError('registry index is too large')
+  return text
+}
+
+export async function readRegistryIndex({ indexPath, registryUrl = DEFAULT_REGISTRY_URL, fetchImpl = fetch } = {}) {
+  let text
+  if (indexPath) {
+    try {
+      text = await readFile(resolve(indexPath), 'utf8')
+    } catch (error) {
+      throw new RegistryQueryInputError(`cannot read registry index ${resolve(indexPath)}: ${error.message}`, { cause: error })
+    }
+  } else {
+    let response
+    try {
+      response = await fetchImpl(registryUrl, {
+        headers: { accept: 'application/json', 'user-agent': 'dsh-plugin-write-registry-query' },
+        signal: AbortSignal.timeout(10_000),
+      })
+    } catch (error) {
+      throw new RegistryQueryInputError(`registry query unavailable: ${error.message}`, { cause: error })
+    }
+    if (!response.ok) throw new RegistryQueryInputError(`registry query unavailable: HTTP ${response.status} ${response.statusText}`)
+    text = await readBoundedResponse(response)
+  }
+  try {
+    return validateIndex(JSON.parse(text))
+  } catch (error) {
+    if (error instanceof RegistryQueryInputError) throw error
+    throw new RegistryQueryInputError(`cannot parse registry index: ${error.message}`, { cause: error })
+  }
+}
+
+function centralNames(plugin) {
+  return {
+    pluginNames: [...plugin.claims.pluginNames].sort(),
+    loaderIds: plugin.claims.loaderIds.map((claim) => claim.name).sort(),
+    services: plugin.claims.services.map((claim) => claim.name).sort(),
+    tools: plugin.claims.tools.map((claim) => claim.name).sort(),
+    commands: plugin.claims.commands.map((claim) => claim.name).sort(),
+    skills: plugin.claims.skills.map((claim) => claim.name).sort(),
+    skillProviders: plugin.claims.skillProviders.map((claim) => claim.name).sort(),
+    events: plugin.claims.events.map((claim) => claim.name).sort(),
+    settingsNamespaces: plugin.claims.settingsNamespaces.map((claim) => claim.name).sort(),
+    routes: plugin.claims.routes.map((claim) => `${claim.kind}\u0000${claim.path}`).sort(),
+  }
+}
+
+function localNames(manifest) {
+  return {
+    ...Object.fromEntries(requiredClaimKinds.filter((kind) => kind !== 'routes').map((kind) => [kind, [...manifest.names[kind]].sort()])),
+    routes: manifest.names.routes.map((claim) => `${claim.kind}\u0000${claim.path}`).sort(),
+  }
+}
+
+function pluginSummary(plugin) {
+  return {
+    id: plugin.plugin.id,
+    repository: plugin.plugin.repository,
+    status: plugin.plugin.status,
+    manifestPath: plugin.manifestPath,
+    harness: plugin.compatibility.harness,
+  }
+}
+
+function pushMatch(matches, plugin, severity, kind, claim, reason, context) {
+  const existing = matches.find((match) => match.severity === severity && match.kind === kind && match.claim === claim && match.reason === reason)
+  const registration = { ...pluginSummary(plugin), context }
+  if (existing) existing.registrations.push(registration)
+  else matches.push({ severity, kind, claim, reason, registrations: [registration] })
+}
+
+export function checkNamingAgainstIndex(manifest, index, { harnessVersion } = {}) {
+  if (harnessVersion && !parseSemver(harnessVersion)) {
+    throw new RegistryQueryInputError('--harness-version must be a semantic version such as 0.1.2-alpha.2')
+  }
+  validateIndex(index)
+  const coordinate = manifest.plugin.coordinate
+  const eligible = index.plugins.filter((plugin) => supportsHarnessVersion(plugin, harnessVersion))
+  const registered = eligible.find((plugin) => plugin.plugin.id === coordinate)
+    ?? index.plugins.find((plugin) => plugin.plugin.id === coordinate)
+  const matches = []
+  if (registered) {
+    if (registered.plugin.package !== manifest.plugin.packageName) {
+      pushMatch(matches, registered, 'error', 'registration', coordinate, 'registered package differs from the local naming declaration')
+    }
+    const local = localNames(manifest)
+    const central = centralNames(registered)
+    for (const kind of requiredClaimKinds) {
+      if (JSON.stringify(local[kind]) !== JSON.stringify(central[kind])) {
+        pushMatch(matches, registered, 'warning', kind, coordinate, 'the reviewed registration is stale relative to the local naming declaration')
+      }
+    }
+  }
+
+  for (const plugin of index.plugins) {
+    if (plugin.plugin.id === coordinate) continue
+    if (plugin.plugin.package === manifest.plugin.packageName) {
+      pushMatch(matches, plugin, plugin.plugin.status === 'archived' ? 'notice' : 'warning', 'packages', manifest.plugin.packageName,
+        'another reviewed coordinate declares the same package; package identity is independent of Harness runtime range')
+    }
+  }
+
+  for (const plugin of eligible) {
+    if (plugin.plugin.id === coordinate) continue
+    const archived = plugin.plugin.status === 'archived'
+    for (const name of manifest.names.pluginNames) {
+      if (plugin.claims.pluginNames.includes(name)) {
+        pushMatch(matches, plugin, 'notice', 'pluginNames', name,
+          'plugin module names are indexed for discovery but are not global exclusive IDs')
+      }
+    }
+    for (const name of manifest.names.loaderIds) {
+      for (const claim of plugin.claims.loaderIds.filter((candidate) => candidate.name === name)) {
+        pushMatch(matches, plugin, archived ? 'notice' : 'warning', 'loaderIds', name,
+          'Loader composition, layer, and replacement intent must be compared in a full registration', claim)
+      }
+    }
+    for (const kind of scopedKinds) {
+      for (const name of manifest.names[kind]) {
+        for (const claim of plugin.claims[kind].filter((candidate) => candidate.name === name)) {
+          pushMatch(matches, plugin, archived ? 'notice' : 'warning', kind, name,
+            'the local naming manifest has no runtime scope; review the registered scope before composing plugins', claim)
+        }
+      }
+    }
+    for (const name of manifest.names.skills) {
+      for (const claim of plugin.claims.skills.filter((candidate) => candidate.name === name)) {
+        pushMatch(matches, plugin, archived ? 'notice' : 'warning', 'skills', name,
+          'Skill selection depends on scope, provider, rank, and local order', claim)
+      }
+    }
+    for (const name of manifest.names.events) {
+      for (const claim of plugin.claims.events.filter((candidate) => candidate.name === name)) {
+        pushMatch(matches, plugin, 'notice', 'events', name,
+          'events are shared channels; compare publisher roles and schemas instead of treating the name as exclusive', claim)
+      }
+    }
+    for (const route of manifest.names.routes) {
+      for (const claim of plugin.claims.routes.filter((candidate) => candidate.kind === route.kind && candidate.path === route.path)) {
+        pushMatch(matches, plugin, archived ? 'notice' : 'warning', 'routes', `${route.kind} ${route.path}`,
+          'the same route kind and path may collide in an overlapping router scope', claim)
+      }
+    }
+  }
+  matches.sort((left, right) =>
+    left.severity.localeCompare(right.severity) || left.kind.localeCompare(right.kind) || left.claim.localeCompare(right.claim),
+  )
+  return {
+    status: 'checked',
+    contract: REGISTRY_CONTRACT,
+    coordinate,
+    harnessVersion: harnessVersion ?? null,
+    registration: registered ? pluginSummary(registered) : null,
+    matches,
+    summary: {
+      errors: matches.filter((match) => match.severity === 'error').length,
+      warnings: matches.filter((match) => match.severity === 'warning').length,
+      notices: matches.filter((match) => match.severity === 'notice').length,
+    },
+  }
+}
+
+export async function queryManifestFile({ manifestPath, indexPath, registryUrl, harnessVersion, fetchImpl } = {}) {
+  const absolute = resolve(manifestPath)
+  let manifest
+  try {
+    manifest = JSON.parse(await readFile(absolute, 'utf8'))
+  } catch (error) {
+    throw new RegistryQueryInputError(`cannot read naming manifest ${absolute}: ${error.message}`, { cause: error })
+  }
+  const policy = await loadNamingPolicy()
+  const validation = validateNamingManifest(manifest, policy)
+  if (!validation.valid) {
+    throw new RegistryQueryInputError(`local naming validation failed: ${validation.errors.map((error) => `${error.path} [${error.code}] ${error.message}`).join('; ')}`)
+  }
+  const index = await readRegistryIndex({ indexPath, registryUrl, fetchImpl })
+  return checkNamingAgainstIndex(manifest, index, { harnessVersion })
+}
+
+export function renderRegistryQuery(result, source) {
+  const lines = [
+    `Registry checked: ${result.coordinate} (${result.contract})`,
+    `- Source: ${source}`,
+    `- Harness version: ${result.harnessVersion ?? 'not supplied; all registered ranges were considered'}`,
+    `- Registration: ${result.registration ? `${result.registration.status} at ${result.registration.repository}` : 'not present in the reviewed registry'}`,
+  ]
+  if (!result.matches.length) lines.push('- No reviewed cross-plugin matches found. This is not a global uniqueness proof.')
+  for (const match of result.matches) {
+    lines.push(`- ${match.severity.toUpperCase()} ${match.kind} ${JSON.stringify(match.claim)}: ${match.reason}; registrations: ${match.registrations.map((entry) => entry.id).join(', ')}`)
+  }
+  return lines.join('\n')
+}
+
+function parseArgs(args) {
+  const options = { format: 'text', strict: false, registryUrl: DEFAULT_REGISTRY_URL }
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index]
+    if (argument === '--help' || argument === '-h') return { help: true }
+    if (argument === '--strict') {
+      options.strict = true
+      continue
+    }
+    if (!['--manifest', '--index', '--registry-url', '--harness-version', '--format'].includes(argument)) {
+      throw new RegistryQueryInputError(`unknown argument: ${argument}`)
+    }
+    const value = args[++index]
+    if (!value || value.startsWith('--')) throw new RegistryQueryInputError(`${argument} requires a value`)
+    const key = argument === '--manifest'
+      ? 'manifestPath'
+      : argument === '--index'
+        ? 'indexPath'
+        : argument.slice(2).replace(/-([a-z])/g, (_, letter) => letter.toUpperCase())
+    options[key] = value
+  }
+  if (!options.manifestPath) throw new RegistryQueryInputError('--manifest is required')
+  if (!['text', 'json'].includes(options.format)) throw new RegistryQueryInputError('--format must be text or json')
+  if (options.indexPath) options.registryUrl = undefined
+  return options
+}
+
+function usage() {
+  return [
+    'Usage: node query-registry.mjs --manifest <dsh-plugin.naming.json> [--harness-version <semver>] [--registry-url <url> | --index <path>] [--format text|json] [--strict]',
+    '',
+    'Performs a read-only phase-two lookup against reviewed central registrations.',
+    'No match is not a global uniqueness proof. Query failure is unknown, never available.',
+  ].join('\n')
+}
+
+const invokedPath = process.argv[1] ? pathToFileURL(resolve(process.argv[1])).href : undefined
+if (invokedPath === import.meta.url) {
+  let format = 'text'
+  try {
+    const options = parseArgs(process.argv.slice(2))
+    if (options.help) {
+      console.log(usage())
+    } else {
+      format = options.format
+      const result = await queryManifestFile(options)
+      const source = options.indexPath ? resolve(options.indexPath) : options.registryUrl
+      console.log(options.format === 'json' ? JSON.stringify({ ...result, source }, null, 2) : renderRegistryQuery(result, source))
+      if (result.summary.errors > 0 || (options.strict && result.summary.warnings > 0)) process.exitCode = 1
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    if (format === 'json') console.error(JSON.stringify({ status: 'unavailable', error: message }))
+    else {
+      console.error(`Registry query unavailable: ${message}`)
+      console.error(usage())
+    }
+    process.exitCode = 2
+  }
+}

--- a/skills/plugin-write/scripts/query-registry.mjs
+++ b/skills/plugin-write/scripts/query-registry.mjs
@@ -5,7 +5,7 @@ import { resolve } from 'node:path'
 import { pathToFileURL } from 'node:url'
 import { loadNamingPolicy, validateNamingManifest } from './validate-names.mjs'
 
-export const DEFAULT_REGISTRY_URL = 'https://raw.githubusercontent.com/zp-home/dsh-plugin-registry/main/registry/index.json'
+export const DEFAULT_REGISTRY_URL = 'https://raw.githubusercontent.com/oh-my-dsh/dsh-plugin-registry/main/registry/index.json'
 export const REGISTRY_CONTRACT = 'dsh-plugin-registry/v2'
 
 const MAX_INDEX_BYTES = 5 * 1024 * 1024

--- a/skills/plugin-write/scripts/validate-names.check.mjs
+++ b/skills/plugin-write/scripts/validate-names.check.mjs
@@ -1,0 +1,231 @@
+import assert from 'node:assert/strict'
+import { spawn } from 'node:child_process'
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+import {
+  DEFAULT_POLICY_FILE,
+  NamingInputError,
+  loadNamingPolicy,
+  renderText,
+  validateManifestFile,
+  validateNamingManifest,
+} from './validate-names.mjs'
+
+function validManifest() {
+  return {
+    $schema: './plugin-naming.schema.json',
+    schemaVersion: 1,
+    policy: 'dsh-plugin-naming/v1',
+    plugin: {
+      namespace: 'alice',
+      name: 'web-search',
+      coordinate: 'alice/web-search',
+      packageName: '@alice/dsh-web-search',
+    },
+    names: {
+      pluginNames: ['web-search'],
+      loaderIds: ['alice-web-search'],
+      services: ['aliceWebSearchIndex'],
+      tools: ['alice_web_search_query'],
+      commands: ['alice-web-search-refresh'],
+      skills: ['alice-web-search'],
+      skillProviders: ['alice-web-search-filesystem'],
+      events: ['alice-web-search/ready'],
+      settingsNamespaces: ['alice-web-search'],
+      routes: [{ kind: 'exact', path: '/api/plugins/alice-web-search/query' }],
+    },
+  }
+}
+
+function officialStyleManifest() {
+  return {
+    schemaVersion: 1,
+    policy: 'dsh-plugin-naming/v1',
+    plugin: {
+      namespace: 'alice',
+      name: 'hello-plugin',
+      coordinate: 'alice/hello-plugin',
+      packageName: 'dsh-hello-plugin',
+    },
+    names: {
+      pluginNames: ['hello-plugin'],
+      loaderIds: ['hello'],
+      services: ['metrics'],
+      tools: ['greet'],
+      commands: ['plan'],
+      skills: ['hello-plugin'],
+      skillProviders: ['hello-filesystem'],
+      events: ['hello-plugin/ready'],
+      settingsNamespaces: ['my-plugin'],
+      routes: [{ kind: 'exact', path: '/hello' }],
+    },
+  }
+}
+
+function codes(issues) {
+  return new Set(issues.map((issue) => issue.code))
+}
+
+function runCli(args) {
+  const validatorPath = fileURLToPath(new URL('./validate-names.mjs', import.meta.url))
+  return new Promise((resolvePromise, reject) => {
+    const child = spawn(process.execPath, [validatorPath, ...args], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    let stdout = ''
+    let stderr = ''
+    child.stdout.setEncoding('utf8')
+    child.stderr.setEncoding('utf8')
+    child.stdout.on('data', (chunk) => { stdout += chunk })
+    child.stderr.on('data', (chunk) => { stderr += chunk })
+    child.on('error', reject)
+    child.on('close', (code, signal) => resolvePromise({ code, signal, stdout, stderr }))
+  })
+}
+
+export async function runNamingValidatorChecks() {
+  const policy = await loadNamingPolicy()
+  const accepted = validateNamingManifest(validManifest(), policy)
+  assert.equal(accepted.valid, true)
+  assert.equal(accepted.coordinate, 'alice/web-search')
+  assert.equal(accepted.declarationCount, 10)
+  assert.equal(accepted.warnings.length, 0)
+  assert.match(renderText({ ...accepted, policy: policy.id }), /^Naming compatible:/)
+
+  const officialStyle = validateNamingManifest(officialStyleManifest(), policy)
+  assert.equal(officialStyle.valid, true, 'Official tutorial-style short names must remain compatible')
+  assert(officialStyle.warnings.some((warning) => warning.code === 'recommended-prefix'))
+
+  const invalid = validManifest()
+  invalid.extra = true
+  invalid.plugin.namespace = 'dsh-community'
+  invalid.plugin.coordinate = 'dsh-community/not-web-search'
+  invalid.plugin.packageName = 'Not A Package'
+  invalid.names.services = ['search']
+  invalid.names.tools = ['run_code']
+  invalid.names.commands = ['dsh-community-web-search', 'dsh-community-web-search']
+  invalid.names.skillProviders = ['runtime']
+  invalid.names.routes = [{ kind: 'exact', path: '/api/search' }]
+  const rejected = validateNamingManifest(invalid, policy)
+  assert.equal(rejected.valid, false)
+  for (const code of [
+    'unknown-property',
+    'coordinate-mismatch',
+    'pattern',
+    'reserved-name',
+    'duplicate',
+  ]) {
+    assert(codes(rejected.errors).has(code), `Expected rejection code ${code}`)
+  }
+  assert(rejected.errors.some(
+    (error) => error.path === '$.names.skillProviders[0]' && error.code === 'reserved-name',
+  ))
+  assert(codes(rejected.warnings).has('reserved-namespace'))
+  assert(codes(rejected.warnings).has('known-built-in'))
+  assert(codes(rejected.warnings).has('recommended-prefix'))
+
+  const malformedNames = validManifest()
+  malformedNames.names.commands = ['alice.web.search']
+  const malformedResult = validateNamingManifest(malformedNames, policy)
+  assert(malformedResult.errors.some(
+    (error) => error.path === '$.names.commands[0]' && error.code === 'pattern',
+  ))
+
+  const nonRecommendedNames = validManifest()
+  nonRecommendedNames.names.tools = ['alice_web_search_']
+  nonRecommendedNames.names.events = ['alice-web-search/ready-']
+  nonRecommendedNames.names.settingsNamespaces = ['alice--web-search']
+  const nonRecommendedResult = validateNamingManifest(nonRecommendedNames, policy)
+  assert.equal(nonRecommendedResult.valid, true)
+  for (const path of ['$.names.tools[0]', '$.names.events[0]', '$.names.settingsNamespaces[0]']) {
+    assert(nonRecommendedResult.warnings.some(
+      (warning) => warning.path === path && warning.code === 'recommended-pattern',
+    ), `Expected community-style warning at ${path}`)
+  }
+
+  const root = await mkdtemp(join(tmpdir(), 'dsh-naming-'))
+  try {
+    const manifestPath = join(root, 'dsh-plugin.naming.json')
+    const content = `${JSON.stringify(validManifest(), null, 2)}\n`
+    await writeFile(manifestPath, content)
+    const before = await readFile(manifestPath, 'utf8')
+    const fileResult = await validateManifestFile({ manifestPath })
+    const after = await readFile(manifestPath, 'utf8')
+    assert.equal(fileResult.valid, true)
+    assert.equal(after, before, 'Naming validator must not modify the manifest')
+
+    const cliAccepted = await runCli(['--manifest', manifestPath, '--format', 'json', '--strict'])
+    assert.equal(cliAccepted.code, 0)
+    assert.equal(cliAccepted.signal, null)
+    assert.equal(cliAccepted.stderr, '')
+    assert.equal(JSON.parse(cliAccepted.stdout).strictValid, true)
+
+    await writeFile(manifestPath, `${JSON.stringify(officialStyleManifest(), null, 2)}\n`)
+    const cliCompatible = await runCli(['--manifest', manifestPath])
+    assert.equal(cliCompatible.code, 0)
+    assert.match(cliCompatible.stdout, /WARN .*recommended-prefix/)
+    const cliStrictWarning = await runCli(['--manifest', manifestPath, '--strict'])
+    assert.equal(cliStrictWarning.code, 1)
+    assert.match(cliStrictWarning.stdout, /Strict naming validation failed/)
+
+    const invalidManifest = validManifest()
+    invalidManifest.names.loaderIds = ['Web Search']
+    await writeFile(manifestPath, `${JSON.stringify(invalidManifest, null, 2)}\n`)
+    const cliRejected = await runCli(['--manifest', manifestPath])
+    assert.equal(cliRejected.code, 1)
+    assert.match(cliRejected.stdout, /pattern/)
+    assert.equal(cliRejected.stderr, '')
+
+    await writeFile(manifestPath, '{ invalid json')
+    await assert.rejects(
+      validateManifestFile({ manifestPath }),
+      (error) => error instanceof NamingInputError && /Cannot parse naming manifest/.test(error.message),
+    )
+    const cliInputError = await runCli(['--manifest', manifestPath])
+    assert.equal(cliInputError.code, 2)
+    assert.match(cliInputError.stderr, /Naming input error: Cannot parse naming manifest/)
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+
+  const schemaPath = resolve(dirname(DEFAULT_POLICY_FILE), 'plugin-naming.schema.json')
+  const schema = JSON.parse(await readFile(schemaPath, 'utf8'))
+  assert.equal(schema.properties.schemaVersion.const, policy.schemaVersion)
+  assert.equal(schema.properties.policy.const, policy.id)
+  assert.deepEqual(schema.properties.names.required, Object.keys(validManifest().names))
+  assert.equal(schema.$defs.nonEmptyPluginNameList.minItems, 1)
+  assert.equal(schema.$defs.nonEmptyLoaderIdList.minItems, 1)
+  assert.equal(schema.properties.plugin.properties.namespace.pattern, policy.surfaces.namespace.pattern)
+  assert.equal(schema.properties.plugin.properties.namespace.maxLength, policy.surfaces.namespace.maxLength)
+  assert.equal(schema.properties.plugin.properties.name.pattern, policy.surfaces.pluginName.pattern)
+  assert.equal(schema.properties.plugin.properties.name.maxLength, policy.surfaces.pluginName.maxLength)
+  assert.equal(schema.properties.plugin.properties.packageName.pattern, policy.surfaces.packageName.pattern)
+  assert.equal(schema.properties.plugin.properties.packageName.maxLength, policy.surfaces.packageName.maxLength)
+  const surfaceDefinitions = {
+    pluginNames: 'nonEmptyPluginNameList',
+    loaderIds: 'nonEmptyLoaderIdList',
+    services: 'serviceList',
+    tools: 'toolList',
+    commands: 'commandList',
+    skills: 'skillList',
+    skillProviders: 'skillProviderList',
+    events: 'eventList',
+    settingsNamespaces: 'settingsNamespaceList',
+  }
+  for (const [surface, definition] of Object.entries(surfaceDefinitions)) {
+    assert.equal(schema.$defs[definition].items.pattern, policy.surfaces[surface].pattern)
+    assert.equal(schema.$defs[definition].items.maxLength, policy.surfaces[surface].maxLength)
+  }
+  assert.equal(schema.$defs.routeList.items.properties.path.pattern, policy.surfaces.routes.pattern)
+  assert.equal(schema.$defs.routeList.items.properties.path.maxLength, policy.surfaces.routes.maxLength)
+  assert.deepEqual(schema.$defs.routeList.items.properties.kind.enum, ['exact', 'prefix', 'upgrade'])
+  assert.deepEqual(Object.keys(policy.collisionSemantics), Object.keys(validManifest().names))
+}
+
+const invokedPath = process.argv[1] ? pathToFileURL(resolve(process.argv[1])).href : undefined
+if (invokedPath === import.meta.url) {
+  await runNamingValidatorChecks()
+  console.log('Naming validator checks OK: official compatibility, strict recommendations, collision semantics, schema, read-only behavior, CLI exits 0/1/2')
+}

--- a/skills/plugin-write/scripts/validate-names.mjs
+++ b/skills/plugin-write/scripts/validate-names.mjs
@@ -1,0 +1,397 @@
+#!/usr/bin/env node
+
+import { readFile } from 'node:fs/promises'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+const scriptDir = dirname(fileURLToPath(import.meta.url))
+export const DEFAULT_POLICY_FILE = resolve(scriptDir, '..', 'references', 'naming-policy.v1.json')
+
+const ROOT_KEYS = new Set(['$schema', 'schemaVersion', 'policy', 'plugin', 'names'])
+const PLUGIN_KEYS = new Set(['namespace', 'name', 'coordinate', 'packageName'])
+const SURFACE_NAMES = [
+  'pluginNames',
+  'loaderIds',
+  'services',
+  'tools',
+  'commands',
+  'skills',
+  'skillProviders',
+  'events',
+  'settingsNamespaces',
+  'routes',
+]
+const NON_EMPTY_SURFACES = new Set(['pluginNames', 'loaderIds'])
+
+export class NamingInputError extends Error {
+  constructor(message, options) {
+    super(message, options)
+    this.name = 'NamingInputError'
+  }
+}
+
+function isObject(value) {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function addError(errors, path, code, message) {
+  errors.push({ path, code, message })
+}
+
+function validateKeys(value, allowed, required, path, errors) {
+  if (!isObject(value)) {
+    addError(errors, path, 'type', 'must be an object')
+    return false
+  }
+  for (const key of Object.keys(value)) {
+    if (!allowed.has(key)) addError(errors, `${path}.${key}`, 'unknown-property', 'is not allowed')
+  }
+  for (const key of required) {
+    if (!Object.hasOwn(value, key)) addError(errors, `${path}.${key}`, 'required', 'is required')
+  }
+  return true
+}
+
+function validatePolicyShape(policy, source) {
+  if (!isObject(policy)) throw new NamingInputError(`Naming policy must be an object: ${source}`)
+  if (typeof policy.id !== 'string' || !policy.id) throw new NamingInputError(`Naming policy has no id: ${source}`)
+  if (!Number.isInteger(policy.schemaVersion)) {
+    throw new NamingInputError(`Naming policy has an invalid schemaVersion: ${source}`)
+  }
+  if (!isObject(policy.surfaces)) throw new NamingInputError(`Naming policy has no surfaces: ${source}`)
+  for (const surface of ['namespace', 'pluginName', 'packageName', ...SURFACE_NAMES]) {
+    const rule = policy.surfaces[surface]
+    if (!isObject(rule) || typeof rule.pattern !== 'string'
+      || (rule.maxLength !== undefined && !Number.isInteger(rule.maxLength))
+      || (rule.recommendedPattern !== undefined && typeof rule.recommendedPattern !== 'string')
+      || (rule.recommendedMaxLength !== undefined && !Number.isInteger(rule.recommendedMaxLength))) {
+      throw new NamingInputError(`Naming policy has an invalid ${surface} rule: ${source}`)
+    }
+    try {
+      new RegExp(rule.pattern, 'u')
+      if (rule.recommendedPattern !== undefined) new RegExp(rule.recommendedPattern, 'u')
+    } catch (error) {
+      throw new NamingInputError(`Naming policy has an invalid ${surface} regex: ${error.message}`, { cause: error })
+    }
+  }
+  if (!isObject(policy.collisionSemantics)) {
+    throw new NamingInputError(`Naming policy has no collisionSemantics: ${source}`)
+  }
+  for (const surface of SURFACE_NAMES) {
+    if (typeof policy.collisionSemantics[surface] !== 'string') {
+      throw new NamingInputError(`Naming policy has no collision semantics for ${surface}: ${source}`)
+    }
+  }
+}
+
+export async function loadNamingPolicy(policyPath = DEFAULT_POLICY_FILE) {
+  const absolute = resolve(policyPath)
+  let text
+  try {
+    text = await readFile(absolute, 'utf8')
+  } catch (error) {
+    throw new NamingInputError(`Cannot read naming policy ${absolute}: ${error.message}`, { cause: error })
+  }
+  let policy
+  try {
+    policy = JSON.parse(text)
+  } catch (error) {
+    throw new NamingInputError(`Cannot parse naming policy ${absolute}: ${error.message}`, { cause: error })
+  }
+  validatePolicyShape(policy, absolute)
+  return policy
+}
+
+function validateString(value, rule, path, errors) {
+  if (typeof value !== 'string') {
+    addError(errors, path, 'type', 'must be a string')
+    return false
+  }
+  if (rule.maxLength !== undefined && value.length > rule.maxLength) {
+    addError(errors, path, 'max-length', `must be at most ${rule.maxLength} characters`)
+  }
+  if (!new RegExp(rule.pattern, 'u').test(value)) {
+    addError(errors, path, 'pattern', `must match ${rule.pattern}`)
+    return false
+  }
+  return true
+}
+
+function validateRecommendation(value, rule, path, warnings) {
+  if (typeof value !== 'string') return
+  if (rule.recommendedMaxLength !== undefined && value.length > rule.recommendedMaxLength) {
+    addError(warnings, path, 'recommended-max-length', `should be at most ${rule.recommendedMaxLength} characters`)
+  }
+  if (rule.recommendedPattern !== undefined && !new RegExp(rule.recommendedPattern, 'u').test(value)) {
+    addError(warnings, path, 'recommended-pattern', `should match ${rule.recommendedPattern}`)
+  }
+}
+
+function kebabToCamel(value) {
+  const parts = value.split('-')
+  return parts[0] + parts.slice(1).map((part) => part[0].toUpperCase() + part.slice(1)).join('')
+}
+
+function hasDelimitedPrefix(value, base, separator) {
+  return value === base || value.startsWith(`${base}${separator}`)
+}
+
+function hasCamelPrefix(value, base) {
+  if (value === base) return true
+  return value.startsWith(base) && /^[A-Z0-9]/u.test(value.slice(base.length, base.length + 1))
+}
+
+function isReservedNamespace(namespace, prefixes) {
+  return prefixes.some((prefix) => namespace === prefix || namespace.startsWith(`${prefix}-`))
+}
+
+function validateSurfaceList(names, surface, policy, errors, warnings) {
+  const path = `$.names.${surface}`
+  const values = names[surface]
+  if (!Array.isArray(values)) {
+    addError(errors, path, 'type', 'must be an array')
+    return []
+  }
+  if (NON_EMPTY_SURFACES.has(surface) && values.length === 0) {
+    addError(errors, path, 'min-items', 'must declare at least one value')
+  }
+  const seen = new Set()
+  for (let index = 0; index < values.length; index += 1) {
+    const value = values[index]
+    const itemPath = `${path}[${index}]`
+    let duplicateKey = value
+    if (surface === 'routes') {
+      const routeOk = validateKeys(
+        value,
+        new Set(['kind', 'path']),
+        ['kind', 'path'],
+        itemPath,
+        errors,
+      )
+      if (!routeOk) continue
+      if (!['exact', 'prefix', 'upgrade'].includes(value.kind)) {
+        addError(errors, `${itemPath}.kind`, 'enum', 'must be exact, prefix, or upgrade')
+      }
+      validateString(value.path, policy.surfaces.routes, `${itemPath}.path`, errors)
+      validateRecommendation(value.path, policy.surfaces.routes, `${itemPath}.path`, warnings)
+      duplicateKey = `${value.kind}:${value.path}`
+    } else {
+      validateString(value, policy.surfaces[surface], itemPath, errors)
+      validateRecommendation(value, policy.surfaces[surface], itemPath, warnings)
+    }
+    if (typeof duplicateKey === 'string') {
+      if (seen.has(duplicateKey)) addError(errors, itemPath, 'duplicate', `duplicates ${JSON.stringify(duplicateKey)}`)
+      seen.add(duplicateKey)
+    }
+  }
+  return values
+}
+
+function validateOwnership(values, surface, bases, policy, errors, warnings) {
+  const path = `$.names.${surface}`
+  const reserved = new Set(policy.reservedExactNames?.[surface] ?? [])
+  const knownBuiltIns = new Set(policy.knownBuiltInExactNames?.[surface] ?? [])
+  for (let index = 0; index < values.length; index += 1) {
+    const declared = values[index]
+    const value = surface === 'routes' && isObject(declared) ? declared.path : declared
+    if (typeof value !== 'string') continue
+    const itemPath = surface === 'routes' ? `${path}[${index}].path` : `${path}[${index}]`
+    if (reserved.has(value)) addError(errors, itemPath, 'reserved-name', `${JSON.stringify(value)} is reserved`)
+    if (knownBuiltIns.has(value)) {
+      addError(warnings, itemPath, 'known-built-in', `${JSON.stringify(value)} is built into the verified Harness baseline`)
+    }
+
+    if (surface === 'pluginNames') continue
+
+    let owned = true
+    if (surface === 'services') owned = hasCamelPrefix(value, bases.camel)
+    else if (surface === 'tools') owned = hasDelimitedPrefix(value, bases.snake, '_')
+    else if (surface === 'events') owned = value.startsWith(`${bases.kebab}/`)
+    else if (surface === 'routes') owned = value === bases.route || value.startsWith(`${bases.route}/`)
+    else owned = hasDelimitedPrefix(value, bases.kebab, '-')
+
+    if (!owned) {
+      const expected = surface === 'services'
+        ? bases.camel
+        : surface === 'tools'
+          ? bases.snake
+          : surface === 'routes'
+            ? bases.route
+            : bases.kebab
+      addError(warnings, itemPath, 'recommended-prefix', `does not use the collision-resistant prefix ${JSON.stringify(expected)}`)
+    }
+  }
+}
+
+export function validateNamingManifest(manifest, policy) {
+  validatePolicyShape(policy, '<memory>')
+  const errors = []
+  const warnings = []
+  const rootOk = validateKeys(manifest, ROOT_KEYS, ['schemaVersion', 'policy', 'plugin', 'names'], '$', errors)
+  if (!rootOk) return { valid: false, errors, warnings, coordinate: undefined, declarationCount: 0 }
+
+  if (manifest.schemaVersion !== policy.schemaVersion) {
+    addError(errors, '$.schemaVersion', 'schema-version', `must equal ${policy.schemaVersion}`)
+  }
+  if (manifest.policy !== policy.id) {
+    addError(errors, '$.policy', 'policy-id', `must equal ${JSON.stringify(policy.id)}`)
+  }
+  if (Object.hasOwn(manifest, '$schema') && typeof manifest.$schema !== 'string') {
+    addError(errors, '$.$schema', 'type', 'must be a string')
+  } else if (manifest.$schema === '') {
+    addError(errors, '$.$schema', 'min-length', 'must not be empty')
+  }
+
+  const pluginOk = validateKeys(
+    manifest.plugin,
+    PLUGIN_KEYS,
+    ['namespace', 'name', 'coordinate', 'packageName'],
+    '$.plugin',
+    errors,
+  )
+  let coordinate
+  let bases
+  if (pluginOk) {
+    const namespaceOk = validateString(
+      manifest.plugin.namespace,
+      policy.surfaces.namespace,
+      '$.plugin.namespace',
+      errors,
+    )
+    const nameOk = validateString(
+      manifest.plugin.name,
+      policy.surfaces.pluginName,
+      '$.plugin.name',
+      errors,
+    )
+    if (namespaceOk && isReservedNamespace(manifest.plugin.namespace, policy.reservedNamespacePrefixes ?? [])) {
+      addError(warnings, '$.plugin.namespace', 'reserved-namespace', 'resembles a publisher namespace reserved by community convention')
+    }
+    if (namespaceOk && nameOk) {
+      const kebab = `${manifest.plugin.namespace}-${manifest.plugin.name}`
+      coordinate = `${manifest.plugin.namespace}/${manifest.plugin.name}`
+      bases = {
+        kebab,
+        snake: kebab.replaceAll('-', '_'),
+        camel: kebabToCamel(kebab),
+        route: `/api/plugins/${kebab}`,
+      }
+      if (manifest.plugin.coordinate !== coordinate) {
+        addError(errors, '$.plugin.coordinate', 'coordinate-mismatch', `must equal ${JSON.stringify(coordinate)}`)
+      }
+    } else if (typeof manifest.plugin.coordinate !== 'string') {
+      addError(errors, '$.plugin.coordinate', 'type', 'must be a string')
+    }
+    validateString(manifest.plugin.packageName, policy.surfaces.packageName, '$.plugin.packageName', errors)
+    validateRecommendation(manifest.plugin.packageName, policy.surfaces.packageName, '$.plugin.packageName', warnings)
+  }
+
+  const namesOk = validateKeys(
+    manifest.names,
+    new Set(SURFACE_NAMES),
+    SURFACE_NAMES,
+    '$.names',
+    errors,
+  )
+  let declarationCount = 0
+  if (namesOk) {
+    for (const surface of SURFACE_NAMES) {
+      const values = validateSurfaceList(manifest.names, surface, policy, errors, warnings)
+      declarationCount += values.length
+      if (bases) validateOwnership(values, surface, bases, policy, errors, warnings)
+    }
+  }
+
+  return { valid: errors.length === 0, errors, warnings, coordinate, declarationCount }
+}
+
+export async function validateManifestFile({ manifestPath, policyPath = DEFAULT_POLICY_FILE }) {
+  const absoluteManifest = resolve(manifestPath)
+  let text
+  try {
+    text = await readFile(absoluteManifest, 'utf8')
+  } catch (error) {
+    throw new NamingInputError(`Cannot read naming manifest ${absoluteManifest}: ${error.message}`, { cause: error })
+  }
+  let manifest
+  try {
+    manifest = JSON.parse(text)
+  } catch (error) {
+    throw new NamingInputError(`Cannot parse naming manifest ${absoluteManifest}: ${error.message}`, { cause: error })
+  }
+  const policy = await loadNamingPolicy(policyPath)
+  return { ...validateNamingManifest(manifest, policy), manifestPath: absoluteManifest, policy: policy.id }
+}
+
+export function renderText(result) {
+  const strictFailure = result.strict === true && result.warnings.length > 0
+  const lines = []
+  if (result.valid && !strictFailure) {
+    lines.push(`Naming compatible: ${result.coordinate} (${result.declarationCount} declarations, ${result.policy})`)
+  } else if (result.valid) {
+    lines.push(`Strict naming validation failed (${result.warnings.length} recommendations):`)
+  } else {
+    lines.push(`Naming validation failed (${result.errors.length} errors):`)
+  }
+  for (const error of result.errors) lines.push(`- ERROR ${error.path} [${error.code}] ${error.message}`)
+  for (const warning of result.warnings) lines.push(`- WARN ${warning.path} [${warning.code}] ${warning.message}`)
+  return lines.join('\n')
+}
+
+function usage() {
+  return [
+    'Usage: node validate-names.mjs --manifest <path> [--policy <path>] [--format text|json] [--strict]',
+    '',
+    'Validates official compatibility and community collision recommendations without network access or file writes.',
+  ].join('\n')
+}
+
+function parseArgs(args) {
+  const options = { format: 'text', strict: false }
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index]
+    if (argument === '--help' || argument === '-h') return { help: true }
+    if (argument === '--strict') {
+      options.strict = true
+      continue
+    }
+    if (argument === '--manifest' || argument === '--policy' || argument === '--format') {
+      const value = args[index + 1]
+      if (!value || value.startsWith('--')) throw new NamingInputError(`${argument} requires a value`)
+      options[argument.slice(2)] = value
+      index += 1
+      continue
+    }
+    throw new NamingInputError(`Unknown argument: ${argument}`)
+  }
+  if (!options.manifest) throw new NamingInputError('--manifest is required')
+  if (!['text', 'json'].includes(options.format)) throw new NamingInputError('--format must be text or json')
+  return options
+}
+
+const invokedPath = process.argv[1] ? pathToFileURL(resolve(process.argv[1])).href : undefined
+if (invokedPath === import.meta.url) {
+  try {
+    const options = parseArgs(process.argv.slice(2))
+    if (options.help) {
+      console.log(usage())
+    } else {
+      const result = await validateManifestFile({
+        manifestPath: options.manifest,
+        policyPath: options.policy,
+      })
+      const output = {
+        ...result,
+        strict: options.strict,
+        strictValid: result.valid && (!options.strict || result.warnings.length === 0),
+      }
+      console.log(options.format === 'json' ? JSON.stringify(output, null, 2) : renderText(output))
+      if (!output.strictValid) process.exitCode = 1
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    console.error(`Naming input error: ${message}`)
+    console.error(usage())
+    process.exitCode = 2
+  }
+}


### PR DESCRIPTION
# 中文

## 摘要

本 PR 为 `plugin-write` Skill 增加两层互相独立的插件冲突预防机制：

1. 第一阶段是完全离线的命名规范、`dsh-plugin.naming.json` JSON Schema 和只读本地校验器。
2. 第二阶段是在本地校验通过后，对中央 `dsh-plugin-registry/v2` 已审核记录执行可选的只读查询。

第一阶段主动减少新插件的命名碰撞概率，第二阶段发现已经登记的身份占用和上下文重叠。两层都不会自动修改插件、替用户改名或声称提供全网唯一性证明。

## 关联 Issue

无。本 PR 来自 DSH 插件方法名、公开 ID、命名规范和中央兼容性检查的设计讨论。

中央 v2 注册表与主动发现机制由以下 PR 提供：

https://github.com/oh-my-dsh/dsh-plugin-registry/pull/1

## 设计原因

DeepSeek Harness 没有一个覆盖所有扩展面的单一“插件 ID”。npm package、插件模块名、Loader 行 ID、Cordis service、模型 tool、用户 command、Skill、Skill provider、event、settings namespace 和 Web route 分别由不同组件管理，冲突条件也不同。

如果只要求所有名称统一加前缀，会错误拒绝官方教程中的 `greet`、`metrics`、`hello` 和 `my-plugin` 等合法短名称，也会把有意 Loader 覆盖、Agent scope 遮蔽、Skill rank 胜出规则和共享事件误判成全局冲突。反过来，仅做本地字符串检查又无法知道其他仓库已经审核登记的名称。

因此本 PR 把问题拆成两个职责清晰的阶段：本地声明负责可重复、无网络依赖的规范检查；中央查询负责读取社区已经审核的事实。中央仓库不可用时，第一阶段仍然完整工作，第二阶段必须报告“未知/未检查”，不能把网络失败解释为“名称可用”。

## 第一阶段：离线命名规范

- 新增 `naming-policy.v1.json`，固定官方核验基线为 `dsh-v0.1.2-alpha.2` 的提交 `0a53fb55bea101816fa226bb964ae2bed71c343b`，并记录每个扩展面的真实冲突语义。
- 新增 `plugin-naming.schema.json`，定义仓库根目录 `dsh-plugin.naming.json` 的结构，分别记录插件模块名、Skill 名、Skill provider 和 `{ kind, path }` route，避免丢失冲突维度。
- 新增零依赖、无网络、只读的 `validate-names.mjs`。Harness 兼容性错误默认失败；社区防碰撞风格只产生 warning；选择 `--strict` 时 warning 也会失败。
- 保持官方教程短名称兼容，不强迫现有已发布插件改名；新插件可以自愿采用 publisher-aware 前缀来降低组合碰撞概率。
- 文档明确说明 `dsh-plugin.naming.json` 是社区协调声明，不是 DeepSeek Harness 官方 manifest，也不构成中央预留。

## 第二阶段：中央只读查询

- 新增 `query-registry.mjs`，默认查询：

```text
https://raw.githubusercontent.com/oh-my-dsh/dsh-plugin-registry/main/registry/index.json
```

- 客户端只接受 `dsh-plugin-registry/v2`，支持精确 Harness 版本过滤、10 秒超时、5 MiB 响应上限、离线 `--index`、镜像 `--registry-url`、JSON 输出和 `--strict`。
- 查询前会再次运行第一阶段校验；无效本地声明不会发送网络请求。
- 查询器识别正式 coordinate/package 登记、Loader composition、带 scope 的 service/tool/command/provider/settings、Skill provider/rank、共享 event 和 `kind + path` route。
- 无匹配只表示“已审核索引中没有匹配”，不代表全网唯一；网络、超时、格式、契约版本或本地输入失败返回退出码 `2`，表示未知/未检查。
- 普通上下文命中默认只报告 warning/notice；身份或 package 不一致失败；`--strict` 可让上下文 warning 失败，notice 永不阻断。
- 查询器不写中央仓库、不修改本地 manifest、不执行注册表或第三方插件代码，也不会根据结果自动重命名已发布接口。

## 与 DeepSeek Harness 的兼容性

本设计没有复制或覆盖 Harness 自带规范，而是引用并固定官方实现，再补充社区协调层：

- Loader ID 可以被后续 patch layer 有意替换，因此同名需要比较 composition、layer 和 replacement intent。
- Service 可通过 Cordis realm/scope 隔离。
- Tool 和 command 在同 scope 内拒绝重复，但较近的 Agent scope 可以遮蔽外层声明。
- Skill 的胜出项由 scope、rank、provider 和本地顺序共同决定。
- Event 是共享通道，不是排他 ID；只有 publisher schema 不兼容时才是实际风险。
- Settings namespace 的重复注册需要检查 scope。
- Web route 的冲突键至少包含 `kind + path + router scope`。
- 端口是部署组合问题，取决于同机部署、绑定地址、协议和配置覆盖，不属于静态名称预留。

因此第一阶段不会把社区前缀建议冒充官方要求，第二阶段也不会仅凭同名字符串直接断言插件不兼容。

## 实际效果

- 插件作者在写代码前即可生成结构化命名清单并离线发现格式、保留名和社区风格问题。
- 有网络时可进一步查询中央审核记录，看到可能冲突的插件、仓库、Harness 范围和声明上下文。
- CI 可以区分“校验通过”“严格模式发现风险”和“查询不可用”，避免错误放行。
- 本地规范与中央登记通过相同示例和跨仓对拍保持契约一致，同时仍可分别升级和独立失败。
- GitHub 主动发现候选不会进入查询结果；只有经人工批准并合并到中央 `registry/entries/` 的记录才参与判断。

## 验证

以下命令已在最终提交 `97c8e2ab76d7b069bb48df6ceeb756c9347a015f` 上实际运行并通过：

```text
npm test
python -X utf8 C:\Users\Administrator.DESKTOP-0KF8V7V\.codex\skills\.system\skill-creator\scripts\quick_validate.py skills/plugin-write
git diff --check HEAD^ HEAD
```

自动化检查覆盖官方短名称兼容、严格社区建议、重复项、保留的 `runtime` Skill provider、已知内置 tool warning、Schema 与 Policy 一致性、只读行为、JSON 输出、本地校验退出码、中央 v2 契约、Harness 版本过滤、上下文命中、共享 event notice、陈旧登记、离线索引和中央查询退出码 `0/1/2`。

跨仓示例对拍结果：

```json
{
  "coordinate": "alice/web-search",
  "registration": "active",
  "errors": 0,
  "warnings": 0,
  "notices": 0
}
```

## 证据

- 第一阶段提交：https://github.com/zp-home/dsh-plugin-upgrade-skill/commit/22c52662ab95e2d7730ed3b13241a804bf86ee28
- 第二阶段提交：https://github.com/zp-home/dsh-plugin-upgrade-skill/commit/b44552e55d0b30eb19a5d700c7d48c058c8203d2
- 组织注册表切换提交：https://github.com/zp-home/dsh-plugin-upgrade-skill/commit/97c8e2ab76d7b069bb48df6ceeb756c9347a015f
- 中央注册表 PR：https://github.com/oh-my-dsh/dsh-plugin-registry/pull/1
- 官方插件与 Loader 示例：https://github.com/deepseek-ai/deepseek-harness/blob/0a53fb55bea101816fa226bb964ae2bed71c343b/docs/user/develop/basic/index.zh.md
- 官方 bundle 与 patch layer 语义：https://github.com/deepseek-ai/deepseek-harness/blob/0a53fb55bea101816fa226bb964ae2bed71c343b/docs/user/develop/basic/publish.zh.md
- 官方 command 语义：https://github.com/deepseek-ai/deepseek-harness/blob/0a53fb55bea101816fa226bb964ae2bed71c343b/packages/interaction/commands/README.zh.md
- 官方 Skill 胜出与 provider 语义：https://github.com/deepseek-ai/deepseek-harness/blob/0a53fb55bea101816fa226bb964ae2bed71c343b/packages/skill/skill/README.zh.md

## 合并顺序

中央注册表 PR #1 已合并到 `oh-my-dsh/dsh-plugin-registry`。本 PR 已 rebase 到最新 `main`，阶段二查询器现在默认读取组织仓库的 v2 索引。

## 限制与剩余风险

- 官方核验基线当前是预发布版本 `dsh-v0.1.2-alpha.2`；Harness 新版本发布后必须重新核验语法和冲突语义。
- 本地声明不会扫描或执行源码来证明所有动态名称都已列出，也不会验证某个真实 Profile 的完整插件组合。
- 中央注册表只覆盖已经合并的公开登记，未登记插件、陈旧记录、动态名称和未知 scope 仍是盲区。
- Raw GitHub 索引可能存在短时缓存；查询结果是审核快照，不是实时锁。
- 已发布名称的任何兼容性破坏性重命名仍必须获得用户明确授权。

## 发布说明

`plugin-write` 现在提供独立的离线命名规范校验和可选的中央 v2 冲突查询：先主动降低新插件的碰撞概率，再基于已审核登记发现已知上下文重叠，同时明确区分“无匹配”和“未检查”。

---

# English

## Summary

This PR adds two independent plugin-conflict prevention layers to the `plugin-write` Skill:

1. Phase one provides fully offline naming guidance, a JSON Schema for `dsh-plugin.naming.json`, and a read-only local validator.
2. Phase two optionally queries reviewed records from the central `dsh-plugin-registry/v2` after local validation succeeds.

Phase one proactively reduces collision risk for new plugins. Phase two finds reviewed identity ownership and contextual overlaps. Neither phase modifies plugins automatically, renames public surfaces, or claims global uniqueness.

## Related Issue

None. This PR follows a design discussion about DSH plugin method names, public IDs, naming conventions, and central compatibility checks.

The central v2 registry and proactive discovery implementation are provided by:

https://github.com/oh-my-dsh/dsh-plugin-registry/pull/1

## Design Rationale

DeepSeek Harness does not have one plugin ID covering every extension surface. npm packages, plugin module names, Loader row IDs, Cordis services, model tools, user commands, Skills, Skill providers, events, settings namespaces, and Web routes are owned by different components with different collision rules.

A universal mandatory prefix would reject valid official tutorial names such as `greet`, `metrics`, `hello`, and `my-plugin`. It would also misclassify intentional Loader replacement, Agent-scope shadowing, Skill rank selection, and shared events as global conflicts. Conversely, local string checks alone cannot know which names have been reviewed in other repositories.

This PR splits those responsibilities into two explicit phases. A local declaration provides deterministic checks without network access. The central lookup reads reviewed community facts. If the registry is unavailable, phase one remains complete while phase two must report unknown/not checked rather than treating a network failure as availability.

## Phase One: Offline Naming Policy

- Add `naming-policy.v1.json`, pinned to DeepSeek Harness `dsh-v0.1.2-alpha.2` commit `0a53fb55bea101816fa226bb964ae2bed71c343b`, with verified collision semantics for every extension surface.
- Add `plugin-naming.schema.json` for a repository-root `dsh-plugin.naming.json`. Plugin module names, Skill names, Skill providers, and `{ kind, path }` routes remain separate so collision dimensions are preserved.
- Add the zero-dependency, offline, read-only `validate-names.mjs`. Harness compatibility errors fail by default; community collision-avoidance style produces warnings; `--strict` makes warnings fail.
- Preserve compatibility with official tutorial-style short names and avoid forced renames for existing public plugins. New plugins may voluntarily adopt publisher-aware prefixes.
- State explicitly that `dsh-plugin.naming.json` is a community coordination declaration, not an official DeepSeek Harness manifest or central reservation.

## Phase Two: Read-Only Central Lookup

- Add `query-registry.mjs`, which defaults to:

```text
https://raw.githubusercontent.com/oh-my-dsh/dsh-plugin-registry/main/registry/index.json
```

- Accept only `dsh-plugin-registry/v2`, with exact Harness version filtering, a 10-second timeout, a 5 MiB response limit, offline `--index`, mirror `--registry-url`, JSON output, and `--strict`.
- Re-run phase-one validation before lookup. Invalid local declarations make no network request.
- Understand formal coordinate/package registrations, Loader composition, scoped service/tool/command/provider/settings claims, Skill provider/rank, shared events, and `kind + path` routes.
- Treat no match only as no match in the reviewed index, never as global uniqueness. Network, timeout, data, contract-version, and local-input failures exit with status `2` for unknown/not checked.
- Keep contextual matches advisory by default. Identity or package mismatches fail; `--strict` makes contextual warnings fail; notices never block.
- Never write to the registry, modify the local manifest, execute registry or plugin code, or rename a released API from lookup results.

## DeepSeek Harness Compatibility

The design does not duplicate or replace built-in Harness rules. It pins the official implementation and adds a community coordination layer:

- Loader IDs may be intentionally replaced by later patch layers, so composition, layer, and replacement intent matter.
- Services may be isolated by Cordis realm or scope.
- Tools and commands reject duplicates within one scope, while a nearer Agent scope may shadow an outer declaration.
- Skill selection depends on scope, rank, provider, and local order.
- Events are shared channels rather than exclusive IDs; incompatible publisher schemas create the real risk.
- Settings namespace duplication must be evaluated by scope.
- Web route collision keys include at least `kind + path + router scope`.
- Ports are deployment-composition concerns depending on host placement, bind address, protocol, and configuration overrides, not static name reservations.

Phase one therefore does not present community prefixes as official requirements, and phase two does not infer incompatibility from equal strings alone.

## User-Visible Effects

- Authors can generate a structured naming declaration before implementation and catch format, reserved-name, and community-style issues offline.
- With network access, they can also inspect matching registered plugins, repositories, Harness ranges, and contextual claims.
- CI can distinguish successful validation, strict-mode risk findings, and unavailable lookup instead of allowing false success.
- Shared examples and a cross-repository contract test keep the local policy and central registry aligned while allowing both components to evolve and fail independently.
- GitHub discovery candidates never enter lookup results. Only human-approved records merged into the central `registry/entries/` participate.

## Verification

The following commands were run and passed on final commit `97c8e2ab76d7b069bb48df6ceeb756c9347a015f`:

```text
npm test
python -X utf8 C:\Users\Administrator.DESKTOP-0KF8V7V\.codex\skills\.system\skill-creator\scripts\quick_validate.py skills/plugin-write
git diff --check HEAD^ HEAD
```

Coverage includes official short-name compatibility, strict community recommendations, duplicates, the reserved `runtime` Skill provider, known built-in tool warnings, Schema and Policy parity, read-only behavior, JSON output, local-validator exits, the central v2 contract, Harness filtering, contextual matches, shared-event notices, stale registrations, offline indexes, and central-query exit codes `0/1/2`.

Cross-repository example result:

```json
{
  "coordinate": "alice/web-search",
  "registration": "active",
  "errors": 0,
  "warnings": 0,
  "notices": 0
}
```

## Evidence

- Phase-one commit: https://github.com/zp-home/dsh-plugin-upgrade-skill/commit/22c52662ab95e2d7730ed3b13241a804bf86ee28
- Phase-two commit: https://github.com/zp-home/dsh-plugin-upgrade-skill/commit/b44552e55d0b30eb19a5d700c7d48c058c8203d2
- Organization-registry switch commit: https://github.com/zp-home/dsh-plugin-upgrade-skill/commit/97c8e2ab76d7b069bb48df6ceeb756c9347a015f
- Central registry PR: https://github.com/oh-my-dsh/dsh-plugin-registry/pull/1
- Official plugin and Loader example: https://github.com/deepseek-ai/deepseek-harness/blob/0a53fb55bea101816fa226bb964ae2bed71c343b/docs/user/develop/basic/index.md
- Official bundle and patch-layer semantics: https://github.com/deepseek-ai/deepseek-harness/blob/0a53fb55bea101816fa226bb964ae2bed71c343b/docs/user/develop/basic/publish.md
- Official command semantics: https://github.com/deepseek-ai/deepseek-harness/blob/0a53fb55bea101816fa226bb964ae2bed71c343b/packages/interaction/commands/README.md
- Official Skill winner and provider semantics: https://github.com/deepseek-ai/deepseek-harness/blob/0a53fb55bea101816fa226bb964ae2bed71c343b/packages/skill/skill/README.md

## Merge Order

Central registry PR #1 is merged into `oh-my-dsh/dsh-plugin-registry`. This PR is rebased onto the latest `main`, and the phase-two client now defaults to the organization-owned v2 index.

## Limits And Residual Risk

- The verified upstream baseline is the prerelease `dsh-v0.1.2-alpha.2`. Grammars and conflict semantics must be rechecked after a new Harness release.
- The local declaration does not scan or execute source to prove every dynamic name is listed and does not validate a complete real Profile composition.
- The central registry covers only merged public registrations. Unregistered plugins, stale records, dynamic names, and unknown scopes remain blind spots.
- Raw GitHub indexes may be briefly cached. Lookup is a reviewed snapshot rather than a real-time lock.
- Any compatibility-breaking rename of a released surface still requires explicit user authorization.

## Release Notes

`plugin-write` now provides independent offline naming-policy validation and optional central v2 conflict lookup: it first reduces collision risk proactively, then checks reviewed registrations for known contextual overlaps while distinguishing no match from not checked.
