### PR TITLE
test(ci): add exact-version DSH migration integration

### DIFF
--- a/.github/workflows/dsh-integration.yml
+++ b/.github/workflows/dsh-integration.yml
@@ -1,0 +1,51 @@
+name: dsh-integration
+
+on:
+  pull_request:
+    paths:
+      - "skills/plugin-test/scripts/**"
+      - "benchmark/runtime/**"
+      - "benchmark/tasks/**/solution/plugin/**"
+      - "package.json"
+      - ".github/workflows/dsh-integration.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "skills/plugin-test/scripts/**"
+      - "benchmark/runtime/**"
+      - "benchmark/tasks/**/solution/plugin/**"
+      - "package.json"
+      - ".github/workflows/dsh-integration.yml"
+  workflow_dispatch:
+  schedule:
+    - cron: "0 3 * * 1"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dsh-integration-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+      - name: Run fast validation first
+        run: npm test
+      - name: Run exact-version DSH integration cases
+        run: npm run test:dsh -- --report-dir .artifacts/dsh-integration
+      - name: Upload failure evidence
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: dsh-integration-reports
+          path: .artifacts/dsh-integration
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ build/
 benchmark/agent-output/
 benchmark/scorecard.json
 jobs/
+.artifacts/
+.dsh-plugin-smoke-run-*/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,12 +66,22 @@
 ## 本地验证
 
 ```sh
-node scripts/validate.mjs
-node scripts/validate-manifests.mjs
+npm test
 ```
 
-修改 Skill、命令、manifest、版本卡或示例时，两条都运行。示例有自己的 build/test 时，
-还要运行对应命令。没运行或受凭据/平台限制的检查必须在 PR 中注明。
+该入口包含原有的两个结构校验器：`node scripts/validate.mjs` 与
+`node scripts/validate-manifests.mjs`，并补跑 release、audit 和 DSH case 定义自检。
+
+修改 Skill、命令、manifest、版本卡或示例时运行快速校验。若改动
+`plugin-upgrade`、`plugin-test`、`dsh-upgrade-audit` 或 `benchmark/runtime/` 中的运行时迁移事实，
+还要在隔离 Docker 环境运行：
+
+```sh
+npm run test:dsh
+```
+
+该命令使用精确 DSH 版本和打包后的 fixture，不会修改本机 `~/.dsh`。示例有自己的
+build/test 时还要运行对应命令；没运行或受 Docker、凭据、平台限制的检查必须在 PR 中注明。
 
 ## PR 检查清单
 

--- a/benchmark/runtime/cases.json
+++ b/benchmark/runtime/cases.json
@@ -1,0 +1,48 @@
+{
+  "schema": 1,
+  "defaults": {
+    "image": "node:24-bookworm",
+    "pnpmVersion": "11.24.0",
+    "profile": "web",
+    "startCommand": ["dsh", "web", "--no-open"],
+    "timeoutSeconds": 60,
+    "shutdownGraceSeconds": 5
+  },
+  "cases": [
+    {
+      "id": "host-api-proxy",
+      "cards": ["DSH-0.1.2-A1-01"],
+      "from": "0.1.1-rc.2",
+      "to": "0.1.2-alpha.2",
+      "compatibility": "target-only",
+      "fixtures": {
+        "legacy": "runtime/fixtures/host-api-proxy-legacy",
+        "migrated": "tasks/M1-host-migration/solution/plugin"
+      },
+      "checks": [
+        {
+          "id": "legacy-source",
+          "fixture": "legacy",
+          "dshVersion": "0.1.1-rc.2",
+          "expect": "pass",
+          "readyText": "[dsh-upgrade-fixture] legacy-api-proxy-ok"
+        },
+        {
+          "id": "legacy-target",
+          "fixture": "legacy",
+          "dshVersion": "0.1.2-alpha.2",
+          "expect": "fail",
+          "failureClassification": "startup",
+          "logPattern": "waiting for service: apiProxy"
+        },
+        {
+          "id": "migrated-target",
+          "fixture": "migrated",
+          "dshVersion": "0.1.2-alpha.2",
+          "expect": "pass",
+          "readyText": "[upgrade-demo] llm.listProviders() 成功"
+        }
+      ]
+    }
+  ]
+}

--- a/benchmark/runtime/fixtures/host-api-proxy-legacy/cordis.patch.yml
+++ b/benchmark/runtime/fixtures/host-api-proxy-legacy/cordis.patch.yml
@@ -1,0 +1,4 @@
+# Runtime control: valid on rc.2 and intentionally pending on alpha.2.
+- insert:
+    - id: dsh-upgrade-host-api-proxy-legacy
+      name: "@dsh-upgrade-fixture/host-api-proxy-legacy"

