### PR TITLE
fix(audit): fail closed on impure version corridors

### DIFF
--- a/skills/dsh-upgrade-audit/scripts/gen-artifacts.check.mjs
+++ b/skills/dsh-upgrade-audit/scripts/gen-artifacts.check.mjs
@@ -1,0 +1,59 @@
+import assert from 'node:assert/strict'
+import { execFileSync, spawnSync } from 'node:child_process'
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const script = resolve(fileURLToPath(new URL('./gen-artifacts.mjs', import.meta.url)))
+
+function git(cwd, ...args) {
+  return execFileSync('git', args, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }).trim()
+}
+
+function createRepository() {
+  const root = mkdtempSync(join(tmpdir(), 'dsh-artifacts-check-'))
+  git(root, 'init', '--quiet')
+  git(root, 'config', 'user.email', 'dsh-artifacts-check@example.invalid')
+  git(root, 'config', 'user.name', 'dsh-artifacts-check')
+  writeFileSync(join(root, 'file.txt'), 'root\n')
+  git(root, 'add', 'file.txt')
+  git(root, 'commit', '--quiet', '-m', 'root')
+  git(root, 'tag', 'dsh-v0.0.0')
+
+  writeFileSync(join(root, 'file.txt'), 'from\n')
+  git(root, 'commit', '--quiet', '-am', 'from')
+  git(root, 'tag', 'dsh-v1.0.0')
+
+  git(root, 'checkout', '--quiet', 'dsh-v0.0.0')
+  writeFileSync(join(root, 'file.txt'), 'to\n')
+  git(root, 'commit', '--quiet', '-am', 'to')
+  git(root, 'tag', 'dsh-v1.0.1')
+  return root
+}
+
+function run(root, from, to, output) {
+  return spawnSync(process.execPath, [script, from, to, output], {
+    cwd: root,
+    encoding: 'utf8',
+  })
+}
+
+const root = createRepository()
+try {
+  const impureOutput = join(root, 'impure-output')
+  const impure = run(root, 'dsh-v1.0.0', 'dsh-v1.0.1', impureOutput)
+  assert.equal(impure.status, 3)
+  assert.match(impure.stderr, /Refusing to audit an impure corridor/)
+  assert.equal(existsSync(impureOutput), false)
+
+  const pureOutput = join(root, 'pure-output')
+  const pure = run(root, 'dsh-v0.0.0', 'dsh-v1.0.0', pureOutput)
+  assert.equal(pure.status, 0, pure.stderr)
+  assert.equal(JSON.parse(pure.stdout).mergeBasePurity, 'pure')
+  assert.equal(readFileSync(join(pureOutput, 'files.txt'), 'utf8').includes('file.txt'), true)
+} finally {
+  rmSync(root, { recursive: true, force: true })
+}
+
+console.log('gen-artifacts checks OK: impure corridors fail closed; pure corridors generate artifacts')

--- a/skills/dsh-upgrade-audit/scripts/gen-artifacts.mjs
+++ b/skills/dsh-upgrade-audit/scripts/gen-artifacts.mjs
@@ -52,11 +52,19 @@ function classify(subject) {
   return m ? m[1].toLowerCase() : 'other'
 }
 
-mkdirSync(out, { recursive: true })
-
 const mergeBase = git('merge-base', from, to).trim()
 const fromCommit = git('rev-parse', `${from}^{commit}`).trim()
 const pure = mergeBase === fromCommit
+
+if (!pure) {
+  console.error(
+    `Refusing to audit an impure corridor: merge-base ${mergeBase} != from ${fromCommit}. ` +
+      'The from tag must be the merge base of the selected range.',
+  )
+  process.exit(3)
+}
+
+mkdirSync(out, { recursive: true })
 
 const commitLines = git('log', '--no-merges', '--pretty=format:%h (%ad) %s', '--date=short', `${from}..${to}`)
   .split('\n')


### PR DESCRIPTION
## Summary

- Refuse to generate audit artifacts when the merge base is not the `from` tag commit.
- Add a black-box regression check for impure and pure corridors.
- Move output directory creation after the purity guard so a rejected audit leaves no artifacts.

## Evidence

Before this change, an impure corridor printed `mergeBasePurity: DRIFT` but exited `0` and wrote five artifacts.

## Verification

- `node skills/dsh-upgrade-audit/scripts/gen-artifacts.check.mjs`
- `npm test`
- `node --check skills/dsh-upgrade-audit/scripts/gen-artifacts.mjs`
- `git diff --check`

The change is limited to the audit script and its regression check.
