### PR TITLE
docs: acknowledge dsh-tui 0.1.2-alpha.2 migration in acknowledgments

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -166,6 +166,7 @@ node scripts/validate-manifests.mjs
 - [@hikariming](https://github.com/hikariming) — repository maintenance and the dsh skill index site [dshfind.com](https://dshfind.com)
 - [@ccch1mneyyy](https://github.com/ccch1mneyyy) — issue #1 proposal and the alpha version cards
 - [@zhu1090093659](https://github.com/zhu1090093659) — [dsh-web](https://github.com/zhu1090093659/dsh-web) migration practice and detailed pain-point records
+- [@huiliyi37](https://github.com/huiliyi37) — [dsh-tui](https://github.com/huiliyi37/dsh-tianshu-tui) 0.1.2-alpha.2 migration field notes (user-questions waterfall card, preset host-scope prerequisite, type-drift ledger)
 - [@tianyicui](https://github.com/tianyicui) — initiated discussion #5120 and the official call for contributions
 
 ## License

--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ node scripts/validate-manifests.mjs
 - [@hikariming](https://github.com/hikariming) — 仓库维护与 dsh 技能检索站 [dshfind.com](https://dshfind.com)
 - [@ccch1mneyyy](https://github.com/ccch1mneyyy) — issue #1 提案和 alpha 版本卡片
 - [@zhu1090093659](https://github.com/zhu1090093659) — [dsh-web](https://github.com/zhu1090093659/dsh-web) 迁移实践与详细痛点记录
+- [@huiliyi37](https://github.com/huiliyi37) — [dsh-tui](https://github.com/huiliyi37/dsh-tianshu-tui) 0.1.2-alpha.2 迁移实测（userQuestions waterfall 卡、preset Host-scope 前置、类型漂移 ledger）
 - [@tianyicui](https://github.com/tianyicui) — discussion #5120 发起和官方征集
 
 ## License


### PR DESCRIPTION
## 变更摘要

在 README.md / README.en.md 的致谢名单补一行：@huiliyi37（dsh-tui，@huiliyi37/dsh-tianshu-tui）的 0.1.2-alpha.2 迁移实测。

对应的内容贡献已随 #35 进入 main（commit 6b3c4da：userQuestions waterfall 卡 DSH-0.1.2-A2-07、preset Host-scope 前置与类型漂移走廊配方、A2-03 实战批注），本 PR 只补署名记录。

## 已运行验证

```
node scripts/validate.mjs          # Validation OK: 5 skill, 2 card sets, 22 cards, 39 Markdown files, 7 touchpoint fixtures, 2 face contracts, read-only planner
node scripts/validate-manifests.mjs  # 通过
```

## 致谢

- hikariming 对 #35 内容的改写落地与编排。