### PR TITLE
chore: 移除 legacy 斜杠命令包装文件

### DIFF
--- a/.claude/commands/dsh-upgrade.md
+++ b/.claude/commands/dsh-upgrade.md
@@ -1,7 +1,0 @@
----
-description: 升级 DSH 插件 — 由 plugin-upgrade Skill 选择只读检查、插件升级或宿主迁移模式
----
-
-调用 `dsh-plugin-upgrade-skill:plugin-upgrade` Skill，并把 `$ARGUMENTS` 原样作为用户的目标版本或附加要求。
-
-严格遵守该 Skill 当前定义的模式分流、只读/写入边界、七类 pre-flight、版本走廊、确认、验证和报告规则。不要在命令文件中复制、简化或重写工作流；用户意图不明确时先确认模式。

--- a/.gemini/commands/dsh-upgrade.toml
+++ b/.gemini/commands/dsh-upgrade.toml
@@ -1,7 +1,0 @@
-description = "升级 DSH 插件 — 由 plugin-upgrade Skill 选择只读检查、插件升级或宿主迁移模式"
-
-prompt = """
-调用 `plugin-upgrade` Skill，并把 `{{args}}` 原样作为用户的目标版本或附加要求。
-
-严格遵守该 Skill 当前定义的模式分流、只读/写入边界、七类 pre-flight、版本走廊、确认、验证和报告规则。不要在命令文件中复制、简化或重写工作流；用户意图不明确时先确认模式。
-"""

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-      - name: Validate skills, cards, commands, and manifests
+      - name: Validate skills, cards, and manifests
         run: npm test
       - name: Install pinned Claude Code validator
         run: npm install --global @anthropic-ai/claude-code@2.1.222

--- a/README.md
+++ b/README.md
@@ -88,10 +88,11 @@ Claude Code 中按名字调用 skill（插件安装后带命名空间）：
 /dsh-plugin-upgrade-skill:plugin-upgrade 0.1.2
 ```
 
-其他 agent 直接在对话中提问，skill 按 description 自动触发：
+也可以直接在对话中提问（任意 agent），skill 按 description 自动触发；只读检查直接给结果，升级或迁移会先出计划再等确认：
 
 ```
 我需要把插件从 0.1.1 升级到 0.1.2，有哪些破坏性变更？
+帮我把 dsh-ads 这个插件升级到 dsh-v0.1.2-alpha.2
 ```
 
 ## Skill 索引

--- a/README.md
+++ b/README.md
@@ -81,26 +81,17 @@ cp -r dsh-plugin-upgrade-skill/skills/* .cursor/skills/
 
 ## 使用
 
-### 斜杠命令（Claude / Gemini）
+Claude Code 中按名字调用 skill（插件安装后带命名空间）：
 
-安装后可使用 `/dsh-upgrade` 命令：
-
-```bash
-/dsh-upgrade 0.1.2
+```
+/plugin-upgrade 0.1.2
+/dsh-plugin-upgrade-skill:plugin-upgrade 0.1.2
 ```
 
-或直接在对话中提问：
+其他 agent 直接在对话中提问，skill 按 description 自动触发：
 
 ```
 我需要把插件从 0.1.1 升级到 0.1.2，有哪些破坏性变更？
-```
-
-### Skill 调用（任意 agent）
-
-对于没有斜杠命令的 agent，直接引用 skill：
-
-```
-使用 plugin-upgrade skill 帮我升级 DSH 插件到 0.1.2
 ```
 
 ## Skill 索引

--- a/scripts/validate-manifests.mjs
+++ b/scripts/validate-manifests.mjs
@@ -1,13 +1,12 @@
 #!/usr/bin/env node
 /**
- * 校验多 agent 清单文件与斜杠命令的一致性。
+ * 校验多 agent 清单文件的一致性。
  *
  * 检查项：
  * 1. 所有清单 JSON 可解析
  * 2. 各清单声明的 version 一致
  * 3. 清单指向的 skills 目录存在
  * 4. skills/ 下每个 skill 有带 name/description 前置元数据的 SKILL.md
- * 5. 各 agent 目录的斜杠命令集合一致，且 description 相同
  */
 
 import { readFileSync, existsSync, readdirSync, statSync } from 'node:fs'
@@ -84,41 +83,6 @@ for (const name of skillNames) {
   if (!/^description:\s*\S/m.test(body)) fail(`${rel} 前置元数据缺少 description`)
 }
 
