### PR TITLE
docs: use full card ids and complete the three-step version chain

### DIFF
--- a/skills/plugin-release/references/profile-dependency-management.md
+++ b/skills/plugin-release/references/profile-dependency-management.md
@@ -1,7 +1,7 @@
 # profile 依赖管理配方
 
 > 承接 [../SKILL.md](../SKILL.md) 的发布轨选择。本文覆盖把插件装进/更新进 `$DSH_HOME/profiles/*` 时的
-> 依赖解析事实与操作配方，取自 17 个插件仓库三个版本台阶的连续迁移（rc.2 → alpha.1 → alpha.2）。技术性迁移坑
+> 依赖解析事实与操作配方，取自 17 个插件仓库三个版本台阶的连续迁移（0.1.0-rc.8 → 0.1.1-rc.2 → 0.1.2-alpha.1 → 0.1.2-alpha.2）。技术性迁移坑
 > （tsbuildinfo、oxc 解析等）见 [migration-hygiene](https://github.com/oh-my-dsh/dsh-plugin-upgrade-skill/blob/main/skills/plugin-upgrade/references/migration-hygiene.md)，
 > 本文不重复。
 
@@ -64,7 +64,7 @@ grep 'codeload.*<pkg>' pnpm-lock.yaml   # 应为 tar.gz/<40位commit>
 ## 6. 自建通道的无浏览器认证冒烟
 
 0.1.2-alpha.1 起 dsh web 使用 bootstrap token + 签名 Cookie 认证（见
-[A1-08 认证模型](https://github.com/oh-my-dsh/dsh-plugin-upgrade-skill/blob/main/skills/plugin-upgrade/references/v0.1.2-alpha.1.md)）。
+[DSH-0.1.2-A1-08 · Web/API 通道认证](https://github.com/oh-my-dsh/dsh-plugin-upgrade-skill/blob/main/skills/plugin-upgrade/references/v0.1.2-alpha.1.md)）。
 插件自建了 HTTP/RPC 通道（如 `/tariff/status`）时，发布前用下面流程证明「通道确实挂在统一认证后面」，
 不依赖浏览器/Playwright。已知行为：token 在同一进程可重复兑换、重启才轮换；自建 route 必须经
 `connection` 注册才会自动继承认证，裸 `ctx.webServer.register()` 不继承。

--- a/skills/plugin-upgrade/examples/07-multi-repo-batch-migration.md
+++ b/skills/plugin-upgrade/examples/07-multi-repo-batch-migration.md
@@ -78,9 +78,9 @@ git push --force-with-lease origin main
 ## 6. 真实验证（每个版本台阶都跑）
 
 1. 目标 tag 冷启动，`pluginInventory/list` 全部本插件 entry `active`、无 `pending`；
-2. 自建通道冒烟：无认证 401 / 消费 token 后 200（[A1-08](../references/v0.1.2-alpha.1.md)）；
+2. 自建通道冒烟：无认证 401 / 消费 token 后 200（[DSH-0.1.2-A1-08 · Web/API 通道认证](../references/v0.1.2-alpha.1.md)）；
 3. 一条真实行为：headless 任务让模型调用本插件工具（如 calculator 计算），核对 stdout 最终文本与
-   stderr reasoning 归属（[A1-05](../references/v0.1.2-alpha.1.md)）；
+   stderr reasoning 归属（[DSH-0.1.2-A1-05 · headless 输出语义](../references/v0.1.2-alpha.1.md)）；
 4. 结果归档：每个版本台阶留存「版本 → 各仓提交 → 验证结果」记录，作为下一个版本台阶的盘点基线。
 
 ## 与本仓库其他材料的关系


### PR DESCRIPTION
## 变更

采纳 #67 评审建议的两处跟补（#67 已合并）：

1. **卡片编号改完整形式**：example 07 与 profile 依赖管理配方中的缩写引用（A1-05 / A1-06 / A1-08）全部换成完整编号（如 `DSH-0.1.2-A1-08 · Web/API 通道认证`），与仓库约定及 example 06 一致；
2. **版本台阶补全起点**：profile 配方开头改为 `0.1.0-rc.8 → 0.1.1-rc.2 → 0.1.2-alpha.1 → 0.1.2-alpha.2`，与“三个版本台阶”的说法对得上。

与 #27 的互链按后合并方负责的方案处理（已在 #27 留言说明）。

## 验证

- `node scripts/validate.mjs`：Validation OK
- `node scripts/validate-manifests.mjs`：清单校验通过
