### PR TITLE
docs(upgrade): add rc1 to rc2 migration cards

### DIFF
--- a/skills/plugin-upgrade/references/README.md
+++ b/skills/plugin-upgrade/references/README.md
@@ -10,8 +10,9 @@ alpha.1 删除、alpha.2 恢复时，不应先删再加。
 
 | 顺序 | 卡片文件 | from | to | 卡数 | 状态 / 覆盖 |
 |---|---|---|---|---:|---|
-| 1 | [v0.1.2-alpha.1.md](v0.1.2-alpha.1.md) | `dsh-v0.1.1-rc.2` | `dsh-v0.1.2-alpha.1` | 20 | reviewed / curated |
-| 2 | [v0.1.2-alpha.2.md](v0.1.2-alpha.2.md) | `dsh-v0.1.2-alpha.1` | `dsh-v0.1.2-alpha.2` | 7 | reviewed / curated |
+| 1 | [v0.1.1-rc.2.md](v0.1.1-rc.2.md) | `dsh-v0.1.1-rc.1` | `dsh-v0.1.1-rc.2` | 3 | reviewed / curated |
+| 2 | [v0.1.2-alpha.1.md](v0.1.2-alpha.1.md) | `dsh-v0.1.1-rc.2` | `dsh-v0.1.2-alpha.1` | 20 | reviewed / curated |
+| 3 | [v0.1.2-alpha.2.md](v0.1.2-alpha.2.md) | `dsh-v0.1.2-alpha.1` | `dsh-v0.1.2-alpha.2` | 7 | reviewed / curated |
 | — | [rollup-0.1.2.md](rollup-0.1.2.md) | `dsh-v0.1.1-rc.2` → `dsh-v0.1.2-alpha.2` 全走廊 | rollup | 非卡片文件：走廊层增量（跨 cohort 共存、未发布 cohort 安装、`RemoteResult` 错误流、迁移前 baseline 归因、boot race 有界重试、base-only preset 前置、类型面导出漂移、分层验证清单）；基于 alpha.2，正式版需复核 |
 
 `curated` 表示只收录已识别的插件相关变化，不表示完整 API diff。走廊缺边时停止

