### PR TITLE
docs: add profile dependency management recipe, token-auth smoke, and 17-plugin batch migration runbook

### DIFF
--- a/skills/plugin-release/SKILL.md
+++ b/skills/plugin-release/SKILL.md
@@ -65,3 +65,4 @@ description: 打包、发布与分发 DeepSeek Harness（DSH）插件——包�
 | 文件 | 内容 |
 |---|---|
 | [references/publish-playbook.md](references/publish-playbook.md) | 未发布 cohort 安装、双兼容写法、CI/发布门禁、真实坑位清单与回滚配方 |
+| [references/profile-dependency-management.md](references/profile-dependency-management.md) | profile 安装/更新配方：github 依赖锁缓存、包改名三处同步、junction 清理与宿主升级联动 |

--- a/skills/plugin-release/references/profile-dependency-management.md
+++ b/skills/plugin-release/references/profile-dependency-management.md
@@ -1,0 +1,70 @@
+# profile 依赖管理配方
+
+> 承接 [../SKILL.md](../SKILL.md) 的发布轨选择。本文覆盖把插件装进/更新进 `$DSH_HOME/profiles/*` 时的
+> 依赖解析事实与操作配方，取自 17 个插件仓库三轮真实迁移（rc.2 → alpha.1 → alpha.2）。技术性迁移坑
+> （tsbuildinfo、oxc 解析等）见 [migration-hygiene](https://github.com/oh-my-dsh/dsh-plugin-upgrade-skill/blob/main/skills/plugin-upgrade/references/migration-hygiene.md)，
+> 本文不重复。
+
+## 1. 两种安装轨的解析事实
+
+| 声明 | 解析行为 | 适用 |
+|---|---|---|
+| `link:<绝对路径>` | 直接 junction/软链到本地目录；不产生版本解析 | 本地开发、批量迁移期间 |
+| `github:owner/repo` | 解析默认分支 HEAD，锁文件记录 codeload tarball 的精确 commit | 发布安装、消费者侧 |
+
+同一 profile 里两种轨可以混用；改名、迁移或收尾时按下面各条处理。
+
+## 2. github 依赖的锁缓存坑：`Already up to date` 不代表拿到了新提交
+
+**症状**：远端已推送新提交，`pnpm install` 输出 `Already up to date`，锁文件里的 codeload URL 仍是旧
+commit；启动加载的仍是旧代码。
+
+**原因**：pnpm 对 github 依赖缓存了 HEAD 解析；常规 `install` 不重解析。
+
+**处置**：
+
+```sh
+# 强制重新解析 github 依赖（web / headless 两个 profile 分别执行）
+cd "$DSH_HOME/profiles/web" && pnpm update <pkg>
+# 验证锁文件里的 commit 等于期望 HEAD
+grep 'codeload.*<pkg>' pnpm-lock.yaml   # 应为 tar.gz/<40位commit>
+```
+
+批量迁移收尾时对每个 github 轨依赖做一次 `pnpm update`，再核对 commit。
+
+## 3. 插件 npm 包改名（scope 变更）的三处同步
+
+包名从 `@deepseek-ai/dsh-x` 改为 `@org/dsh-x` 时，以下三处必须一致，否则 Loader 解析失败：
+
+1. profile `package.json` 的 dependencies key（安装名）；
+2. profile `dsh.profile.bundles` 条目（bundle 名）；
+3. 插件自身 `cordis.patch.yml` 里的行 `name`。
+
+**残留清理**：改名后 `pnpm install` 可能保留旧名字的 junction（新旧两个目录并存）。确认锁文件只剩新名
+后，手动删除 `node_modules/@旧scope/旧包名` 的残留目录。
+
+## 4. healed 回退镜像与 junction 更新语义
+
+- profile 自身的 `node_modules` 只含 profile 声明依赖；bare 行名解析不到时回退到共享的
+  `$DSH_HOME/profiles/node_modules`（镜像 app 与各 bundle 的声明依赖）。
+- junction 指向本地工作区包时，**工作区源码更新后重启 dsh 即生效**；host 半段改动必须重启，
+  client 半段才可能硬刷新（见 [migration-hygiene](https://github.com/oh-my-dsh/dsh-plugin-upgrade-skill/blob/main/skills/plugin-upgrade/references/migration-hygiene.md) 第 3 条）。
+- profile 根 `cordis.yml` 会在 boot 时被重写为 `[]`（组合事实在 patch 层）——**不要手改它**，改
+  `cordis.patch.yml`。
+
+## 5. 宿主 tag 升级后的 profile 联动顺序
+
+1. checkout 检出精确 tag → `pnpm install` → `pnpm run clean` → `pnpm run build`（clean 排除
+   tsbuildinfo 假阳性）；
+2. 批量插件迁移完成并推送到各自仓库后，回到 profile：`pnpm update` 重解析 github 轨依赖；
+3. `dsh --profile <p> --dump-config` 核对行集；
+4. 真实冷启动：目标 tag 的 dsh 起来后，插件清单（pluginInventory）里本插件 entry `active`、
+   无 `pending`。
+
+## 6. 验证清单
+
+- [ ] 锁文件里每个 github 依赖的 commit 等于期望 HEAD；
+- [ ] 改名插件在锁文件、bundles 列表、cordis.patch.yml 三处同名，旧 junction 已清理；
+- [ ] `--dump-config` 行集符合预期；
+- [ ] 真实冷启动 entry active；自建通道按 [A1-08 认证模型](https://github.com/oh-my-dsh/dsh-plugin-upgrade-skill/blob/main/skills/plugin-upgrade/references/v0.1.2-alpha.1.md) 冒烟
+      （有 token 200 / 无认证 401）。

--- a/skills/plugin-release/references/profile-dependency-management.md
+++ b/skills/plugin-release/references/profile-dependency-management.md
@@ -61,10 +61,43 @@ grep 'codeload.*<pkg>' pnpm-lock.yaml   # 应为 tar.gz/<40位commit>
 4. 真实冷启动：目标 tag 的 dsh 起来后，插件清单（pluginInventory）里本插件 entry `active`、
    无 `pending`。
 
-## 6. 验证清单
+## 6. 自建通道的无浏览器认证冒烟
+
+0.1.2-alpha.1 起 dsh web 使用 bootstrap token + 签名 Cookie 认证（见
+[A1-08 认证模型](https://github.com/oh-my-dsh/dsh-plugin-upgrade-skill/blob/main/skills/plugin-upgrade/references/v0.1.2-alpha.1.md)）。
+插件自建了 HTTP/RPC 通道（如 `/tariff/status`）时，发布前用下面流程证明「通道确实挂在统一认证后面」，
+不依赖浏览器/Playwright。已知行为：token 在同一进程可重复兑换、重启才轮换；自建 route 必须经
+`connection` 注册才会自动继承认证，裸 `ctx.webServer.register()` 不继承。
+
+PowerShell（自带 Cookie 容器）：
+
+```powershell
+# 1. 从启动输出抓认证 URL：dsh web: http://127.0.0.1:3190/?token=<T>
+# 2. 兑换 Cookie
+$sess = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+Invoke-WebRequest "http://127.0.0.1:3190/?token=$token" -WebSession $sess -UseBasicParsing
+# 3. 带会话调用自建通道 → 断言 200
+$body = @{ type = 'client-request'; rpcId = 'smoke'; method = 'status'; payload = $null } | ConvertTo-Json
+Invoke-WebRequest 'http://127.0.0.1:3190/tariff/status' -Method POST -ContentType 'application/json' -Body $body -WebSession $sess
+# 4. 无认证重发 → 断言 401（证明通道受保护）
+Invoke-WebRequest 'http://127.0.0.1:3190/tariff/status' -Method POST -ContentType 'application/json' -Body $body
+```
+
+curl 等价（`-c/-b` cookie jar）：
+
+```sh
+curl -s -c jar.txt "http://127.0.0.1:3190/?token=$TOKEN" >/dev/null      # 兑换 Cookie（303→/）
+curl -s -b jar.txt -X POST -H 'content-type: application/json' \
+  -d '{"type":"client-request","rpcId":"smoke","method":"status","payload":null}' \
+  http://127.0.0.1:3190/tariff/status        # 期望 200
+curl -s -o /dev/null -w '%{http_code}\n' -X POST \
+  http://127.0.0.1:3190/tariff/status        # 期望 401
+```
+
+## 7. 验证清单
 
 - [ ] 锁文件里每个 github 依赖的 commit 等于期望 HEAD；
 - [ ] 改名插件在锁文件、bundles 列表、cordis.patch.yml 三处同名，旧 junction 已清理；
 - [ ] `--dump-config` 行集符合预期；
-- [ ] 真实冷启动 entry active；自建通道按 [A1-08 认证模型](https://github.com/oh-my-dsh/dsh-plugin-upgrade-skill/blob/main/skills/plugin-upgrade/references/v0.1.2-alpha.1.md) 冒烟
-      （有 token 200 / 无认证 401）。
+- [ ] 真实冷启动 entry active；
+- [ ] 自建通道认证冒烟：无认证 401、兑换 Cookie 后 200（第 6 节流程）。

--- a/skills/plugin-release/references/profile-dependency-management.md
+++ b/skills/plugin-release/references/profile-dependency-management.md
@@ -1,7 +1,7 @@
 # profile 依赖管理配方
 
 > 承接 [../SKILL.md](../SKILL.md) 的发布轨选择。本文覆盖把插件装进/更新进 `$DSH_HOME/profiles/*` 时的
-> 依赖解析事实与操作配方，取自 17 个插件仓库三轮真实迁移（rc.2 → alpha.1 → alpha.2）。技术性迁移坑
+> 依赖解析事实与操作配方，取自 17 个插件仓库三个版本台阶的连续迁移（rc.2 → alpha.1 → alpha.2）。技术性迁移坑
 > （tsbuildinfo、oxc 解析等）见 [migration-hygiene](https://github.com/oh-my-dsh/dsh-plugin-upgrade-skill/blob/main/skills/plugin-upgrade/references/migration-hygiene.md)，
 > 本文不重复。
 
@@ -9,8 +9,8 @@
 
 | 声明 | 解析行为 | 适用 |
 |---|---|---|
-| `link:<绝对路径>` | 直接 junction/软链到本地目录；不产生版本解析 | 本地开发、批量迁移期间 |
-| `github:owner/repo` | 解析默认分支 HEAD，锁文件记录 codeload tarball 的精确 commit | 发布安装、消费者侧 |
+| `link:<绝对路径>` | 直接目录联接/软链到本地目录；不产生版本解析 | 本地开发、批量迁移期间 |
+| `github:owner/repo` | 解析默认分支 HEAD，锁文件记录 源码打包地址（codeload）的精确 commit | 发布安装、消费者侧 |
 
 同一 profile 里两种轨可以混用；改名、迁移或收尾时按下面各条处理。
 
@@ -32,7 +32,7 @@ grep 'codeload.*<pkg>' pnpm-lock.yaml   # 应为 tar.gz/<40位commit>
 
 批量迁移收尾时对每个 github 轨依赖做一次 `pnpm update`，再核对 commit。
 
-## 3. 插件 npm 包改名（scope 变更）的三处同步
+## 3. 插件 npm 包改名（包名前缀变更）的三处同步
 
 包名从 `@deepseek-ai/dsh-x` 改为 `@org/dsh-x` 时，以下三处必须一致，否则 Loader 解析失败：
 
@@ -40,14 +40,14 @@ grep 'codeload.*<pkg>' pnpm-lock.yaml   # 应为 tar.gz/<40位commit>
 2. profile `dsh.profile.bundles` 条目（bundle 名）；
 3. 插件自身 `cordis.patch.yml` 里的行 `name`。
 
-**残留清理**：改名后 `pnpm install` 可能保留旧名字的 junction（新旧两个目录并存）。确认锁文件只剩新名
-后，手动删除 `node_modules/@旧scope/旧包名` 的残留目录。
+**残留清理**：改名后 `pnpm install` 可能保留旧名字的目录联接（新旧两个目录并存）。确认锁文件只剩新名
+后，手动删除 `node_modules/@旧前缀/旧包名` 的残留目录。
 
-## 4. healed 回退镜像与 junction 更新语义
+## 4. 共享回退 node_modules 与目录联接的更新语义
 
 - profile 自身的 `node_modules` 只含 profile 声明依赖；bare 行名解析不到时回退到共享的
-  `$DSH_HOME/profiles/node_modules`（镜像 app 与各 bundle 的声明依赖）。
-- junction 指向本地工作区包时，**工作区源码更新后重启 dsh 即生效**；host 半段改动必须重启，
+  `$DSH_HOME/profiles/node_modules`（里面是 app 与各 bundle 声明依赖的副本）。
+- 目录联接指向本地工作区包时，**工作区源码更新后重启 dsh 即生效**；host 半段改动必须重启，
   client 半段才可能硬刷新（见 [migration-hygiene](https://github.com/oh-my-dsh/dsh-plugin-upgrade-skill/blob/main/skills/plugin-upgrade/references/migration-hygiene.md) 第 3 条）。
 - profile 根 `cordis.yml` 会在 boot 时被重写为 `[]`（组合事实在 patch 层）——**不要手改它**，改
   `cordis.patch.yml`。
@@ -56,7 +56,7 @@ grep 'codeload.*<pkg>' pnpm-lock.yaml   # 应为 tar.gz/<40位commit>
 
 1. checkout 检出精确 tag → `pnpm install` → `pnpm run clean` → `pnpm run build`（clean 排除
    tsbuildinfo 假阳性）；
-2. 批量插件迁移完成并推送到各自仓库后，回到 profile：`pnpm update` 重解析 github 轨依赖；
+2. 批量插件迁移完成并推送到各自仓库后，回到 profile：`pnpm update` 重解析 github 安装轨依赖；
 3. `dsh --profile <p> --dump-config` 核对行集；
 4. 真实冷启动：目标 tag 的 dsh 起来后，插件清单（pluginInventory）里本插件 entry `active`、
    无 `pending`。
@@ -97,7 +97,7 @@ curl -s -o /dev/null -w '%{http_code}\n' -X POST \
 ## 7. 验证清单
 
 - [ ] 锁文件里每个 github 依赖的 commit 等于期望 HEAD；
-- [ ] 改名插件在锁文件、bundles 列表、cordis.patch.yml 三处同名，旧 junction 已清理；
+- [ ] 改名插件在锁文件、bundles 列表、cordis.patch.yml 三处同名，旧目录联接已清理；
 - [ ] `--dump-config` 行集符合预期；
 - [ ] 真实冷启动 entry active；
 - [ ] 自建通道认证冒烟：无认证 401、兑换 Cookie 后 200（第 6 节流程）。

--- a/skills/plugin-upgrade/examples/07-multi-repo-batch-migration.md
+++ b/skills/plugin-upgrade/examples/07-multi-repo-batch-migration.md
@@ -1,13 +1,13 @@
-# 示例 07：17 个工具插件 × 三轮的多仓库批量迁移 runbook
+# 示例 07：17 个工具插件 × 三个版本台阶的批量迁移操作手册
 
 **场景**: omdsh-dev 组织 17 个工具/诊断插件仓库（calculator/json/time/encoding/diff/stat/schema/markdown/
 csv/regex、security-audit、session-health、plugin-check、plugin-dev、tariff、sandbox-micro、toolkit）连续
-三轮宿主升级批量适配：`0.1.0-rc.8 → 0.1.1-rc.2 → 0.1.2-alpha.1 → 0.1.2-alpha.2`。与
+三个版本台阶的宿主升级批量适配：`0.1.0-rc.8 → 0.1.1-rc.2 → 0.1.2-alpha.1 → 0.1.2-alpha.2`。与
 [示例 06](06-real-world-batch-migration.md)（6 个 Web Client 插件的技术迁移实录）互补：本示例聚焦
 **N 仓库的过程管理**——同步审计、批量门禁、提交推送、profile 收尾，技术触点一律引用走廊卡片与
 [migration-hygiene](../references/migration-hygiene.md)，不在此重复。
 
-**运行平面**: Host 工具插件为主；含 1 个自建 RPC 通道插件（tariff）与 profile 组合面。
+**运行平面**: Host 工具插件为主；含 1 个自建 RPC 通道插件（tariff）和 profile 依赖管理。
 **复杂度**: ⭐⭐⭐（过程管理）＋ ⭐（代码触点，见卡片）
 
 ## 流程总览
@@ -15,7 +15,7 @@ csv/regex、security-audit、session-health、plugin-check、plugin-dev、tariff
 | 阶段 | 动作 | 依据 |
 |---|---|---|
 | 1 盘点 | 逐仓记录 HEAD/remote/基线；fetch + `--ff-only` 审计 | 下文常见错误 1 |
-| 2 基线 | devDeps 用 npm 发布线、peer 宽范围、代码双兼容 | [publish-playbook](https://github.com/oh-my-dsh/dsh-plugin-upgrade-skill/blob/main/skills/plugin-release/references/publish-playbook.md) 双兼容节 |
+| 2 基线 | devDependencies 用 npm 发布线、peer 宽范围、代码双兼容 | [publish-playbook](https://github.com/oh-my-dsh/dsh-plugin-upgrade-skill/blob/main/skills/plugin-release/references/publish-playbook.md) 双兼容节 |
 | 3 批量修改 | 逐仓最小 diff：版本 bump / 文档基线 / 触点代码 | 走廊卡片 + 批量 check 循环 |
 | 4 提交推送 | 统一消息模板；逐仓 push；失败 rebase 后 `--force-with-lease` | 常见错误 2/3 |
 | 5 profile 收尾 | `pnpm update` 重解析 github 轨、改名三处同步 | [profile-dependency-management](https://github.com/oh-my-dsh/dsh-plugin-upgrade-skill/blob/main/skills/plugin-release/references/profile-dependency-management.md) |
@@ -51,7 +51,7 @@ alpha 系不在 npm 上，公开仓库的 devDependencies 保持 npm 发布线�
   [A1-06 卡片](../references/v0.1.2-alpha.1.md)）；
 - 逐仓跑完整门禁循环（typecheck + test + build）。**Windows 注意**：批量脚本里调用 npm 用
   `npm.cmd`，PowerShell 5.1 解析 `npm` 到 `npm.ps1` 会把参数打乱（`Unknown command: "pm"`）；
-- 循环实现里不要用 `& $数组 @另一数组`（PS 5.1 会把数组拼成单个命令名），按分支直写调用。
+- 批量脚本里不要用 `& $数组 @另一数组` 这种调用方式（PowerShell 5.1 会把数组拼成单个命令名），按分支直接写命令。
 
 ## 4. 提交与推送
 
@@ -66,22 +66,22 @@ git push --force-with-lease origin main
 
 - **常见错误 2——rebase 冲突的取舍**：本轮适配与远端迟到提交同文件冲突时，以“本轮基线为最终态”
   解冲突（实战：alpha.2 文档基线覆盖迟到的 alpha.1 提交）。解完逐仓验证再推。
-- **常见错误 3——两点 diff 误读他人改动**：判断某 PR/提交“删除/回退了什么”必须用三点 diff
-  （`git diff main...branch`）；两点 diff 会把“分支没跟上 main 的新增”显示成删除。实战误报两例：
-  把“未删除的 skill”读成删除、把“未回退的卡片措辞”读成回退——均因两点 diff 方向误读。
+- **常见错误 3——两点比较（`git diff a b`） 误读他人改动**：判断某 PR/提交“删除/回退了什么”必须用三点比较
+  （`git diff main...branch`）；两点比较（`git diff a b`） 会把“分支没跟上 main 的新增”显示成删除。实战误报两例：
+  把“未删除的 skill”读成删除、把“未回退的卡片措辞”读成回退——均因两点比较（`git diff a b`） 方向误读。
 
 ## 5. profile 收尾
 
 按 [profile-dependency-management](https://github.com/oh-my-dsh/dsh-plugin-upgrade-skill/blob/main/skills/plugin-release/references/profile-dependency-management.md)：
-`pnpm update` 重解析 github 轨依赖并核对锁 commit；包改名时三处同步 + 清残留 junction。
+`pnpm update` 重解析 github 安装轨依赖并核对锁文件 commit；包改名时三处同步、清理残留目录联接。
 
-## 6. 真实验证（每轮都跑）
+## 6. 真实验证（每个版本台阶都跑）
 
 1. 目标 tag 冷启动，`pluginInventory/list` 全部本插件 entry `active`、无 `pending`；
 2. 自建通道冒烟：无认证 401 / 消费 token 后 200（[A1-08](../references/v0.1.2-alpha.1.md)）；
 3. 一条真实行为：headless 任务让模型调用本插件工具（如 calculator 计算），核对 stdout 最终文本与
    stderr reasoning 归属（[A1-05](../references/v0.1.2-alpha.1.md)）；
-4. 结果归档：每轮留存「版本 → 各仓提交 → 验证结果」记录，作为下一轮盘点基线。
+4. 结果归档：每个版本台阶留存「版本 → 各仓提交 → 验证结果」记录，作为下一个版本台阶的盘点基线。
 
 ## 与本仓库其他材料的关系
 

--- a/skills/plugin-upgrade/examples/07-multi-repo-batch-migration.md
+++ b/skills/plugin-upgrade/examples/07-multi-repo-batch-migration.md
@@ -1,0 +1,92 @@
+# 示例 07：17 个工具插件 × 三轮的多仓库批量迁移 runbook
+
+**场景**: omdsh-dev 组织 17 个工具/诊断插件仓库（calculator/json/time/encoding/diff/stat/schema/markdown/
+csv/regex、security-audit、session-health、plugin-check、plugin-dev、tariff、sandbox-micro、toolkit）连续
+三轮宿主升级批量适配：`0.1.0-rc.8 → 0.1.1-rc.2 → 0.1.2-alpha.1 → 0.1.2-alpha.2`。与
+[示例 06](06-real-world-batch-migration.md)（6 个 Web Client 插件的技术迁移实录）互补：本示例聚焦
+**N 仓库的过程管理**——同步审计、批量门禁、提交推送、profile 收尾，技术触点一律引用走廊卡片与
+[migration-hygiene](../references/migration-hygiene.md)，不在此重复。
+
+**运行平面**: Host 工具插件为主；含 1 个自建 RPC 通道插件（tariff）与 profile 组合面。
+**复杂度**: ⭐⭐⭐（过程管理）＋ ⭐（代码触点，见卡片）
+
+## 流程总览
+
+| 阶段 | 动作 | 依据 |
+|---|---|---|
+| 1 盘点 | 逐仓记录 HEAD/remote/基线；fetch + `--ff-only` 审计 | 下文常见错误 1 |
+| 2 基线 | devDeps 用 npm 发布线、peer 宽范围、代码双兼容 | [publish-playbook](https://github.com/oh-my-dsh/dsh-plugin-upgrade-skill/blob/main/skills/plugin-release/references/publish-playbook.md) 双兼容节 |
+| 3 批量修改 | 逐仓最小 diff：版本 bump / 文档基线 / 触点代码 | 走廊卡片 + 批量 check 循环 |
+| 4 提交推送 | 统一消息模板；逐仓 push；失败 rebase 后 `--force-with-lease` | 常见错误 2/3 |
+| 5 profile 收尾 | `pnpm update` 重解析 github 轨、改名三处同步 | [profile-dependency-management](https://github.com/oh-my-dsh/dsh-plugin-upgrade-skill/blob/main/skills/plugin-release/references/profile-dependency-management.md) |
+| 6 真实验证 | 目标 tag 冷启动 + 清单全 active + 一条真实行为 | 分层验证清单 |
+
+## 1. 盘点：同步状态审计
+
+```sh
+for d in plugins/*; do
+  (cd "$d" && git fetch origin && \
+   git rev-parse HEAD > /tmp/before && \
+   git pull --ff-only origin main && \
+   git rev-parse HEAD > /tmp/after && \
+   printf '%s %s\n' "$d" "$(diff -q /tmp/before /tmp/after >/dev/null && echo same || echo UPDATED)")
+done
+```
+
+**常见错误 1——`same` 不等于作者已更新**：pull 显示 `same` 只说明本地已是最新，不代表远端仓库
+有/没有该轮的适配提交。实战：一轮迁移中 `dsh-tool-diff` 显示 `same`，其实是它的适配提交**迟于**其他
+仓库推送；如果按“已全量更新”直接开跑，就会漏掉这个仓库。审计结论必须以「每仓最后一笔提交是否
+属于本轮适配」为准，而不是 pull 输出。
+
+## 2. 基线：npm 发布线类型 + 本地 harness 验证
+
+alpha 系不在 npm 上，公开仓库的 devDependencies 保持 npm 发布线（当时为 `^0.1.1-rc.2`），peer 用
+宽范围（`<0.2.0`）覆盖未发布 cohort；代码对签名漂移的 API 用双兼容写法（例见
+[publish-playbook](https://github.com/oh-my-dsh/dsh-plugin-upgrade-skill/blob/main/skills/plugin-release/references/publish-playbook.md) 的 `rpc.handle` 案例），保证
+任意机器 `npm install` 后 typecheck 可用、alpha 运行时行为不变。
+
+## 3. 批量修改与批量门禁
+
+- 版本/文档基线类改动用脚本批量替换 + 逐仓 diff 复核（禁止无脑全局替换 `code` 一类语义词，见
+  [A1-06 卡片](../references/v0.1.2-alpha.1.md)）；
+- 逐仓跑完整门禁循环（typecheck + test + build）。**Windows 注意**：批量脚本里调用 npm 用
+  `npm.cmd`，PowerShell 5.1 解析 `npm` 到 `npm.ps1` 会把参数打乱（`Unknown command: "pm"`）；
+- 循环实现里不要用 `& $数组 @另一数组`（PS 5.1 会把数组拼成单个命令名），按分支直写调用。
+
+## 4. 提交与推送
+
+- 消息模板与历史一致：`chore(dsh): align devDependencies with dsh <v> and rebuild lib` /
+  `fix(dsh): <触点描述> for harness <v>` / `docs(dsh): note harness <v> validation`；
+- 逐仓 `git push origin main`；失败时：
+
+```sh
+git pull --rebase origin main          # GIT_EDITOR=true 防编辑器挂起
+git push --force-with-lease origin main
+```
+
+- **常见错误 2——rebase 冲突的取舍**：本轮适配与远端迟到提交同文件冲突时，以“本轮基线为最终态”
+  解冲突（实战：alpha.2 文档基线覆盖迟到的 alpha.1 提交）。解完逐仓验证再推。
+- **常见错误 3——两点 diff 误读他人改动**：判断某 PR/提交“删除/回退了什么”必须用三点 diff
+  （`git diff main...branch`）；两点 diff 会把“分支没跟上 main 的新增”显示成删除。实战误报两例：
+  把“未删除的 skill”读成删除、把“未回退的卡片措辞”读成回退——均因两点 diff 方向误读。
+
+## 5. profile 收尾
+
+按 [profile-dependency-management](https://github.com/oh-my-dsh/dsh-plugin-upgrade-skill/blob/main/skills/plugin-release/references/profile-dependency-management.md)：
+`pnpm update` 重解析 github 轨依赖并核对锁 commit；包改名时三处同步 + 清残留 junction。
+
+## 6. 真实验证（每轮都跑）
+
+1. 目标 tag 冷启动，`pluginInventory/list` 全部本插件 entry `active`、无 `pending`；
+2. 自建通道冒烟：无认证 401 / 消费 token 后 200（[A1-08](../references/v0.1.2-alpha.1.md)）；
+3. 一条真实行为：headless 任务让模型调用本插件工具（如 calculator 计算），核对 stdout 最终文本与
+   stderr reasoning 归属（[A1-05](../references/v0.1.2-alpha.1.md)）；
+4. 结果归档：每轮留存「版本 → 各仓提交 → 验证结果」记录，作为下一轮盘点基线。
+
+## 与本仓库其他材料的关系
+
+- 技术触点与卡片：见 [v0.1.1-rc.2](../references/v0.1.1-rc.2.md)、[alpha.1](../references/v0.1.2-alpha.1.md)、
+  [alpha.2](../references/v0.1.2-alpha.2.md) 与 [rollup](../references/rollup-0.1.2.md)；
+- 工具链坑：[migration-hygiene](../references/migration-hygiene.md)（本文不重复）；
+- 发布/分发面：[publish-playbook](https://github.com/oh-my-dsh/dsh-plugin-upgrade-skill/blob/main/skills/plugin-release/references/publish-playbook.md) 与
+  [profile-dependency-management](https://github.com/oh-my-dsh/dsh-plugin-upgrade-skill/blob/main/skills/plugin-release/references/profile-dependency-management.md)。

--- a/skills/plugin-upgrade/examples/README.md
+++ b/skills/plugin-upgrade/examples/README.md
@@ -11,6 +11,7 @@
 | `04-dual-cohort-plugin.md`（待补） | 双 cohort 共存 | 未实现 |
 | `05-third-party-plugin-patch.md`（待补） | 第三方预构建插件 patch | 未实现 |
 | [06-real-world-batch-migration.md](06-real-world-batch-migration.md)（[EN](06-real-world-batch-migration.en.md)） | 真实批量迁移实录（6 个插件，三种形态，含踩坑清单） | 实测记录：源自 6 个真实插件的实机 boot 验证 + 单测回归（非本仓库可执行夹具） |
+| [07-multi-repo-batch-migration.md](07-multi-repo-batch-migration.md) | 17 个工具插件 × 三轮的多仓库批量迁移 runbook（同步审计、批量门禁、推送与 profile 收尾） | 实测记录：三轮真实迁移过程记录（技术触点引用卡片） |
 
 ## 贡献要求
 

--- a/skills/plugin-upgrade/examples/README.md
+++ b/skills/plugin-upgrade/examples/README.md
@@ -11,7 +11,7 @@
 | `04-dual-cohort-plugin.md`（待补） | 双 cohort 共存 | 未实现 |
 | `05-third-party-plugin-patch.md`（待补） | 第三方预构建插件 patch | 未实现 |
 | [06-real-world-batch-migration.md](06-real-world-batch-migration.md)（[EN](06-real-world-batch-migration.en.md)） | 真实批量迁移实录（6 个插件，三种形态，含踩坑清单） | 实测记录：源自 6 个真实插件的实机 boot 验证 + 单测回归（非本仓库可执行夹具） |
-| [07-multi-repo-batch-migration.md](07-multi-repo-batch-migration.md) | 17 个工具插件 × 三轮的多仓库批量迁移 runbook（同步审计、批量门禁、推送与 profile 收尾） | 实测记录：三轮真实迁移过程记录（技术触点引用卡片） |
+| [07-multi-repo-batch-migration.md](07-multi-repo-batch-migration.md) | 17 个工具插件 × 三个版本台阶的批量迁移操作手册（同步审计、批量门禁、推送与 profile 收尾） | 实测记录：三个版本台阶的连续迁移过程记录（技术触点引用卡片） |
 
 ## 贡献要求
 


### PR DESCRIPTION
### 1. profile 依赖管理配方（`plugin-release/references/profile-dependency-management.md` 新文件）
- github 安装轨的锁缓存坑：`pnpm install` 说 Already up to date ≠ 拿到新提交，用 `pnpm update` 强制重解析并核对锁文件 commit；
- 插件 npm 包改名（包名前缀变更）三处同步（profile 依赖键、bundle 列表、cordis.patch.yml 行名）+ 残留目录联接清理；
- 共享回退 node_modules 与目录联接更新语义、profile boot 重写 cordis.yml 的事实；
- 宿主 tag 升级后的 profile 联动顺序；
- **自建通道的无浏览器认证冒烟**（并入第 6 节）：PowerShell / curl 两个版本——从启动输出抓 token URL → 兑换 Cookie → 带会话调用断言 200 → 无认证重发断言 401，不依赖浏览器/Playwright。

### 2. 批量迁移操作手册（`plugin-upgrade/examples/07-*.md` 新文件）
- 与示例 06（客户端技术迁移实录）分工：本手册讲 N 仓库的过程管理——同步状态审计（pull 显示 same ≠ 作者已更新）、批量门禁循环（npm.cmd / PowerShell 5.1 数组陷阱）、提交消息模板、push 失败 rebase 处理、profile 收尾；
- 收录两点比较误读“删除/回退”的坑（判断他人改动必须用三点比较）；
- 技术触点一律引用版本走廊卡片与 migration-hygiene，不重复。

### 3. 索引更新
- plugin-release SKILL 参考材料表 +1 行；examples/README 索引 +1 行。

## 验证
- `node scripts/validate.mjs`：Validation OK（5 skill / 3 card sets / 30 cards / 73 Markdown files …）
- `node scripts/validate-manifests.mjs`：清单校验通过
- 全部内容来自 17 个仓库三轮真实迁移的一手记录；跨 skill 引用按自包含规则使用 GitHub URL

## 与开放 PR 的关系
- 仅与 #27、#64 共享 `examples/README.md` 索引表各一行（git 层面一行级重叠，任一方先合并后另一方 rebase 补一行即可）；其余 8 个 PR 零重叠、内容零重复。
