### PR TITLE
chore: add contribution templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,48 @@
+---
+name: Bug report
+about: Report an incorrect migration fact, validator failure, or reproducibility problem
+title: "bug: "
+labels: bug
+assignees: ""
+---
+
+## Environment
+
+- DSH version or exact tag:
+- Plugin version or exact commit:
+- Operating system and Node version:
+- Product entry point or profile:
+
+## Reproduction
+
+1.
+2.
+3.
+
+## Expected behavior
+
+
+## Actual behavior
+
+
+## Affected surface
+
+- [ ] `SKILL.md`
+- [ ] Version card or `references/README.md`
+- [ ] Validator or planner
+- [ ] Runtime verification or release smoke
+- [ ] Other:
+
+Affected touchpoint or complete card ID, if known:
+
+## Evidence
+
+Paste the smallest relevant command output, source link, or report excerpt. Remove tokens, credentials, session data, and private paths before posting.
+
+```text
+
+```
+
+## Additional context
+
+<!-- Mention whether the issue reproduces from a clean checkout and which checks were run. -->

--- a/.github/ISSUE_TEMPLATE/version-tracking.yml
+++ b/.github/ISSUE_TEMPLATE/version-tracking.yml
@@ -1,0 +1,62 @@
+name: 版本走廊认领
+description: 认领一个 DSH 版本走廊并准备迁移卡片
+labels:
+  - version-tracking
+  - card
+body:
+  - type: input
+    id: from
+    attributes:
+      label: from 精确 tag 或 commit
+      description: 使用官方 release tag 或完整 commit hash，不要填写 latest。
+      placeholder: dsh-v0.1.1-rc.1
+    validations:
+      required: true
+  - type: input
+    id: to
+    attributes:
+      label: to 精确 tag 或 commit
+      description: 目标官方 release tag 或完整 commit hash。
+      placeholder: dsh-v0.1.1-rc.2
+    validations:
+      required: true
+  - type: input
+    id: corridor
+    attributes:
+      label: 目标卡片或走廊
+      description: 说明准备新增的 card-set 文件和版本边。
+      placeholder: v0.1.1-rc.2.md
+    validations:
+      required: true
+  - type: textarea
+    id: sources
+    attributes:
+      label: 固定一手来源
+      description: 填写上游源码、固定 tag、release notes 或架构决策链接。
+      placeholder: https://github.com/deepseek-ai/deepseek-harness/releases/tag/...
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: 认领范围
+      description: 说明会检查的影响触点、消费者面和未覆盖内容。
+    validations:
+      required: true
+  - type: textarea
+    id: verification
+    attributes:
+      label: 预计验证
+      description: 列出校验命令、实测入口和无法覆盖的平台或凭据边界。
+      placeholder: node scripts/validate.mjs
+    validations:
+      required: true
+  - type: checkboxes
+    id: coordination
+    attributes:
+      label: 协作确认
+      options:
+        - label: 我已检查现有 Issue 和 PR，没有重复认领，或已在说明中完成协调。
+          required: true
+        - label: 我会使用 curated 覆盖声明，不把卡片描述成完整 API diff。
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,33 @@
+## Summary
+
+Describe the single logical change and link the related Issue, card, or version corridor.
+
+## Scope Checklist
+
+- [ ] I checked existing Issues and PRs for overlap and coordinated any related work.
+- [ ] For version-specific work, I used exact DSH tags or commit hashes, not `latest` or inferred versions.
+- [ ] I cited fixed first-party sources for version-specific claims.
+- [ ] For migration or card work, I listed the affected touchpoints (`#1`-`#7`) and complete card IDs.
+- [ ] I kept Host, Web Client, and ordinary Cordis plugin faces distinct.
+
+## Verification
+
+Commands run:
+
+```text
+node scripts/validate.mjs
+node scripts/validate-manifests.mjs
+```
+
+Additional checks:
+
+- [ ] I ran the focused tests or example checks for the changed behavior.
+- [ ] I reviewed the complete diff and `git diff --check`.
+
+Unverified boundaries (providers, browsers, operating systems, credentials, or product entry points):
+
+<!-- State "None" or describe exactly what was not tested. -->
+
+## Review Notes
+
+<!-- Mention any source/runtime conflict, compatibility assumption, or follow-up work. -->


### PR DESCRIPTION
## Summary

Add structured contribution entry points:

- Pull request template with version, evidence, scope, and verification prompts.
- Version corridor issue form for exact from/to tags and first-party sources.
- Bug report template with runtime boundaries and log-redaction guidance.

The templates keep card-specific fields conditional so release, CI, and tooling PRs are not forced to invent card IDs.

## Verification

- `npm test`
- `git diff --check`
- Parsed `version-tracking.yml` with PyYAML