-// 5. 斜杠命令跨工具对齐
-/** 收集一个命令目录下的命令名 → description。 */
-function collectCommands(dir, ext, extract) {
-  const abs = join(root, dir)
-  if (!existsSync(abs)) return null
-  const out = new Map()
-  for (const file of readdirSync(abs).filter((f) => f.endsWith(ext))) {
-    const text = readFileSync(join(abs, file), 'utf8')
-    out.set(file.slice(0, -ext.length), extract(text))
-  }
-  return out
-}
-
-const claudeCommands = collectCommands('.claude/commands', '.md', (text) =>
-  /^description:\s*(.+)$/m.exec(text)?.[1].trim(),
-)
-const geminiCommands = collectCommands('.gemini/commands', '.toml', (text) =>
-  /^description\s*=\s*"(.*)"$/m.exec(text)?.[1].trim(),
-)
-
-if (claudeCommands && geminiCommands) {
-  for (const name of claudeCommands.keys()) {
-    if (!geminiCommands.has(name)) fail(`命令 ${name} 缺少 .gemini/commands/${name}.toml`)
-  }
-  for (const name of geminiCommands.keys()) {
-    if (!claudeCommands.has(name)) fail(`命令 ${name} 缺少 .claude/commands/${name}.md`)
-  }
-  for (const [name, description] of claudeCommands) {
-    if (!description) fail(`.claude/commands/${name}.md 缺少 description`)
-    else if (geminiCommands.has(name) && geminiCommands.get(name) !== description) {
-      fail(`命令 ${name} 的 description 在 Claude 与 Gemini 之间不一致`)
-    }
-  }
-}
-
 // Distribution docs must use commands supported by the current CLI surfaces.
 const readme = readFileSync(join(root, 'README.md'), 'utf8')
 if (/\bcodex plugin add\b/.test(readme)) fail('README.md 使用不存在的 codex plugin add')
@@ -142,4 +106,3 @@ if (errors.length > 0) {
 const version = distinct.values().next().value
 console.log(`清单校验通过：${Object.keys(manifests).length} 个清单，版本 ${version}`)
 console.log(`skills：${skillNames.join(', ')}`)
-if (claudeCommands) console.log(`命令：${[...claudeCommands.keys()].join(', ')}`)

--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -76,23 +76,6 @@ for (const file of markdownFiles) {
   }
 }
 
-// Slash commands are thin delegates; copied workflows drift independently from SKILL.md.
-const commandFiles = [
-  join(root, '.claude', 'commands', 'dsh-upgrade.md'),
-  join(root, '.gemini', 'commands', 'dsh-upgrade.toml'),
-]
-for (const file of commandFiles) {
-  if (!existsSync(file)) {
-    fail(file, 'missing dsh-upgrade command wrapper')
-    continue
-  }
-  const text = await readFile(file, 'utf8')
-  if (!/plugin-upgrade/.test(text)) fail(file, 'command must delegate to plugin-upgrade')
-  if (!/不要.*复制|不要.*重写/.test(text)) fail(file, 'command must forbid duplicated workflow logic')
-  if (/^\s*\d+\.\s+\*\*/m.test(text)) fail(file, 'command must not duplicate numbered workflow steps')
-  if (/六类|全零命中|只需烟测|缺卡片时先补卡/.test(text)) fail(file, 'command contains a retired workflow rule')
-}
-
 // CONTRIBUTING delegates the card schema instead of maintaining a second copy.
 const contributingFile = join(root, 'CONTRIBUTING.md')
 const contributingText = await readFile(contributingFile, 'utf8')


### PR DESCRIPTION
## 改动

删除 `.claude/commands/dsh-upgrade.md` 和 `.gemini/commands/dsh-upgrade.toml`，以及 `validate.mjs` / `validate-manifests.mjs` 中要求它们存在的规则。README「使用」小节改为直接调用 `/plugin-upgrade`。

## 原因

- Claude Code 官方文档：[custom commands 已并入 skills](https://code.claude.com/docs/en/skills)，`SKILL.md` 本身注册 `/<name>`；[插件目录参考](https://code.claude.com/docs/en/plugins-reference)把 `commands/` 标为 legacy，新插件用 `skills/`。
- `.claude/commands/` 是项目级目录，不随插件分发；插件用户实际拿到的是 `/dsh-plugin-upgrade-skill:plugin-upgrade`。这个文件只给同一个 skill 加了第二个名字 `/dsh-upgrade`，且只在把本仓库当工作目录打开时生效。
- `.gemini/commands/` 是 Gemini CLI 的项目级自定义命令，`gemini skills install` 不安装它，用户要手动复制到 `~/.gemini/commands/`。
- 两个文件内容都只是「调用 plugin-upgrade skill」，没有独立信息。

一个 skill 一个入口，SKILL.md 是唯一真源。

## 验证

- `npm test`：`Validation OK: 4 skill, 2 card sets, 20 cards, 31 Markdown files …` / `清单校验通过：4 个清单，版本 0.2.0`
- `claude plugin validate .`：passed（Claude Code 2.1.251）
- `git diff --check`