--- a/skills/plugin-upgrade/references/v0.1.1-rc.2.md
+++ b/skills/plugin-upgrade/references/v0.1.1-rc.2.md
@@ -1,0 +1,48 @@
+---
+kind: dsh-version-card-set
+schema: 1
+from: dsh-v0.1.1-rc.1
+to: dsh-v0.1.1-rc.2
+status: reviewed
+coverage: curated
+cardCount: 3
+idPrefix: DSH-0.1.1-R2
+verifiedAt: 2026-08-31
+---
+
+# DSH v0.1.1-rc.1 → v0.1.1-rc.2
+
+> 本卡片集只收录已核对的插件可观察变化，不是完整 API diff。rc.2 的 release notes 将本次版本描述为图像上传与预处理改进；卡片同时核对了对应的 rc.1/rc.2 源码。
+
+### DSH-0.1.1-R2-01 · 图片附件引用增加原始尺寸信息
+
+- **类型**: behavior
+- **适用对象**: 使用 `ImageAttachmentRef`、`read_image` 输出或自行持久化图片元数据的插件
+- **影响触点**: #5
+- **操作级别**: conditional
+- **症状**: rc.2 的图片附件引用新增可选 `originalDimensions`。当宿主在入库时对图片做了归一化缩放，插件收到的引用可能同时包含原始宽高；只接受固定字段集合的 schema、快照或序列化逻辑可能拒绝这个新增字段。
+- **迁移配方**: 对图片引用和 `read_image` 结果采用“已知字段读取、未知可选字段保留”的方式；若插件自有 schema 使用 `additionalProperties: false`，为 `originalDimensions.width` 与 `originalDimensions.height` 增加可选字段。不要把该字段当作每张图片都存在的必填字段。
+- **验证**: 在 rc.2 的目标 Profile 中读取一张触发归一化的超尺寸图片，确认 `width/height` 是归一化后的尺寸，并在存在时保留 `originalDimensions`；对未缩放图片确认不会凭空生成该字段。检查持久化记录和模型可见结果均能正常解码。
+- **来源**: rc.1 类型基线 [`types.ts`](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.1-rc.1/packages/attachment/attachment/src/types.ts)；rc.2 类型定义 [`types.ts`](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.1-rc.2/packages/attachment/attachment/src/types.ts)；引入变化的固定提交 [`8f83853b601b`](https://github.com/deepseek-ai/deepseek-harness/commit/8f83853b601b)
+
+### DSH-0.1.1-R2-02 · `read_image` 输出暴露缩放事实并改变提示文本
+
+- **类型**: behavior
+- **适用对象**: 注册、包装、解析或快照测试 `read_image` 的插件与 Web/Host 集成
+- **影响触点**: #5
+- **操作级别**: conditional
+- **症状**: rc.2 的 `read_image` 输出 schema 增加可选 `originalDimensions`；当图片被缩放时，模型可见文本还会说明原始尺寸以及把坐标映射回原图的乘数。严格匹配完整 XML 文本、工具输出 schema 或快照的插件会发生差异。
+- **迁移配方**: 不要按完整 `<content>` 字符串做脆弱匹配；读取结构化的 `path`、`image` 和尺寸字段。若必须保留快照，分别覆盖“未缩放”和“已缩放”两种结果，并把坐标说明当作 rc.2 的条件输出。宿主平面和客户端平面仍按各自的工具/Remote 合约验证，不要仅凭文本变化替换服务注入。
+- **验证**: 在精确 `dsh-v0.1.1-rc.2` 上运行 `read_image` 的已缩放与未缩放用例；断言结构化输出可解码、图片 block 的尺寸与引用一致，并检查快照只在缩放场景出现坐标说明。未运行真实浏览器或 provider 的部分必须单独标记未验证。
+- **来源**: rc.1 实现 [`read-image.ts`](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.1-rc.1/packages/fs/tool-fs/src/read-image.ts)；rc.2 实现 [`read-image.ts`](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.1-rc.2/packages/fs/tool-fs/src/read-image.ts)；对应固定提交 [`6e17c20804cd`](https://github.com/deepseek-ai/deepseek-harness/commit/6e17c20804cd)
+
+### DSH-0.1.1-R2-03 · DeepSeek 图片请求优先使用 Files API 并保留回退路径
+
+- **类型**: behavior
+- **适用对象**: 自定义 DeepSeek LLM adapter、图片请求拦截器、附件/上传缓存插件
+- **影响触点**: #5
+- **操作级别**: conditional
+- **症状**: rc.2 的 DeepSeek adapter 在支持时会把规范化图片解析为 Files API 引用，并对失效的 provider file id 或不兼容的文件图片响应执行一次受限处理/回退。只按 rc.1 的 base64 request body 统计字节、重复上传同一附件，或把 provider 文件 ID 当作永久值的插件可能观察到请求形态、上传次数和错误处理发生变化。
+- **迁移配方**: 把图片身份与 provider 文件 ID 分开；以 `attachmentId`/请求版本作为本地缓存键，并把 Files API 上传结果视为有过期和失效可能的临时映射。请求观测同时支持文件引用和 base64 fallback，不要假设所有图片都会出现在 JSON 的 `data` 字段中。遇到文件解析失败时只接受宿主定义的受限 fallback，不要自行无限重试。
+- **验证**: 在精确 rc.2 上使用带图片的脚本化请求，分别验证首次上传、同一请求版本复用、Files API 失败后的受限回退和取消；确认没有无限重试、上传结果未泄露到 session 日志，并记录 provider credential 未覆盖时的边界。真实 DeepSeek API 未配置时只能验证静态/脚本化路径，不能声称 provider e2e 已通过。
+- **来源**: rc.2 adapter [`adapter.ts`](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.1-rc.2/packages/llm/llm-deepseek/src/adapter.ts)；Files API contract [`files-api.ts`](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.1-rc.2/packages/llm/llm-deepseek/src/files-api.ts)；rc.2 发布说明 [`v0.1.1-rc.2`](https://github.com/deepseek-ai/deepseek-harness/releases/tag/dsh-v0.1.1-rc.2)；对应固定提交 [`1b389798dcab`](https://github.com/deepseek-ai/deepseek-harness/commit/1b389798dcab)


### PR DESCRIPTION
## Summary

- Add the missing `dsh-v0.1.1-rc.1 -> dsh-v0.1.1-rc.2` curated card set.
- Cover canonical image metadata, `read_image` output changes, and DeepSeek Files API behavior.
- Add the corridor edge to the reference index.

Related tracking issue: #51

## Sources

All version-specific claims cite fixed upstream tags, commits, or the rc.2 release page. The card set is explicitly `curated`, not a complete API diff.

## Verification

- `node scripts/validate.mjs`
- `node scripts/validate-manifests.mjs`
- `git diff --check`