--- a/benchmark/runtime/fixtures/host-api-proxy-legacy/index.js
+++ b/benchmark/runtime/fixtures/host-api-proxy-legacy/index.js
@@ -1,0 +1,15 @@
+// Red control for DSH-0.1.2-A1-01: this is the real rc.2 Host-plane contract.
+export const inject = ['apiProxy']
+
+export function apply(ctx) {
+  ctx.effect(async () => {
+    const response = await ctx.apiProxy.llm.providers({
+      rpcId: 'dsh-upgrade-fixture',
+      payload: {},
+    })
+    if (!response?.result?.ok || !Array.isArray(response.result.value?.providers)) {
+      throw new Error('legacy apiProxy provider probe returned an invalid response')
+    }
+    console.error(`[dsh-upgrade-fixture] legacy-api-proxy-ok providers=${response.result.value.providers.length}`)
+  })
+}

--- a/benchmark/runtime/fixtures/host-api-proxy-legacy/package.json
+++ b/benchmark/runtime/fixtures/host-api-proxy-legacy/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@dsh-upgrade-fixture/host-api-proxy-legacy",
+  "version": "0.0.0",
+  "description": "Runtime control fixture for the removed rc.2 Host APIProxy contract",
+  "private": true,
+  "type": "module",
+  "main": "index.js",
+  "files": [
+    "index.js",
+    "cordis.patch.yml"
+  ],
+  "dsh": {
+    "bundle": {
+      "patch": "./cordis.patch.yml"
+    }
+  }
+}

