### PR TITLE
docs(example-06): reference the filled rc.1->rc.2 corridor card set in the coverage note

### DIFF
--- a/skills/plugin-upgrade/examples/06-real-world-batch-migration.en.md
+++ b/skills/plugin-upgrade/examples/06-real-world-batch-migration.en.md
@@ -12,7 +12,7 @@ English | [简体中文](06-real-world-batch-migration.md)
 
 **Sources**: Community migration practice (migration completed 2026-08-28, verified by real boot + unit-test regression) — [deepseek-harness discussion #5120](https://github.com/deepseek-ai/deepseek-harness/discussions/5120#discussioncomment-18208001); the six plugin repositories are listed at the bottom.
 
-> Corridor coverage note: the existing corridor cards cover `dsh-v0.1.1-rc.2 → dsh-v0.1.2-alpha.1` (see the from/to in [v0.1.2-alpha.1.md](../references/v0.1.2-alpha.1.md)), while this example starts from `0.1.1-rc.1` — the rc.1 → rc.2 segment has no cards yet. The technical claims in this example (client-runtime removal, `ctx.slots.inject`, `views.get('chat')?.legacy`, etc.) are first-hand sources for that segment, pending cards; the closest existing card is DSH-0.1.2-A1-03 · 会话视图工程大幅拆分 (session-view engineering split).
+> Corridor coverage note: the corridor now covers `dsh-v0.1.1-rc.1 → dsh-v0.1.2-alpha.2` (when this example was written the rc.1 → rc.2 segment had no cards; it was later filled by [v0.1.1-rc.2.md](../references/v0.1.1-rc.2.md), 3 cards, `DSH-0.1.1-R2` prefix). The technical claims in this example (client-runtime removal, `ctx.slots.inject`, `views.get('chat')?.legacy`, etc.) were first-hand sources at the time of writing; the closest existing card is DSH-0.1.2-A1-03 · 会话视图工程大幅拆分 (session-view engineering split).
 
 ---
 

--- a/skills/plugin-upgrade/examples/06-real-world-batch-migration.md
+++ b/skills/plugin-upgrade/examples/06-real-world-batch-migration.md
@@ -12,7 +12,7 @@
 
 **素材来源**: 社区迁移实践（2026-08-28 完成迁移，实机 boot 验证 + 单测回归）——[deepseek-harness discussion #5120](https://github.com/deepseek-ai/deepseek-harness/discussions/5120#discussioncomment-18208001)，六个插件仓库见文末。
 
-> 走廊覆盖说明: 现有走廊卡片覆盖 `dsh-v0.1.1-rc.2 → dsh-v0.1.2-alpha.1`（from/to 见 [v0.1.2-alpha.1.md](../references/v0.1.2-alpha.1.md)），本示例起点为 `0.1.1-rc.1`——rc.1 → rc.2 段尚无卡片。文中 client-runtime 移除、`ctx.slots.inject`、`views.get('chat')?.legacy` 等技术声明在该段为本示例一手来源，待补卡；主题最接近的现有卡片为 DSH-0.1.2-A1-03 · 会话视图工程大幅拆分。
+> 走廊覆盖说明: 走廊现已覆盖 `dsh-v0.1.1-rc.1 → dsh-v0.1.2-alpha.2`（本示例写作时 rc.1 → rc.2 段尚无卡片，后由 [v0.1.1-rc.2.md](../references/v0.1.1-rc.2.md) 补齐，3 张卡，`DSH-0.1.1-R2` 前缀）。文中 client-runtime 移除、`ctx.slots.inject`、`views.get('chat')?.legacy` 等技术声明写作时为本示例一手来源；主题最接近的现有卡片为 DSH-0.1.2-A1-03 · 会话视图工程大幅拆分。
 
 ---
 


### PR DESCRIPTION
## 变更摘要

rc.1 → rc.2 走廊缺口已由 v0.1.1-rc.2.md（DSH-0.1.1-R2，3 张卡）补齐，example 06 里的「走廊覆盖说明」随之过时——原文写「该段尚无卡片……待补卡」。本 PR 更新中英两份的说明：改为走廊现已覆盖 rc.1 → alpha.2，注明缺口系写作后由新卡片集补齐，技术声明的「一手来源」限定为写作当时。

## 信息来源

对 #47/#44 等上游补卡提交的跟进清理，无新事实引入。