### PR TITLE
test(ci): run smoke checks on Node 22 and 24

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -16,15 +16,21 @@ concurrency:
 
 jobs:
   validate:
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [22, 24]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: ${{ matrix.node-version }}
       - name: Validate skills, cards, and manifests
         run: npm test
       - name: Install pinned Claude Code validator
+        if: matrix.node-version == 22
         run: npm install --global @anthropic-ai/claude-code@2.1.222
       - name: Validate Claude plugin marketplace
+        if: matrix.node-version == 22
         run: claude plugin validate .

--- a/package.json
+++ b/package.json
@@ -4,10 +4,11 @@
   "type": "module",
   "scripts": {
     "test": "npm run validate",
-    "validate": "node scripts/validate.mjs && node scripts/validate-manifests.mjs",
+    "validate": "node scripts/validate.mjs && node scripts/validate-manifests.mjs && npm run test:smoke",
     "validate:skills": "node scripts/validate.mjs",
     "validate:manifests": "node scripts/validate-manifests.mjs",
     "validate:naming": "node skills/plugin-write/scripts/validate-names.check.mjs",
-    "validate:registry": "node skills/plugin-write/scripts/query-registry.check.mjs"
+    "validate:registry": "node skills/plugin-write/scripts/query-registry.check.mjs",
+    "test:smoke": "node --test skills/plugin-test/scripts/docker-release-smoke.test.mjs"
   }
 }


### PR DESCRIPTION
## Summary

- Add the existing `docker-release-smoke.test.mjs` suite to `npm test`.
- Run the dependency-free validation on Node 22 and Node 24.
- Keep the pinned Claude marketplace validator on one matrix leg to avoid duplicate work.

This branch is based on the latest main, including the already merged naming and runtime checks.

## Verification

- `npm test`
- 6 smoke tests passed
- Workflow YAML parsed with PyYAML
- `git diff --check`

No Docker daemon or provider credentials are required by the unit suite; the real Docker smoke remains an explicit pre-release check.