--- a/benchmark/runtime/verify.mjs
+++ b/benchmark/runtime/verify.mjs
@@ -40,9 +40,9 @@ function parseArguments(argv) {
 function usage() {
   return [
     'Usage:',
-    '  node tests/dsh/verify.mjs --check',
-    '  node tests/dsh/verify.mjs --all [--report-dir <path>]',
-    '  node tests/dsh/verify.mjs --case <id> [--report-dir <path>]',
+    '  node benchmark/runtime/verify.mjs --check',
+    '  node benchmark/runtime/verify.mjs --all [--report-dir <path>]',
+    '  node benchmark/runtime/verify.mjs --case <id> [--report-dir <path>]',
   ].join('\n')
 }
 

--- a/benchmark/runtime/verify.mjs
+++ b/benchmark/runtime/verify.mjs
@@ -1,0 +1,326 @@
+#!/usr/bin/env node
+
+import { spawn } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+import { runDockerSmoke } from '../../skills/plugin-test/scripts/docker-release-smoke.mjs'
+
+const runtimeRoot = dirname(fileURLToPath(import.meta.url))
+const benchmarkRoot = resolve(runtimeRoot, '..')
+const repositoryRoot = resolve(benchmarkRoot, '..')
+const casesPath = join(runtimeRoot, 'cases.json')
+const referencesRoot = join(repositoryRoot, 'skills', 'plugin-upgrade', 'references')
+
+function parseArguments(argv) {
+  const options = { caseIds: [] }
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index]
+    if (argument === '--check') options.check = true
+    else if (argument === '--all') options.all = true
+    else if (argument === '--case') {
+      const value = argv[++index]
+      if (!value) throw new Error('--case requires an ID')
+      options.caseIds.push(value)
+    } else if (argument === '--report-dir') {
+      const value = argv[++index]
+      if (!value) throw new Error('--report-dir requires a path')
+      options.reportDirectory = resolve(value)
+    } else if (argument === '--help' || argument === '-h') options.help = true
+    else throw new Error(`unknown argument: ${argument}`)
+  }
+  if (!options.help && !options.check && !options.all && options.caseIds.length === 0) {
+    throw new Error('choose --check, --all, or at least one --case <id>')
+  }
+  return options
+}
+
+function usage() {
+  return [
+    'Usage:',
+    '  node tests/dsh/verify.mjs --check',
+    '  node tests/dsh/verify.mjs --all [--report-dir <path>]',
+    '  node tests/dsh/verify.mjs --case <id> [--report-dir <path>]',
+  ].join('\n')
+}
+
+function requireString(value, name) {
+  if (typeof value !== 'string' || !value.trim()) throw new Error(`${name} must be a non-empty string`)
+  return value
+}
+
+function requireExactVersion(value, name) {
+  const version = requireString(value, name)
+  if (!/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/.test(version)) {
+    throw new Error(`${name} must be an exact semver version`)
+  }
+  return version
+}
+
+function requireInteger(value, name, minimum, maximum) {
+  if (!Number.isInteger(value) || value < minimum || value > maximum) {
+    throw new Error(`${name} must be an integer from ${minimum} to ${maximum}`)
+  }
+  return value
+}
+
+function validateCases(data) {
+  if (data?.schema !== 1) throw new Error('cases.json schema must be 1')
+  if (!data.defaults || typeof data.defaults !== 'object') throw new Error('cases.json defaults are required')
+  requireString(data.defaults.image, 'defaults.image')
+  requireExactVersion(data.defaults.pnpmVersion, 'defaults.pnpmVersion')
+  requireString(data.defaults.profile, 'defaults.profile')
+  if (!Array.isArray(data.defaults.startCommand) || data.defaults.startCommand.length === 0) {
+    throw new Error('defaults.startCommand must be a non-empty argv array')
+  }
+  data.defaults.startCommand.forEach((part, index) => requireString(part, `defaults.startCommand[${index}]`))
+  requireInteger(data.defaults.timeoutSeconds, 'defaults.timeoutSeconds', 1, 1800)
+  requireInteger(data.defaults.shutdownGraceSeconds, 'defaults.shutdownGraceSeconds', 1, 60)
+  if (!Array.isArray(data.cases) || data.cases.length === 0) throw new Error('cases.json must contain cases')
+  const ids = new Set()
+  for (const [caseIndex, entry] of data.cases.entries()) {
+    const prefix = `cases[${caseIndex}]`
+    const id = requireString(entry.id, `${prefix}.id`)
+    if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(id)) throw new Error(`${prefix}.id must be kebab-case`)
+    if (ids.has(id)) throw new Error(`duplicate case id: ${id}`)
+    ids.add(id)
+    const fromVersion = requireExactVersion(entry.from, `${prefix}.from`)
+    const toVersion = requireExactVersion(entry.to, `${prefix}.to`)
+    const corridorVersions = new Set([fromVersion, toVersion])
+    if (!['target-only', 'dual'].includes(entry.compatibility)) {
+      throw new Error(`${prefix}.compatibility must be target-only or dual`)
+    }
+    if (!Array.isArray(entry.cards) || entry.cards.length === 0) throw new Error(`${prefix}.cards are required`)
+    for (const card of entry.cards) {
+      requireString(card, `${prefix}.cards[]`)
+      if (!new RegExp(`^### ${card.replaceAll('.', '\\.')}(?: |$)`, 'm').test(data.referenceText)) {
+        throw new Error(`${id} references an unknown card: ${card}`)
+      }
+    }
+    if (!entry.fixtures || typeof entry.fixtures !== 'object') throw new Error(`${prefix}.fixtures are required`)
+    for (const [name, relativePath] of Object.entries(entry.fixtures)) {
+      const path = resolve(benchmarkRoot, requireString(relativePath, `${prefix}.fixtures.${name}`))
+      if (!path.startsWith(`${benchmarkRoot}/`)) throw new Error(`${id} fixture leaves benchmark: ${relativePath}`)
+      if (!existsSync(join(path, 'package.json'))) throw new Error(`${id} fixture is missing package.json: ${relativePath}`)
+    }
+    if (!Array.isArray(entry.checks) || entry.checks.length === 0) throw new Error(`${prefix}.checks are required`)
+    const checkIds = new Set()
+    for (const [checkIndex, check] of entry.checks.entries()) {
+      const checkPrefix = `${prefix}.checks[${checkIndex}]`
+      const checkId = requireString(check.id, `${checkPrefix}.id`)
+      if (checkIds.has(checkId)) throw new Error(`${id} has duplicate check id: ${checkId}`)
+      checkIds.add(checkId)
+      if (!entry.fixtures[check.fixture]) throw new Error(`${checkPrefix}.fixture is unknown: ${check.fixture}`)
+      const dshVersion = requireExactVersion(check.dshVersion, `${checkPrefix}.dshVersion`)
+      if (!corridorVersions.has(dshVersion)) {
+        throw new Error(`${checkPrefix}.dshVersion must match the case from or to version`)
+      }
+      if (!['pass', 'fail'].includes(check.expect)) throw new Error(`${checkPrefix}.expect must be pass or fail`)
+      if (check.expect === 'pass') requireString(check.readyText, `${checkPrefix}.readyText`)
+      if (check.expect === 'fail') {
+        requireString(check.failureClassification, `${checkPrefix}.failureClassification`)
+        requireString(check.logPattern, `${checkPrefix}.logPattern`)
+      }
+    }
+  }
+  return data
+}
+
+async function loadCases() {
+  const data = JSON.parse(await readFile(casesPath, 'utf8'))
+  const referenceFiles = (await readdir(referencesRoot)).filter((name) => /^v\d.*\.md$/.test(name)).sort()
+  data.referenceText = (
+    await Promise.all(referenceFiles.map((name) => readFile(join(referencesRoot, name), 'utf8')))
+  ).join('\n')
+  return validateCases(data)
+}
+
+function runProcess(command, args, options = {}) {
+  return new Promise((resolvePromise) => {
+    const child = spawn(command, args, {
+      cwd: options.cwd,
+      env: options.env,
+      shell: false,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    let stdout = ''
+    let stderr = ''
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk.toString('utf8')
+    })
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk.toString('utf8')
+    })
+    child.once('error', (error) => resolvePromise({ exitCode: null, stdout, stderr, error }))
+    child.once('close', (exitCode) => resolvePromise({ exitCode, stdout, stderr }))
+  })
+}
+
+async function packFixture(path, destination) {
+  const result = await runProcess('npm', ['pack', '--json', '--pack-destination', destination], { cwd: path })
+  if (result.error) throw result.error
+  if (result.exitCode !== 0) throw new Error(`npm pack failed for ${path}: ${result.stderr || result.stdout}`)
+  let metadata
+  try {
+    metadata = JSON.parse(result.stdout)
+  } catch {
+    throw new Error(`npm pack returned invalid JSON for ${path}: ${result.stdout}`)
+  }
+  const filename = metadata?.[0]?.filename
+  if (!filename) throw new Error(`npm pack did not report an artifact for ${path}`)
+  return join(destination, filename)
+}
+
+function escapeRegex(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+function evaluateCheck(check, report) {
+  if (check.expect === 'pass') {
+    if (report.status !== 'passed') return `expected pass, got ${report.failureClassification ?? report.status}`
+    return null
+  }
+  if (report.status !== 'failed') return `expected failure containing ${check.logPattern}, got pass`
+  if (report.failureClassification !== check.failureClassification) {
+    return `expected ${check.failureClassification} failure, got ${report.failureClassification}`
+  }
+  const logs = `${report.logs.stdout}\n${report.logs.stderr}`
+  if (!logs.includes(check.logPattern)) return `expected failure log to contain: ${check.logPattern}`
+  return null
+}
+
+async function runCase(entry, defaults, reportRoot, packageRoot, cacheVolume, toolchainVolumes) {
+  const artifacts = new Map()
+  const results = []
+  for (const [name, relativePath] of Object.entries(entry.fixtures)) {
+    artifacts.set(name, await packFixture(resolve(benchmarkRoot, relativePath), packageRoot))
+  }
+  for (const check of entry.checks) {
+    const checkDirectory = join(reportRoot, entry.id, check.id)
+    await mkdir(checkDirectory, { recursive: true })
+    const config = {
+      schema: 1,
+      image: defaults.image,
+      dshVersion: check.dshVersion,
+      pnpmVersion: defaults.pnpmVersion,
+      profile: defaults.profile,
+      startCommand: defaults.startCommand,
+      readyPattern: escapeRegex(check.readyText ?? '__dsh_upgrade_expected_failure_never_ready__'),
+      timeoutSeconds: defaults.timeoutSeconds,
+      shutdownGraceSeconds: defaults.shutdownGraceSeconds,
+      probeCommand: [],
+    }
+    const { report, jsonPath, markdownPath } = await runDockerSmoke({
+      config,
+      pluginPath: artifacts.get(check.fixture),
+      reportDirectory: checkDirectory,
+      cacheVolume,
+      toolchainVolume: toolchainVolumes.get(check.dshVersion),
+    })
+    const error = evaluateCheck(check, report)
+    const result = {
+      caseId: entry.id,
+      checkId: check.id,
+      expected: check.expect,
+      status: error ? 'failed' : 'passed',
+      error,
+      smokeStatus: report.status,
+      failureClassification: report.failureClassification,
+      report: { jsonPath, markdownPath },
+    }
+    results.push(result)
+    const detail = error
+      ?? (check.expect === 'fail'
+        ? `expected ${check.failureClassification} failure observed`
+        : 'smoke passed')
+    console.log(`${error ? 'FAIL' : 'PASS'} ${entry.id}/${check.id}: ${detail}`)
+  }
+  return results
+}
+
+function renderSummary(results) {
+  const lines = ['# DSH migration integration summary', '', '| Case | Check | Expected | Result |', '|---|---|---|---|']
+  for (const result of results) {
+    lines.push(`| ${result.caseId} | ${result.checkId} | ${result.expected} | ${result.status}${result.error ? `: ${result.error}` : ''} |`)
+  }
+  lines.push('')
+  return lines.join('\n')
+}
+
+export async function main(argv = process.argv.slice(2)) {
+  const options = parseArguments(argv)
+  if (options.help) {
+    console.log(usage())
+    return 0
+  }
+  const data = await loadCases()
+  console.log(`DSH case definitions OK: ${data.cases.length} case, ${data.cases.flatMap((entry) => entry.checks).length} checks`)
+  if (options.check) return 0
+
+  const selected = options.all
+    ? data.cases
+    : data.cases.filter((entry) => options.caseIds.includes(entry.id))
+  const selectedIds = new Set(selected.map((entry) => entry.id))
+  const missing = options.caseIds.filter((id) => !selectedIds.has(id))
+  if (missing.length) throw new Error(`unknown case ID: ${missing.join(', ')}`)
+
+  // Keep bind-mounted artifacts below the checkout. Docker Desktop and Colima
+  // do not necessarily expose the host's system temporary directory to the VM.
+  const temporaryBase = join(repositoryRoot, '.artifacts')
+  await mkdir(temporaryBase, { recursive: true })
+  const temporaryRoot = await mkdtemp(join(temporaryBase, 'dsh-upgrade-integration-'))
+  const reportRoot = options.reportDirectory ?? join(temporaryRoot, 'reports')
+  const packageRoot = join(temporaryRoot, 'packages')
+  await mkdir(reportRoot, { recursive: true })
+  await mkdir(packageRoot, { recursive: true })
+  const cacheVolume = `dsh-upgrade-cache-${process.pid}-${Date.now()}`
+  const versions = [...new Set(selected.flatMap((entry) => entry.checks.map((check) => check.dshVersion)))]
+  const toolchainVolumes = new Map(
+    versions.map((version, index) => [version, `dsh-upgrade-toolchain-${process.pid}-${Date.now()}-${index}`]),
+  )
+  const volumes = [cacheVolume, ...toolchainVolumes.values()]
+  const createdVolumes = []
+  const results = []
+  try {
+    for (const volume of volumes) {
+      const volumeResult = await runProcess('docker', ['volume', 'create', volume])
+      if (volumeResult.error) throw volumeResult.error
+      if (volumeResult.exitCode !== 0) {
+        throw new Error(`docker volume create failed: ${volumeResult.stderr || volumeResult.stdout}`)
+      }
+      createdVolumes.push(volume)
+    }
+    for (const entry of selected) {
+      results.push(...(
+        await runCase(entry, data.defaults, reportRoot, packageRoot, cacheVolume, toolchainVolumes)
+      ))
+    }
+    await writeFile(join(reportRoot, 'summary.json'), `${JSON.stringify({ schema: 1, results }, null, 2)}\n`, 'utf8')
+    await writeFile(join(reportRoot, 'summary.md'), renderSummary(results), 'utf8')
+    const failed = results.some((result) => result.status === 'failed')
+    console.log(options.reportDirectory || failed ? `Reports: ${reportRoot}` : 'Reports: not retained after successful run')
+    return failed ? 1 : 0
+  } finally {
+    for (const volume of createdVolumes.reverse()) {
+      await runProcess('docker', ['volume', 'rm', '--force', volume])
+    }
+    await rm(packageRoot, { recursive: true, force: true })
+    if (options.reportDirectory || !results.some((result) => result.status === 'failed')) {
+      await rm(temporaryRoot, { recursive: true, force: true })
+    }
+  }
+}
+
+if (process.argv[1] && pathToFileURL(resolve(process.argv[1])).href === import.meta.url) {
+  main().then(
+    (exitCode) => {
+      process.exitCode = exitCode
+    },
+    (error) => {
+      console.error(`DSH integration failed: ${error.stack ?? error.message}`)
+      process.exitCode = 2
+    },
+  )
+}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test": "npm run validate",
+    "test": "npm run validate && npm run test:release && npm run test:audit && npm run test:dsh:cases",
     "validate": "node scripts/validate.mjs && node scripts/validate-manifests.mjs && node benchmark/scripts/validate-task-registry.mjs && node --test benchmark/scripts/validate-task-registry.test.mjs && node benchmark/scripts/validate-evaluation-snapshots.mjs && node --test benchmark/scripts/validate-evaluation-snapshots.test.mjs && node benchmark/scripts/validate-checkpoints.mjs && node --test benchmark/scripts/validate-checkpoints.test.mjs && node benchmark/scripts/validate-task-toml.mjs && node --test benchmark/scripts/validate-task-toml.test.mjs && node skills/plugin-upgrade/scripts/verify-runtime.check.mjs && npm run test:smoke",
     "validate:skills": "node scripts/validate.mjs",
     "validate:manifests": "node scripts/validate-manifests.mjs",
@@ -16,6 +16,10 @@
     "validate:registry": "node skills/plugin-write/scripts/query-registry.check.mjs",
     "verify:runtime": "node skills/plugin-upgrade/scripts/verify-runtime.check.mjs",
     "test:smoke": "node --test skills/plugin-test/scripts/docker-release-smoke.test.mjs",
-    "validate:workflow": "node skills/plugin-workflow/scripts/plan-workflow.check.mjs"
+    "validate:workflow": "node skills/plugin-workflow/scripts/plan-workflow.check.mjs",
+    "test:release": "node --test skills/plugin-release/scripts/verify-release.test.mjs",
+    "test:audit": "node skills/dsh-upgrade-audit/scripts/gen-artifacts.check.mjs",
+    "test:dsh:cases": "node benchmark/runtime/verify.mjs --check",
+    "test:dsh": "node benchmark/runtime/verify.mjs --all"
   }
 }

