### PR TITLE
dsh-TUI 迁移经验回填（1/4）：按 tag 源码修正 A1-01/A1-04/A1-05/A2-02/A2-04

### DIFF
--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -207,7 +207,7 @@ for (const file of markdownFiles) {
 // The rollup is a current navigation document, not an unchecked historical snapshot.
 const rollupFile = join(referencesDir, 'rollup-0.1.2.md')
 const rollupText = await readFile(rollupFile, 'utf8')
-for (const required of ['（15 张）', '（7 张）', '#7 子进程']) {
+for (const required of ['#7 子进程']) {
   if (!rollupText.includes(required)) fail(rollupFile, `missing current rollup contract: ${required}`)
 }
 if (/Consumer.*永不 reject|#6 子进程|git checkout <tag> -- pnpm-lock\.yaml/.test(rollupText)) {

--- a/skills/plugin-upgrade/SKILL.md
+++ b/skills/plugin-upgrade/SKILL.md
@@ -90,8 +90,8 @@ Structure the report as:
 |---|---|
 | [references/README.md](references/README.md) | Version corridors, card schema, and maintenance rules |
 | [references/pre-flight.md](references/pre-flight.md) | Seven-class touchpoint self-check and summary template |
-| [references/v0.1.2-alpha.1.md](references/v0.1.2-alpha.1.md) | rc.2→alpha.1: 15 curated cards |
-| [references/v0.1.2-alpha.2.md](references/v0.1.2-alpha.2.md) | alpha.1→alpha.2: 7 curated cards |
+| [references/v0.1.2-alpha.1.md](references/v0.1.2-alpha.1.md) | rc.2→alpha.1 curated cards |
+| [references/v0.1.2-alpha.2.md](references/v0.1.2-alpha.2.md) | alpha.1→alpha.2 curated cards |
 | [references/rollup-0.1.2.md](references/rollup-0.1.2.md) | 0.1.1 → 0.1.2 corridor (rollup): cross-cohort coexistence, unpublished-cohort installation, `RemoteResult` error flow, pre-migration baseline attribution, bounded retry for boot race, base-only preset precondition, type-surface export drift, and the layered validation checklist; **based on alpha.2 and subject to final-release review** |
 | [migration planner](../../docs/migration-planner.md) | Read-only scan of the target repository, connects the card corridor, and outputs a candidate migration plan |
 | [examples/legacy-plugin/](examples/legacy-plugin/) | Static fixture for the seven touchpoint classes (never execute) |

--- a/skills/plugin-upgrade/SKILL.zh-CN.md
+++ b/skills/plugin-upgrade/SKILL.zh-CN.md
@@ -108,8 +108,8 @@
 |---|---|
 | [references/README.md](references/README.md) | 版本走廊、卡片 schema 与维护规则 |
 | [references/pre-flight.md](references/pre-flight.md) | 七类触点自查与汇总模板 |
-| [references/v0.1.2-alpha.1.md](references/v0.1.2-alpha.1.md) | rc.2→alpha.1：15 张 curated 卡 |
-| [references/v0.1.2-alpha.2.md](references/v0.1.2-alpha.2.md) | alpha.1→alpha.2：7 张 curated 卡 |
+| [references/v0.1.2-alpha.1.md](references/v0.1.2-alpha.1.md) | rc.2→alpha.1 curated 卡 |
+| [references/v0.1.2-alpha.2.md](references/v0.1.2-alpha.2.md) | alpha.1→alpha.2 curated 卡 |
 | [references/rollup-0.1.2.md](references/rollup-0.1.2.md) | 0.1.1 → 0.1.2 走廊（rollup）：跨 cohort 共存、未发布 cohort 安装、`RemoteResult` 错误流、迁移前 baseline 归因、boot race 有界重试、base-only preset 前置、类型面导出漂移、分层验证清单；**基于 alpha.2，正式版需复核** |
 | [migration planner](../../docs/migration-planner.md) | 只读扫描目标仓库、连接卡片走廊并输出候选迁移计划 |
 | [examples/legacy-plugin/](examples/legacy-plugin/) | 七类触点静态夹具（不得执行） |

--- a/skills/plugin-upgrade/references/rollup-0.1.2.md
+++ b/skills/plugin-upgrade/references/rollup-0.1.2.md
@@ -8,7 +8,7 @@
 
 0. 迁移动手前，先按 R-06 采集 baseline（即分层验证清单第 0 层）；
 1. 先按 [pre-flight.md](pre-flight.md) 测出命中的触点类；
-2. 按 `from → to` 读完整走廊并先计算净状态：[v0.1.2-alpha.1.md](v0.1.2-alpha.1.md)（15 张）→ [v0.1.2-alpha.2.md](v0.1.2-alpha.2.md)（7 张）；
+2. 按 `from → to` 读完整走廊并先计算净状态：[v0.1.2-alpha.1.md](v0.1.2-alpha.1.md) → [v0.1.2-alpha.2.md](v0.1.2-alpha.2.md)（各文件张数见 [README.md](README.md) 索引）；
 3. 回到本文件处理走廊层问题——这些跨越单版本，卡片里没有；
 4. 按本文件末尾的分层验证清单收工。
 
@@ -34,8 +34,8 @@
 ## Remote 调用的错误流
 
 承接 [DSH-0.1.2-A1-01](v0.1.2-alpha.1.md) 与
-[DSH-0.1.2-A2-02](v0.1.2-alpha.2.md)。alpha.2 的 unary Remote 返回
-`Promise<RemoteResult<T>>`：业务/载体失败走 `ok: false`；参数个数、未挂载方法、缺少
+[DSH-0.1.2-A2-02](v0.1.2-alpha.2.md)。unary Remote 从 rc.2 起就返回
+`Promise<RemoteResult<T>>`，alpha.2 改的是 `error` 的类型和错误码命名空间：业务/载体失败走 `ok: false`；参数个数、未挂载方法、缺少
 Context adapter 等装配/编程错误仍可能 reject，应暴露修复而不是吞掉重试。
 
 ```typescript
@@ -139,6 +139,7 @@ return result.value
 - **类型**: process
 - **症状**: 依赖被删 SDK 包才能构建的插件（承接 [DSH-0.1.2-A1-01](v0.1.2-alpha.1.md)），迁移中途才发现无法构建，只能随迁移退役。
 - **配方**: 迁移前先对全部插件跑一次「import 了哪些被删包」的盘点，把「必须退役」与「可迁移」分开排期，而不是边迁边发现。
+- **被删包清单**（按各 tag `packages/*/*/package.json` 的 `name` 比对，2026-08-31）: rc.2 → alpha.1 删除 5 个：`@deepseek-ai/dsh-acp-demo`、`dsh-acp-snapshot`、`dsh-client-runtime`、`dsh-host-apiproxy`、`dsh-sdk-jsonrpc-demo`；新增 25 个。alpha.1 → alpha.2 无删除，新增 `dsh-client-ui-schedule`、`dsh-deque`、`dsh-util-time`、`dsh-util-values`。盘点先 grep 这 5 个名字。
 - **验证**: 盘点清单与实际迁移结果一致，无中途新增退役项。
 - **来源**: [#5120](https://github.com/deepseek-ai/deepseek-harness/discussions/5120) 第 10 条。
 

--- a/skills/plugin-upgrade/references/v0.1.2-alpha.1.md
+++ b/skills/plugin-upgrade/references/v0.1.2-alpha.1.md
@@ -7,7 +7,7 @@ status: reviewed
 coverage: curated
 cardCount: 15
 idPrefix: DSH-0.1.2-A1
-verifiedAt: 2026-08-30
+verifiedAt: 2026-08-31
 ---
 
 # 变更卡片 · 0.1.2-alpha.1
@@ -33,23 +33,30 @@ verifiedAt: 2026-08-30
 
 | 旧 APIProxy 操作 | 新 Remote 方法 | 备注 |
 |---|---|---|
-| `session.rename` | `sessionTitle/rename` | 返回标题事件序列 |
-| `command.list` / `command.execute` | `commands/list` / `commands/execute` | 保留 Agent 查找与调用方取消 |
+| `session.rename` | `session/rename` | 生成声明在 `session` 命名空间（`ctx.remote.session.rename`）。上游 08-10 架构笔记写的 `sessionTitle/rename` 是设计稿；`sessionTitle` 是普通服务，不是 Remote 命名空间 |
+| `session.list/search/create/selectModel/fork/prompt/attachment/updateQueue/cancel/history` | `session/list`、`search`、`create`、`selectModel`、`fork`、`prompt`、`attachment`、`updateQueue`、`cancel`、`page`；流 `session/follow`、`session/control` | `history` 没有同名 Remote，分页读用 `page`，实时用 `follow` 流；以生成声明为准 |
+| `command.list` / `command.execute` | `commands/list` / `commands/execute` | rc.2 就已是 Remote（`commandsRemote` 在 rc.2 已挂载），不是本次迁移；保留 Agent 查找与调用方取消 |
 | `llm.providers` | `llm/listProviders` + `llm/listConfigurableProviders` | 一个拆为两个结果 |
 | `llm.discoverModels` | `llm/discoverModels` | |
 | `llm.models` | `session/modelCatalog` | 从 LLM 域移到 Session 域 |
 | `credentials.describe/set/unset` | `credentials/describe/set/unset` | |
 | `settings.describe/update/replace/mutate` | `settings/*` 同名方法 | 保留脱敏与 revision 检查 |
 | `settings.openDocument` | `settings/openSettingsDocument` | |
-| `agentPreset.read/copy/remove` | `agentPresets/*` | |
+| `agentPreset.read/copy/remove` | `agentPresets/read` / `agentPresets/copy` / `agentPresets/deletePreset` | `remove` 在生成声明里叫 `deletePreset` |
+| `agentPreset.list/select` | `agentPresets/list` / `agentPresets/select` | |
 | `agentPreset.openDocument` | `settings/openAgentPresetDirectory` | 移到 Settings 域 |
 | `subagent.interrupt` | `subagents/interruptByParent` | 保留父 Agent 权威 |
-| `workspace.list/insertSessionBefore/archiveSession` | `workspace/*` | |
+| `subagent.list/prompt/history` | `subagents/list` / `subagents/prompt` | `history` 没有同名方法，以生成声明为准 |
+| `workspace.list/insertSessionBefore/archiveSession` | `workspace/follow`（stream）/ `workspace/insertSessionBefore` / `workspace/archiveSession` | 没有 `workspace/list`：列表改为 `follow` 流，先发一帧完整 baseline，再发 upsert/remove/order/archived 增量 |
+| `workspace.create/rename/delete/insertBefore` | `workspace/create` / `rename` / `delete` / `insertBefore` | |
+| `host.pickDirectory/listDirectory/createDirectory` | `directoryPicker/pick` / `directoryPicker/list` / `directoryPicker/createDirectory` | |
 | `skill.list` | `skills/list` | 列举不激活冷 Agent |
-| `fileReferences/list` | `fileReferences/list` | |
+| `fileReferences/list` | `fileReferences/list` | wire 名不变，rc.2 就已是 Remote；owner 从 `dsh-file-reference/remote` 移到 `dsh-api-session-controller`，`dsh-file-reference` 不再导出 `./remote` |
 | `host.openPath` | `session/openWorkspacePath` | Client 先解析工作区相对路径 |
 | `host.describe` | `$events` ready 帧 + 按域查询 | alpha.1 通过 generation-ready 帧携带 Host home，尚无 `ctx.remote.$host`；alpha.2 见 A2-06 |
-| `session.export` | `GET/HEAD /api/session.export` | Fetch 流式 ZIP，不走 JSON Remote 信封；认证见 A1-08 |
+| `session.export` | `GET/HEAD /api/session.export` | 路径 rc.2 已如此，变的是 route owner（apiproxy fetch handler → Connection exact Fetch route）；Fetch 流式 ZIP，不走 JSON Remote 信封；认证见 A1-08 |
+
+  标识符：rc.2 的服务键是 `apiProxy`（类型 `ApiProxy`，包 `@deepseek-ai/dsh-host-apiproxy`），alpha.1 删除该包；不存在 `APIProxy` 标识符。rc.2 已是混合状态，`goals/*`、`dynamicCordisRunner/*`、`pluginInventory/list`、`messageFeedback/*`、`sessionReferenceResolver/candidates` 在 rc.2 就是 Remote，不在本表。表中命名以目标 tag 的生成声明（`lib/typert.remote-client.d.ts`）为准，笔记和 release notes 只给方向。
 
   调用插件在 `inject` 声明所需 Remote contribution，经
   `@deepseek-ai/dsh-api-remotes/client` 获得生成的类型挂载，再调用
@@ -66,7 +73,7 @@ verifiedAt: 2026-08-30
   同款症状。客户端平面（浏览器插件）才走本表 `ctx.remote.*`，且需在
   package.json 声明 `dsh.client` 才会进入浏览器插件名册。
   完整过程见仓库 [docs/validation-report-2026-08-30.md](../../../docs/validation-report-2026-08-30.md)。
-- **来源**: [APIProxy→Remote 架构笔记（alpha.1）](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/.agents/notes/implemented/architecture/2026-08-10-unary-apiproxy-remote-migration.md)
+- **来源**: [APIProxy→Remote 架构笔记（alpha.1）](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/.agents/notes/implemented/architecture/2026-08-10-unary-apiproxy-remote-migration.md) · [alpha.1 session-controller `@Remote` 声明](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/packages/api/session-controller/src/index.ts) · [alpha.1 agent-presets `@Remote('deletePreset')`](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/packages/preset/agent-presets/src/index.ts) · [alpha.1 workspace-controller `follow` 流](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/packages/api/workspace-controller/src/index.ts) · [rc.2 apiproxy rpc-map（旧键全表）](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.1-rc.2/packages/host/apiproxy/src/api/rpc-map.ts)
 
 ---
 
@@ -97,13 +104,13 @@ verifiedAt: 2026-08-30
 
 ---
 
-### DSH-0.1.2-A1-04 · 应用统一经 `dsh` Profile 启动
+### DSH-0.1.2-A1-04 · ACP/SDK 示例并入 `dsh` Profile，独立 demo bin 与包删除
 
 - **类型**: behavior
 - **适用对象**: 启动包装器、Python SDK/ACP 集成、直接读取 profile 文件的插件
 - **影响触点**: #4、#7
 - **操作级别**: required-if-hit
-- **症状**: 旧进程树、cwd、环境变量或固定 profile 路径假设失配。
+- **症状**: `dsh --profile <name>` 在 rc.2 就有，不是 alpha.1 新增。alpha.1 变的是：新增 `acp`、`sdk`、`sdk-minimal` 三个 profile，删除独立 bin `dsh-acp-demo`、`dsh-jsonrpc-agent` 及包 `@deepseek-ai/dsh-acp-demo`、`dsh-sdk-jsonrpc-demo`、`dsh-acp-snapshot`。硬编码这些 bin、旧进程树或固定 profile 路径的包装器失配。
 - **迁移配方**: 以运行时 `DSH_HOME`、目标 profile 和官方启动器为事实源；区分 profile composition（如 `cordis.patch.yml` / `agent.cordis.yml`）、包清单和 resolved config，不硬编码用户目录。
 - **验证**: 新 profile 冷启动与旧 profile 升级启动各一次；核对 cwd、环境变量、插件挂载与 resolved config。
 - **实战批注**（2026-08-30，alpha.2 容器实测）: `dsh --help` 确认 profile 位于 `$DSH_HOME/profiles` 下；未配置 API key 时 headless 冷启动报 `dsh: MISSING_CREDENTIAL: ... store DEEPSEEK_API_KEY through the credentials service`——属 profile 配置问题，归类时勿误判为插件/运行时故障。
@@ -111,17 +118,17 @@ verifiedAt: 2026-08-30
 
 ---
 
-### DSH-0.1.2-A1-05 · Headless：stderr 输出 reasoning/错误，stdout 输出最终文本
+### DSH-0.1.2-A1-05 · Headless：stderr 新增 `dsh: reasoning:` 段，stdout 仍是最终文本
 
 - **类型**: behavior
 - **适用对象**: headless 包装器、进程监督器、stdout/stderr 解析器
 - **影响触点**: #7
 - **操作级别**: required-if-hit
-- **症状**: 把 stdout 当 JSONL 事件流会解析失败；忽略 stderr 会丢 reasoning 与错误；只看输出文本会误判失败。
+- **症状**: rc.2 的 stdout 就已是最终 assistant 文本、退出码 0/1（`packages/bundle/headless/src/index.ts:129`），从来不是 JSONL；alpha.1 唯一变化是 stderr 多了 `dsh: reasoning:` 段（rc.2 成功时 stderr 为空）。忽略 stderr 会丢 reasoning；把「stderr 有输出」当失败会误判。
 - **迁移配方**: 将 stdout 作为最终 assistant **文本**通道（除非具体入口另有结构化契约）；stderr 接收 `dsh: reasoning:` 段或 `dsh: <code>: <message>`；以退出码判定成功（完成为 0，失败/中止/无完成回合为 1）。不要对 stdout 默认 `JSON.parse`。
 - **验证**: 覆盖纯文本成功、带 reasoning、空最终文本、直接启动失败与非零退出；确认敏感 reasoning 被送到受控 stderr sink。
 - **实战批注**（2026-08-30，alpha.2 容器实测）: 与上述契约一致——stdout 无结果时仅一个换行，报错（如 `dsh: AUTH: ...`）全走 stderr。
-- **来源**: [alpha.1 headless README](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/packages/bundle/headless/README.md)
+- **来源**: [alpha.1 headless README](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/packages/bundle/headless/README.md) · [rc.2 headless src（stdout 已是最终文本）](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.1-rc.2/packages/bundle/headless/src/index.ts)
 
 ---
 

--- a/skills/plugin-upgrade/references/v0.1.2-alpha.2.md
+++ b/skills/plugin-upgrade/references/v0.1.2-alpha.2.md
@@ -7,7 +7,7 @@ status: reviewed
 coverage: curated
 cardCount: 7
 idPrefix: DSH-0.1.2-A2
-verifiedAt: 2026-08-30
+verifiedAt: 2026-08-31
 ---
 
 # 变更卡片 · 0.1.2-alpha.2
@@ -34,17 +34,22 @@ verifiedAt: 2026-08-30
 
 ---
 
-### DSH-0.1.2-A2-02 · Remote unary 统一 `RemoteResult` / `RemoteError` 词汇
+### DSH-0.1.2-A2-02 · Remote failure 改为 `RemoteError` 实例，错误码加命名空间
 
 - **类型**: breaking
 - **适用对象**: 使用 `ctx.remote` 或承接 Remote failure 的 Host/Web Client 集成
 - **影响触点**: #3
 - **操作级别**: required-if-hit
-- **症状**: 解析 `Error.message`、给每次调用套防御性 catch、或跨 realm 使用 `instanceof RemoteError` 会误分业务失败与本地装配缺陷。
+- **症状**: `RemoteResult<T>` 的 `{ ok, value } | { ok: false, error }` 形状 rc.2 和 alpha.1 就是这样（gateway `src/client/index.ts` rc.2:334、alpha.1:404），alpha.2 没改调用形状。变的是：
+  - `error` 从普通对象 `{ code, message, details }` 变成 `RemoteError` 实例（`packages/typert/protocol/src/remote-error.ts:12`），`throw result.error` 保留 throw 语义；
+  - 错误码加命名空间：`session-not-found` → `session/not-found`、`agent-busy` → `session/agent-busy`、`internal` → `gateway/internal`、`cancelled` → `gateway/cancelled`、`bad-request` → `gateway/bad-request`、`agent-preset-not-found` → `agent-preset/not-found`、`agent-preset-locked` → `agent-preset/locked`；
+  - 新增 `isRemoteFailure`；删除 `RemoteStreamError`（gateway client）、`TypertRemoteFailure`、`TypertLookupFailure`（typert-protocol），stream 终止失败改抛 `RemoteError`；`dsh-client-connection` 的 `RpcErrorDetailsMap`/`RpcErrorCode`/`RpcError` 删除。
+
+  按旧码字符串分支、解析 `Error.message`、给每次调用套防御性 catch、或跨 realm 用 `instanceof RemoteError`，都会误分业务失败与本地装配缺陷。
 - **迁移配方**: Unary Remote 调用解析为 `RemoteResult<T>`，业务/载体失败在结果分支中处理：
 
   ```ts
-  const result = await ctx.remote.sessionTitle.rename(args)
+  const result = await ctx.remote.session.rename(args)
   if (!result.ok) {
     switch (result.error.code) {
       case 'gateway/cancelled':
@@ -63,9 +68,9 @@ verifiedAt: 2026-08-30
 
   Remote 调用不会因普通业务/载体失败 reject；装配故障应暴露而不是被防御性 catch 吞掉。只有上层接住主动 `throw result.error` 的值时，才用
   `isRemoteFailure`（`@deepseek-ai/dsh-api-gateway/client`）做结构判别；永远不要用
-  `instanceof`。`gateway/cancelled` 应终止/静默取消或沿调用链传播；`gateway/internal` 与未知码默认保留原始 `code/details` 并上报，不重试。只有明确瞬态码、幂等操作且用户策略允许时才重试。
+  `instanceof`。导入位置：`RemoteError`、`RemoteResult`、`RemoteErrorCode`、`RemoteErrorDetailsMap` 来自 `@deepseek-ai/dsh-typert-protocol`；gateway client 只导出 `isRemoteFailure` 和 `TypertGatewayFaultDetails`。`gateway/cancelled` 应终止/静默取消或沿调用链传播；`gateway/internal` 与未知码默认保留原始 `code/details` 并上报，不重试。只有明确瞬态码、幂等操作且用户策略允许时才重试。
 - **验证**: 覆盖成功、`gateway/cancelled`、`session/not-found`、`session/agent-busy`、`gateway/internal`、未知业务码和本地装配缺陷；取消不得变成通用错误，internal/未知不得自动重试。
-- **来源**: [RemoteError failure vocabulary](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/.agents/notes/implemented/architecture/2026-08-28-ctx-remote-failure-vocabulary.md) · [adding a Remote API](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/docs/cookbook/adding-a-remote-api.md)
+- **来源**: [RemoteError failure vocabulary](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/.agents/notes/implemented/architecture/2026-08-28-ctx-remote-failure-vocabulary.md) · [adding a Remote API](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/docs/cookbook/adding-a-remote-api.md) · [alpha.2 `RemoteError` 类](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/typert/protocol/src/remote-error.ts) · [alpha.2 gateway client（`isRemoteFailure`）](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/api/gateway/src/client/index.ts) · [alpha.1 gateway client（同样返回 `RemoteResult`）](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/packages/api/gateway/src/client/index.ts)
 
 ---
 
@@ -83,16 +88,16 @@ verifiedAt: 2026-08-30
 
 ---
 
-### DSH-0.1.2-A2-04 · Node.js 24.0–24.11.1 启动失败修复
+### DSH-0.1.2-A2-04 · Node.js 24.0–24.11.1 下 `dsh web` 空 client graph 修复
 
 - **类型**: fix
-- **适用对象**: 启动包装器、Node engines 限制和临时降级逻辑
+- **适用对象**: 为这段 Node 版本加过强制 Node 22 / 跳过 web 等绕行逻辑的启动包装器与 CI 矩阵
 - **影响触点**: #7
 - **操作级别**: conditional
-- **症状**: 无新破坏；为受影响区间添加的 workaround 可能不再需要。
-- **迁移配方**: 只删除有证据专门绕过该缺陷的 engines 限制或版本分支；保留其他 Node 兼容约束。验证矩阵必须包含故障窗口内版本，不能只测 latest/LTS。
+- **症状**: Node 24.0–24.11.1 报 major 24 但仍带 v1 内部 loader；alpha.1 的 `vendor/loader` 按 major 判 v2，`resolveSync` 参数反了，`dsh web` 进程能起来但 `__DSH_BOOT__.entries` 为空、HMR 找不到入口。alpha.2 改为按 `getOrCreateModuleJob` / `getModuleJobForImport` 探测 loader 形状。`engines.node` 两个 tag 都是 `^22.19.0 || >=24.0.0`，没有变化，不要在 engines 上找差异。
+- **迁移配方**: 只删除有证据专门绕过该缺陷的分支（强制 Node 22、跳过 `dsh web`、按 major 探测 loader）；保留其他 Node 兼容约束。验证矩阵必须包含故障窗口内版本，不能只测 latest/LTS。
 - **验证**: 至少在官方 CI 使用的 Node 24.9（故障窗口 24.0–24.11.1）、修复后的 Node 24.12 或当前 24.x、以及受支持的 Node 22 LTS 上冷启动；插件涉及 HMR 时三档都验证 HMR。
-- **来源**: [alpha.2 release notes「问题修复」](https://github.com/deepseek-ai/deepseek-harness/releases/tag/dsh-v0.1.2-alpha.2)
+- **来源**: [alpha.2 release notes「问题修复」](https://github.com/deepseek-ai/deepseek-harness/releases/tag/dsh-v0.1.2-alpha.2) · [alpha.2 vendor/README 第 19 条](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/vendor/README.md) · [alpha.2 loader 形状探测](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/vendor/loader/src/internal.ts) · [alpha.2 CI 钉 Node 24.9](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/.github/workflows/ci.yml)
 
 ---
 


### PR DESCRIPTION
## dsh-TUI 0.1.1 → 0.1.2 迁移经验回填（1/4）：修错

dsh-TUI（宿主平面的 TUI 插件）已经走完 rc.2 → alpha.1（[dsh-TUI #622](https://github.com/ccch1mneyyy/dsh-TUI/pull/622)）和 alpha.1 → alpha.2（[dsh-TUI #647](https://github.com/ccch1mneyyy/dsh-TUI/pull/647)）两段。回头对照本 skill：迁移实际改了 11 处上游面，卡片只覆盖 `code → ptc` 一条；把现有 20 张卡对着三个 tag 的源码逐条核，5 张有错。这批回填拆成 4 个 PR，按顺序叠：#44 修错 → #45 宿主平面新卡 → #46 alpha.2 类型面 → #47 走廊配方。

---

把 20 张卡对着 `dsh-v0.1.1-rc.2`、`dsh-v0.1.2-alpha.1`、`dsh-v0.1.2-alpha.2` 三个 tag 的源码逐条核了一遍，改掉核出来的错误。每条都给了文件和行号。

## 改了什么

| 卡 | 错在哪 | 依据 |
|---|---|---|
| A1-01 | `session.rename` 的 Remote 是 `session/rename`，不是 `sessionTitle/rename`（`sessionTitle` 是普通服务）；`agentPreset.remove` 是 `agentPresets/deletePreset`；`workspace/list` 不存在，列表是 `workspace/follow` 流 | alpha.1 `packages/api/session-controller/src/index.ts:115,304`、`packages/preset/agent-presets/src/index.ts:601`、`packages/api/workspace-controller/src/index.ts:117` |
| A1-01 | `commands/*`、`fileReferences/list`、`session.export` 路径在 rc.2 就已是 Remote/同路径，不算这次迁移；补上表里缺的 `session/*`、`subagents`、`directoryPicker/*`、`workspace` 其余方法 | rc.2 `packages/host/apiproxy/src/api/rpc-map.ts` 旧键全表 vs alpha.1 各 `@Remote` 声明 |
| A1-04 | `dsh --profile` 在 rc.2 就有。alpha.1 变的是并入 `acp`/`sdk`/`sdk-minimal` profile，删掉独立 bin 和 `dsh-acp-demo`、`dsh-sdk-jsonrpc-demo`、`dsh-acp-snapshot` 三个包 | rc.2 `apps/cli/README.md:11-14` |
| A1-05 | rc.2 的 stdout 就是最终文本加退出码，不是 JSONL。alpha.1 唯一变化是 stderr 多了 `dsh: reasoning:` 段 | rc.2 `packages/bundle/headless/src/index.ts:129` |
| A2-02 | `RemoteResult` 的 `{ok,value}|{ok:false,error}` 形状 rc.2 和 alpha.1 就有。alpha.2 改的是 `error` 变成 `RemoteError` 实例、错误码加命名空间（旧的是 `session-not-found`，不是 `not-found`）、删 `RemoteStreamError`/`TypertRemoteFailure`/`TypertLookupFailure`。`RemoteError` 在 `@deepseek-ai/dsh-typert-protocol`，gateway client 只导出 `isRemoteFailure` | gateway `src/client/index.ts` rc.2:334 / alpha.1:404；alpha.2 `packages/typert/protocol/src/remote-error.ts:12` |
| A2-04 | `engines.node` 两个 tag 都是 `^22.19.0 || >=24.0.0`，没变。修复在 `vendor/loader` 的 loader 形状探测；症状是 `dsh web` 起来了但 `__DSH_BOOT__.entries` 为空，不是进程启动失败 | alpha.2 `vendor/loader/src/internal.ts:137-141`、`vendor/README.md` 第 19 条 |
| R-05 | 说"盘点被删包"但没列。补 rc.2→alpha.1 删除的 5 个包名 | 各 tag `packages/*/*/package.json` 的 `name` 比对 |

## 顺手做的

卡片张数原来在 `validate.mjs`、`rollup-0.1.2.md`、`SKILL.md` 三处硬编码，每加一张卡要改三个地方。现在只留 frontmatter `cardCount` 和 `references/README.md` 的索引表，校验脚本继续比对这两处。

## 和 open PR 的关系

#37 也改了 `session/rename` 和 `deletePreset` 两行，内容一致；本 PR 另外修了 `workspace/list` 和其他几张卡。`api-migration-0.1.2-alpha.2.md` 早已写明 `ctx.remote.session.rename`，这次是让 A1-01 跟它对齐。

## 验证

- `npm test`：`Validation OK: 5 skill, 2 card sets, 22 cards …` / `清单校验通过`
- `claude plugin validate .`：passed
- `git diff --check`