--- a/scripts/validate-manifests.mjs
+++ b/scripts/validate-manifests.mjs
@@ -98,7 +98,10 @@ const validateScript = rootPackage?.scripts?.validate ?? ''
 if (!validateScript.includes('scripts/validate.mjs') || !validateScript.includes('scripts/validate-manifests.mjs')) {
   fail('package.json scripts.validate must chain both validators')
 }
-if (rootPackage?.scripts?.test !== 'npm run validate') fail('package.json scripts.test must delegate to npm run validate')
+const testScript = rootPackage?.scripts?.test ?? ''
+if (!/^npm run validate(?:\s*&&|\s*$)/.test(testScript)) {
+  fail('package.json scripts.test must delegate to npm run validate first')
+}
 
 if (errors.length > 0) {
   console.error('Manifest validation failed:')

--- a/skills/plugin-test/scripts/container-runner.mjs
+++ b/skills/plugin-test/scripts/container-runner.mjs
@@ -3,9 +3,10 @@
 import { spawn } from 'node:child_process'
 import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { join, resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
 
 const MAX_LOG_BYTES = 2 * 1024 * 1024
-const SETUP_TIMEOUT_MS = 5 * 60 * 1000
+const SETUP_TIMEOUT_MS = 8 * 60 * 1000
 
 class SmokeFailure extends Error {
   constructor(phase, message, details = {}) {
@@ -204,7 +205,20 @@ async function run() {
   const pluginPath = resolve(options.plugin)
   const home = process.env.HOME || '/workspace/home'
   await mkdir(home, { recursive: true })
-  const environment = { ...process.env, HOME: home, CI: '1', NO_COLOR: '1' }
+  const environment = {
+    ...process.env,
+    HOME: home,
+    PATH: process.env.NPM_CONFIG_PREFIX
+      ? `${join(process.env.NPM_CONFIG_PREFIX, 'bin')}:${process.env.PATH ?? ''}`
+      : process.env.PATH,
+    NPM_CONFIG_MAXSOCKETS: process.env.NPM_CONFIG_MAXSOCKETS ?? '12',
+    NPM_CONFIG_FETCH_RETRIES: process.env.NPM_CONFIG_FETCH_RETRIES ?? '3',
+    NPM_CONFIG_FETCH_RETRY_MINTIMEOUT: process.env.NPM_CONFIG_FETCH_RETRY_MINTIMEOUT ?? '1000',
+    NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT: process.env.NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT ?? '10000',
+    NPM_CONFIG_FETCH_TIMEOUT: process.env.NPM_CONFIG_FETCH_TIMEOUT ?? '300000',
+    CI: '1',
+    NO_COLOR: '1',
+  }
   const logs = { stdout: new CappedLog(), stderr: new CappedLog() }
   const steps = []
   const runCommand = createCommandRunner(logs)
@@ -212,13 +226,39 @@ async function run() {
   let failure = null
 
   try {
-    const toolchain = await runCommand(
-      'install-toolchain',
-      'npm',
-      ['install', '--global', `pnpm@${config.pnpmVersion}`, `@deepseek-ai/dsh@${config.dshVersion}`],
-      { env: environment },
-    )
-    steps.push(stripOutput(toolchain))
+    const prefix = environment.NPM_CONFIG_PREFIX
+    const cachedPnpmVersion = prefix
+      ? await readPackageVersion(join(prefix, 'lib', 'node_modules', 'pnpm', 'package.json'))
+      : null
+    const cachedDshVersion = prefix
+      ? await readPackageVersion(join(prefix, 'lib', 'node_modules', '@deepseek-ai', 'dsh', 'package.json'))
+      : null
+    if (cachedPnpmVersion === config.pnpmVersion && cachedDshVersion === config.dshVersion) {
+      steps.push({
+        name: 'install-toolchain',
+        status: 'passed',
+        exitCode: 0,
+        durationMs: 0,
+        message: 'reused exact-version toolchain volume',
+      })
+    } else {
+      const toolchain = await runCommand(
+        'install-toolchain',
+        'npm',
+        ['install', '--global', `pnpm@${config.pnpmVersion}`, `@deepseek-ai/dsh@${config.dshVersion}`],
+        { env: environment },
+      )
+      steps.push(stripOutput(toolchain))
+    }
+
+    const pnpmVersion = await runCommand('verify-pnpm-version', 'pnpm', ['--version'], { env: environment })
+    if (pnpmVersion.stdout.trim() !== config.pnpmVersion) {
+      throw new SmokeFailure(
+        'verify-pnpm-version',
+        `resolved pnpm ${pnpmVersion.stdout.trim() || 'unknown'}, expected ${config.pnpmVersion}`,
+      )
+    }
+    steps.push(stripOutput(pnpmVersion))
 
     const npmRoot = await runCommand('verify-dsh-version', 'npm', ['root', '--global'], { env: environment })
     const packagePath = join(npmRoot.stdout.trim(), '@deepseek-ai', 'dsh', 'package.json')
@@ -296,12 +336,22 @@ function stripOutput(step) {
   return result
 }
 
-run().then(
-  (exitCode) => {
-    process.exitCode = exitCode
-  },
-  (error) => {
-    console.error(`container runner failed: ${error.message}`)
-    process.exitCode = 2
-  },
-)
+async function readPackageVersion(path) {
+  try {
+    return JSON.parse(await readFile(path, 'utf8')).version ?? null
+  } catch {
+    return null
+  }
+}
+
+if (process.argv[1] && pathToFileURL(resolve(process.argv[1])).href === import.meta.url) {
+  run().then(
+    (exitCode) => {
+      process.exitCode = exitCode
+    },
+    (error) => {
+      console.error(`container runner failed: ${error.message}`)
+      process.exitCode = 2
+    },
+  )
+}

--- a/skills/plugin-test/scripts/docker-release-smoke.mjs
+++ b/skills/plugin-test/scripts/docker-release-smoke.mjs
@@ -3,7 +3,7 @@
 import { createHash } from 'node:crypto'
 import { spawn } from 'node:child_process'
 import { createReadStream } from 'node:fs'
-import { access, mkdir, mkdtemp, readFile, realpath, rm, stat, writeFile } from 'node:fs/promises'
+import { access, copyFile, mkdir, mkdtemp, readFile, realpath, rm, stat, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { basename, dirname, join, resolve } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
@@ -12,6 +12,17 @@ const scriptDirectory = dirname(fileURLToPath(import.meta.url))
 const containerRunner = join(scriptDirectory, 'container-runner.mjs')
 const exactVersion = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/
 const profileName = /^[A-Za-z0-9._-]+$/
+const volumeName = /^[A-Za-z0-9][A-Za-z0-9_.-]*$/
+const proxyEnvironmentNames = [
+  'HTTP_PROXY',
+  'HTTPS_PROXY',
+  'ALL_PROXY',
+  'NO_PROXY',
+  'http_proxy',
+  'https_proxy',
+  'all_proxy',
+  'no_proxy',
+]
 
 export function validateConfig(input) {
   if (!input || typeof input !== 'object' || Array.isArray(input)) throw new Error('config must be a JSON object')
@@ -116,7 +127,9 @@ export function classifyFailure(containerResult, containerExitCode, infrastructu
   if (!containerResult) return containerExitCode === 0 ? 'result' : 'container'
   if (containerResult.status === 'passed' && containerExitCode === 0) return null
   const phase = containerResult.failure?.phase
-  if (['install-toolchain', 'verify-dsh-version'].includes(phase)) return 'host-setup'
+  if (['install-package-manager', 'install-dsh', 'install-toolchain', 'verify-pnpm-version', 'verify-dsh-version'].includes(phase)) {
+    return 'host-setup'
+  }
   if (phase === 'install-plugin') return 'plugin-install'
   if (phase === 'cold-start') return 'startup'
   if (phase === 'probe') return 'probe'
@@ -319,20 +332,32 @@ function bindMount(source, target, readOnly = false) {
   return `type=bind,source=${source},target=${target}${readOnly ? ',readonly' : ''}`
 }
 
-export async function runDockerSmoke({ config, pluginPath, reportDirectory }) {
+function inheritedDockerEnvironment(names) {
+  return names.flatMap((name) => (process.env[name] ? ['--env', name] : []))
+}
+
+export async function runDockerSmoke({ config, pluginPath, reportDirectory, cacheVolume, toolchainVolume }) {
   const validatedConfig = validateConfig(config)
   const artifactPath = await realpath(resolve(pluginPath))
   await access(artifactPath)
   const artifactStat = await stat(artifactPath)
   if (!artifactStat.isFile()) throw new Error('plugin path must point to a packaged artifact file')
+  if (cacheVolume && !volumeName.test(cacheVolume)) throw new Error('cache volume has an invalid name')
+  if (toolchainVolume && !volumeName.test(toolchainVolume)) throw new Error('toolchain volume has an invalid name')
 
-  const runDirectory = await mkdtemp(join(tmpdir(), 'dsh-plugin-smoke-run-'))
+  // Keep bind-mounted control files below the caller's working directory.
+  // Colima and some Docker Desktop setups do not share the host's system temp
+  // directory with their VM, while the checkout is already expected to be
+  // available to Docker.
+  const runDirectory = await mkdtemp(join(process.cwd(), '.dsh-plugin-smoke-run-'))
   const outputDirectory = join(runDirectory, 'output')
   const finalReportDirectory = reportDirectory
     ? resolve(reportDirectory)
     : await mkdtemp(join(tmpdir(), 'dsh-plugin-smoke-report-'))
   await mkdir(outputDirectory, { recursive: true })
   await mkdir(finalReportDirectory, { recursive: true })
+  const stagedArtifactPath = join(runDirectory, 'plugin.tgz')
+  await copyFile(artifactPath, stagedArtifactPath)
   const configPath = join(runDirectory, 'config.json')
   await writeFile(configPath, `${JSON.stringify(validatedConfig, null, 2)}\n`, 'utf8')
 
@@ -357,7 +382,7 @@ export async function runDockerSmoke({ config, pluginPath, reportDirectory }) {
     dockerServerVersion = (
       await checkedProcess('docker', ['version', '--format', '{{.Server.Version}}'])
     ).stdout.trim()
-    await checkedProcess('docker', [
+    const dockerArguments = [
       'create',
       '--name',
       containerName,
@@ -366,8 +391,25 @@ export async function runDockerSmoke({ config, pluginPath, reportDirectory }) {
       '/workspace',
       '--env',
       'HOME=/workspace/home',
+      ...inheritedDockerEnvironment(proxyEnvironmentNames),
+      ...(cacheVolume
+        ? [
+            '--env',
+            'NPM_CONFIG_CACHE=/workspace/package-cache/npm',
+            '--mount',
+            `type=volume,source=${cacheVolume},target=/workspace/package-cache`,
+          ]
+        : []),
+      ...(toolchainVolume
+        ? [
+            '--env',
+            'NPM_CONFIG_PREFIX=/workspace/toolchain',
+            '--mount',
+            `type=volume,source=${toolchainVolume},target=/workspace/toolchain`,
+          ]
+        : []),
       '--mount',
-      bindMount(artifactPath, '/workspace/plugin.tgz', true),
+      bindMount(stagedArtifactPath, '/workspace/plugin.tgz', true),
       '--mount',
       bindMount(configPath, '/workspace/config.json', true),
       '--mount',
@@ -383,7 +425,8 @@ export async function runDockerSmoke({ config, pluginPath, reportDirectory }) {
       '/workspace/plugin.tgz',
       '--output',
       '/workspace/output',
-    ])
+    ]
+    await checkedProcess('docker', dockerArguments)
     containerCreated = true
     const inspectImage = await checkedProcess('docker', ['inspect', '--format', '{{.Image}}', containerName])
     containerImageId = inspectImage.stdout.trim()

--- a/skills/plugin-test/scripts/docker-release-smoke.mjs
+++ b/skills/plugin-test/scripts/docker-release-smoke.mjs
@@ -127,7 +127,7 @@ export function classifyFailure(containerResult, containerExitCode, infrastructu
   if (!containerResult) return containerExitCode === 0 ? 'result' : 'container'
   if (containerResult.status === 'passed' && containerExitCode === 0) return null
   const phase = containerResult.failure?.phase
-  if (['install-package-manager', 'install-dsh', 'install-toolchain', 'verify-pnpm-version', 'verify-dsh-version'].includes(phase)) {
+  if (['install-toolchain', 'verify-pnpm-version', 'verify-dsh-version'].includes(phase)) {
     return 'host-setup'
   }
   if (phase === 'install-plugin') return 'plugin-install'

--- a/skills/plugin-test/scripts/docker-release-smoke.test.mjs
+++ b/skills/plugin-test/scripts/docker-release-smoke.test.mjs
@@ -57,8 +57,6 @@ test('redactLogs removes common credential forms', () => {
 
 test('classifyFailure maps setup, install, startup, probe, and infrastructure failures', () => {
   assert.equal(classifyFailure({ status: 'failed', failure: { phase: 'install-toolchain' } }, 1), 'host-setup')
-  assert.equal(classifyFailure({ status: 'failed', failure: { phase: 'install-package-manager' } }, 1), 'host-setup')
-  assert.equal(classifyFailure({ status: 'failed', failure: { phase: 'install-dsh' } }, 1), 'host-setup')
   assert.equal(classifyFailure({ status: 'failed', failure: { phase: 'verify-pnpm-version' } }, 1), 'host-setup')
   assert.equal(classifyFailure({ status: 'failed', failure: { phase: 'install-plugin' } }, 1), 'plugin-install')
   assert.equal(classifyFailure({ status: 'failed', failure: { phase: 'cold-start' } }, 1), 'startup')

--- a/skills/plugin-test/scripts/docker-release-smoke.test.mjs
+++ b/skills/plugin-test/scripts/docker-release-smoke.test.mjs
@@ -57,6 +57,9 @@ test('redactLogs removes common credential forms', () => {
 
 test('classifyFailure maps setup, install, startup, probe, and infrastructure failures', () => {
   assert.equal(classifyFailure({ status: 'failed', failure: { phase: 'install-toolchain' } }, 1), 'host-setup')
+  assert.equal(classifyFailure({ status: 'failed', failure: { phase: 'install-package-manager' } }, 1), 'host-setup')
+  assert.equal(classifyFailure({ status: 'failed', failure: { phase: 'install-dsh' } }, 1), 'host-setup')
+  assert.equal(classifyFailure({ status: 'failed', failure: { phase: 'verify-pnpm-version' } }, 1), 'host-setup')
   assert.equal(classifyFailure({ status: 'failed', failure: { phase: 'install-plugin' } }, 1), 'plugin-install')
   assert.equal(classifyFailure({ status: 'failed', failure: { phase: 'cold-start' } }, 1), 'startup')
   assert.equal(classifyFailure({ status: 'failed', failure: { phase: 'probe' } }, 1), 'probe')


### PR DESCRIPTION
## Summary

- add a self-contained benchmark/runtime verifier with exact DSH and pnpm versions
- prove DSH-0.1.2-A1-01 with a red-green chain: rc.2 legacy pass, alpha.2 legacy startup failure, alpha.2 M1 solution pass
- reuse benchmark/tasks/M1-host-migration/solution/plugin instead of maintaining a duplicate migrated fixture
- share short-lived npm and per-version toolchain volumes while keeping each container HOME/Profile isolated
- wire all existing release/audit/runtime definition checks into npm test
- add a path-filtered Docker workflow for relevant PRs/main changes, manual runs, and weekly drift checks; upload failure reports only

This supports the evaluation direction discussed in deepseek-ai/deepseek-harness#5120. It complements #38: that PR verifies arbitrary external plugin runtime signatures, while this PR verifies repository-owned migration facts and benchmark answers across exact DSH versions.

## Local verification

- npm test
- npm run test:dsh -- --report-dir .artifacts/local-dsh-integration
- skill quick validation for plugin-test and plugin-upgrade

Final Docker result: 3/3 checks accepted in about 217 seconds locally. The negative alpha.2 control was accepted only after a startup-class failure containing waiting for service: apiProxy. The migrated alpha.2 check reused the exact target toolchain and completed in about 2.7 seconds.

## Boundaries

This first runtime case covers the Host-plane APIProxy to llm migration only. Browser/client execution, real provider credentials, other operating systems, and additional DSH corridors remain unverified and should be added as case-specific fixtures rather than a blanket version matrix.