### PR TITLE
i18n(plugin-release): English SKILL.md with zh-CN companion, English references

### DIFF
--- a/skills/plugin-release/SKILL.md
+++ b/skills/plugin-release/SKILL.md
@@ -1,68 +1,70 @@
 ---
 name: plugin-release
-description: 打包、发布与分发 DeepSeek Harness（DSH）插件——包括 npm pack 产物校验、GitHub/npm/hub 发布轨选择、未发布 cohort（0.1.2-alpha.*）的 tarball overrides 安装、CI/发布门禁与回滚。当需要发布插件、给插件打 tarball、把插件接入 profile/hub、或处理“alpha 版本不在 npm 上怎么装”时使用；任何发布动作前必须先展示计划并取得用户确认。
+description: Package, publish, and distribute DeepSeek Harness (DSH) plugins — npm pack artifact validation, GitHub/npm/hub release-track selection, tarball overrides installs for the unpublished cohort (0.1.2-alpha.*), and CI/release gates with rollback. Use when publishing a plugin, packing a tarball, wiring a plugin into a profile/hub, or installing an alpha version that is not on npm; show a plan and obtain user confirmation before any publish action.
 ---
+
+English | [简体中文](SKILL.zh-CN.md)
 
 # plugin-release
 
-把已开发、已测试的插件安全地发出去。发布是单向外发动作，**任何实际发布或推 tag 前必须先展示计划并确认**；本 Skill 不替你决定版本号，也不自动 bump 版本。
+Ship developed, tested plugins safely. Publishing is a one-way outbound action — **show a plan and obtain confirmation before any actual publish or tag push**; this skill does not decide version numbers for you, and it never bumps versions automatically.
 
-## 第 0 步：确认目标版本与发布轨
+## Step 0: confirm the target version and release track
 
-| 发布轨 | 适用 | 关键事实 |
+| Release track | Applies to | Key facts |
 |---|---|---|
-| GitHub 直装 | `dsh plugin --profile <p> add github:owner/repo` | 消费者解析默认分支 HEAD；发布=推送到 main，**推前必须跑完整门禁** |
-| npm registry | `npm publish` | 仅正式发布线可用；`@deepseek-ai/*` 的 alpha/rc 前缀版本**不一定**在 npm 上，发布前先 `npm view <pkg> versions` 核实 |
-| hub 收录 | 在 hub catalog 登记 | 登记是独立动作，不代替打包验证 |
-| collection | 把成员插件 vendored 成 pack artifact | 见所属 collection 仓库的自有流程 |
+| GitHub direct install | `dsh plugin --profile <p> add github:owner/repo` | Consumers resolve the default-branch HEAD; publishing = pushing to main — **run the full gate before pushing** |
+| npm registry | `npm publish` | Official release line only; alpha/rc-prefixed `@deepseek-ai/*` versions are **not guaranteed** on npm — verify with `npm view <pkg> versions` before publishing |
+| hub listing | register in the hub catalog | Registration is a separate action and does not replace packaging validation |
+| collection | member plugins vendored into a pack artifact | Follow the owning collection repository's own process |
 
-未发布 cohort（例如 0.1.2-alpha.* 只有 GitHub 来源）走 [references/publish-playbook.md](references/publish-playbook.md) 的 overrides 流程，**不要**在 npm 上找不存在的版本，也不要因此切换包管理器。
+The unpublished cohort (for example 0.1.2-alpha.* exists only on GitHub) goes through the overrides flow in [references/publish-playbook.md](references/publish-playbook.md). **Do not** look for versions that do not exist on npm, and do not switch package managers because of it.
 
-## 第 1 步：打包与产物校验
+## Step 1: pack and validate the artifact
 
-1. 用仓库唯一的包管理器与 lockfile（有 `package-lock.json` 用 npm，有 `pnpm-lock.yaml` 用 pnpm）；
-2. 跑完整门禁（见第 3 步），再 `npm pack` / `pnpm pack`；
-3. 解包校验：`files` 覆盖全部运行时相对导入与资产；产物里没有 `.ts` 残留；`cordis.patch.yml`/`dsh.plugin.json`/`SKILL.md` 等形态文件齐全；
-4. tarball 装入隔离 profile 做消费验证（`dsh --profile compat --dump-config` 出现本插件 row → 工具真实注册与执行）。
+1. Use the repository's single package manager and lockfile (`package-lock.json` → npm, `pnpm-lock.yaml` → pnpm);
+2. Run the full gate (see Step 3), then `npm pack` / `pnpm pack`;
+3. Unpack and validate: `files` covers every runtime relative import and asset; no `.ts` leftovers in the artifact; the manifest files such as `cordis.patch.yml` / `dsh.plugin.json` / `SKILL.md` are all present;
+4. Install the tarball into an isolated profile for consumption validation (the plugin's row appears in `dsh --profile compat --dump-config` → the tool is genuinely registered and executes).
 
-## 第 2 步：版本依赖基线（alpha 时代）
+## Step 2: version dependency baseline (alpha era)
 
-- devDependencies 使用 **npm 发布线**（当前 0.1.1-rc.2）作为类型基线，保证公开仓库在任何机器上 `npm install` 后 typecheck 可用；
-- peer 范围用宽范围（如 `<0.2.0`）覆盖未发布的 alpha/rc；
-- 代码需要兼容本地 harness（GitHub tag）与 npm 发布线两侧时，用**双兼容写法**：保留 npm 发布线类型要求的形态，同时在 alpha 运行时语义不变（见 playbook 的“双兼容写法”节）；
-- 不要把本机绝对路径（junction/file:）写进提交的 package.json。
+- devDependencies use the **npm release line** (currently 0.1.1-rc.2) as the type baseline, so a public repository typechecks after `npm install` on any machine;
+- peer ranges use a wide range (such as `<0.2.0`) to cover unpublished alphas/rcs;
+- when code must stay compatible with both the local harness (GitHub tag) and the npm release line, use the **dual-compatibility pattern**: keep the shape that the npm release line's types require, while the alpha runtime semantics remain unchanged (see the "dual-compatibility pattern" section of the playbook);
+- never write local absolute paths (junction/file:) into a committed package.json.
 
-## 第 3 步：发布门禁（逐层，前层不过不进后层）
+## Step 3: release gate (layer by layer; a lower layer must pass before the next one)
 
-1. 依赖解析：lockfile 只发生预期变化；无混合 cohort；
-2. 静态：typecheck + 插件测试 + build；
-3. 真实挂载：在**锁定精确 DSH tag**（禁止用可变的 master/main 冒名验收）的隔离 profile 上冷启动目标宿主，entry active、服务不停 pending。Web Client 插件还要验证：宿主公告资源（启动图/boot 名单中的 bundle 入口）可访问、bundle 注册成功、DOM 挂载完成、无 page error——只看 `--dump-config` 不算完成本层；
-4. 行为：一条核心路径真实执行（工具插件=一次消息→工具→回复；或等价专用流程）；
-5. 包装器：核对退出码与 stdout/stderr 归属。
+1. Dependency resolution: the lockfile changes only as expected; no mixed cohorts;
+2. Static: typecheck + plugin tests + build;
+3. Real mount: cold-boot the target host on an isolated profile **pinned to an exact DSH tag** (never let a mutable master/main masquerade as acceptance), with the entry active and no service left pending. Web Client plugins must additionally verify: the host-advertised resources (the bundle entry from the boot manifest/boot list) are reachable, the bundle registers successfully, the DOM mount completes, and there are no page errors — looking at `--dump-config` alone does not complete this layer;
+4. Behavior: one core path actually executes (for tool plugins: one message → tool → response; or an equivalent dedicated flow);
+5. Wrapper: verify exit codes and stdout/stderr attribution.
 
-## 第 4 步：发布语义门禁（任一不满足即停止发布）
+## Step 4: release semantic gate (stop publishing if any check fails)
 
-1. GitHub Release tag 必须等于 `v${package.json.version}`；
-2. 版本号是否含 prerelease 后缀（`-` 之后、`+` build metadata 之前的段），必须与 GitHub Release 的 prerelease 状态一致；
-3. prerelease 只能发布到**项目声明的非 latest dist-tag**（名称由项目自定，如 `next`、`alpha`——不写死具体名字）；无后缀的 stable 版本才进入 `latest`；
-4. stable 发布前查询现有 `latest`（`npm view <pkg> dist-tags.latest`），semver 低于现有 latest 时拒绝发布，防止把 latest 回退到更低版本。
+1. The GitHub Release tag must equal `v${package.json.version}`;
+2. Whether the version carries a prerelease suffix (the segment after `-`, before the `+` build metadata) must match the GitHub Release's prerelease status;
+3. Prereleases may only go to a **project-declared non-latest dist-tag** (the name is chosen by the project, such as `next` or `alpha` — the skill does not hard-code a specific name); only stable versions without a suffix go to `latest`;
+4. Before a stable publish, query the current `latest` (`npm view <pkg> dist-tags.latest`) and refuse to publish when the semver is lower than the existing latest, to prevent moving latest backwards to a lower version.
 
-## 第 5 步：发布与回滚
+## Step 5: publish and rollback
 
-- 发布前：干净提交 + 打 tag；记录 lockfile 与 composition 基线 hash；
-- 发布后：以消费者身份重装一次并冒烟；
-- 回滚：优先回退发布（删 tag/重新指向旧 commit），不发布“兼容两边”的补丁掩盖问题；
-- 未发布 cohort 的 CI 见 playbook 的“CI 与发布门禁”节（缓存 cohort store、`NPM_PUBLISH_ENABLED` 开关）。
+- Before publishing: clean commit + tag; record the lockfile and composition baseline hashes;
+- After publishing: reinstall once as a consumer and smoke-test;
+- Rollback: prefer reverting the release (delete the tag / re-point at the old commit); do not publish a "works on both sides" patch to paper over the problem;
+- For unpublished-cohort CI, see the "CI and release gates" section of the playbook (cohort store caching, the `NPM_PUBLISH_ENABLED` switch).
 
-## 安全边界
+## Safety boundaries
 
-- 发布/推 tag/写 hub 登记前必须展示计划并确认；不自动 bump 版本；
-- 不发布含凭据、`.npmrc` 内容、会话日志或私有路径的产物；
-- 不切换包管理器、不重写另一套 lockfile；失败时只回滚本次拥有的路径并报告残留。
+- Show a plan and obtain confirmation before any publish / tag push / hub registration write; never bump versions automatically;
+- Never publish artifacts containing credentials, `.npmrc` contents, session logs, or private paths;
+- Do not switch package managers or rewrite a different lockfile; on failure, roll back only the paths owned by this run and report residue.
 
-## 参考材料
+## References
 
-| 文件 | 内容 |
+| File | Contents |
 |---|---|
-| [references/publish-playbook.md](references/publish-playbook.md) | 未发布 cohort 安装、双兼容写法、CI/发布门禁、真实坑位清单与回滚配方 |
-| [references/profile-dependency-management.md](references/profile-dependency-management.md) | profile 安装/更新配方：github 依赖锁缓存、包改名三处同步、junction 清理与宿主升级联动 |
+| [references/publish-playbook.md](references/publish-playbook.md) | Unpublished-cohort installation, dual-compatibility pattern, CI/release gates, real pitfall list, and rollback recipes |
+| [references/profile-dependency-management.md](references/profile-dependency-management.md) | Profile install/update recipes: github dependency lock caching, three-place sync on package rename, junction cleanup, and host-upgrade linkage |

--- a/skills/plugin-release/SKILL.zh-CN.md
+++ b/skills/plugin-release/SKILL.zh-CN.md
@@ -1,0 +1,69 @@
+---
+name: plugin-release
+description: 打包、发布与分发 DeepSeek Harness（DSH）插件——包括 npm pack 产物校验、GitHub/npm/hub 发布轨选择、未发布 cohort（0.1.2-alpha.*）的 tarball overrides 安装、CI/发布门禁与回滚。当需要发布插件、给插件打 tarball、把插件接入 profile/hub、或处理“alpha 版本不在 npm 上怎么装”时使用；任何发布动作前必须先展示计划并取得用户确认。
+---
+[English](SKILL.md) | 简体中文
+
+# plugin-release
+
+把已开发、已测试的插件安全地发出去。发布是单向外发动作，**任何实际发布或推 tag 前必须先展示计划并确认**；本 Skill 不替你决定版本号，也不自动 bump 版本。
+
+## 第 0 步：确认目标版本与发布轨
+
+| 发布轨 | 适用 | 关键事实 |
+|---|---|---|
+| GitHub 直装 | `dsh plugin --profile <p> add github:owner/repo` | 消费者解析默认分支 HEAD；发布=推送到 main，**推前必须跑完整门禁** |
+| npm registry | `npm publish` | 仅正式发布线可用；`@deepseek-ai/*` 的 alpha/rc 前缀版本**不一定**在 npm 上，发布前先 `npm view <pkg> versions` 核实 |
+| hub 收录 | 在 hub catalog 登记 | 登记是独立动作，不代替打包验证 |
+| collection | 把成员插件 vendored 成 pack artifact | 见所属 collection 仓库的自有流程 |
+
+未发布 cohort（例如 0.1.2-alpha.* 只有 GitHub 来源）走 [references/publish-playbook.md](references/publish-playbook.md) 的 overrides 流程，**不要**在 npm 上找不存在的版本，也不要因此切换包管理器。
+
+## 第 1 步：打包与产物校验
+
+1. 用仓库唯一的包管理器与 lockfile（有 `package-lock.json` 用 npm，有 `pnpm-lock.yaml` 用 pnpm）；
+2. 跑完整门禁（见第 3 步），再 `npm pack` / `pnpm pack`；
+3. 解包校验：`files` 覆盖全部运行时相对导入与资产；产物里没有 `.ts` 残留；`cordis.patch.yml`/`dsh.plugin.json`/`SKILL.md` 等形态文件齐全；
+4. tarball 装入隔离 profile 做消费验证（`dsh --profile compat --dump-config` 出现本插件 row → 工具真实注册与执行）。
+
+## 第 2 步：版本依赖基线（alpha 时代）
+
+- devDependencies 使用 **npm 发布线**（当前 0.1.1-rc.2）作为类型基线，保证公开仓库在任何机器上 `npm install` 后 typecheck 可用；
+- peer 范围用宽范围（如 `<0.2.0`）覆盖未发布的 alpha/rc；
+- 代码需要兼容本地 harness（GitHub tag）与 npm 发布线两侧时，用**双兼容写法**：保留 npm 发布线类型要求的形态，同时在 alpha 运行时语义不变（见 playbook 的“双兼容写法”节）；
+- 不要把本机绝对路径（junction/file:）写进提交的 package.json。
+
+## 第 3 步：发布门禁（逐层，前层不过不进后层）
+
+1. 依赖解析：lockfile 只发生预期变化；无混合 cohort；
+2. 静态：typecheck + 插件测试 + build；
+3. 真实挂载：在**锁定精确 DSH tag**（禁止用可变的 master/main 冒名验收）的隔离 profile 上冷启动目标宿主，entry active、服务不停 pending。Web Client 插件还要验证：宿主公告资源（启动图/boot 名单中的 bundle 入口）可访问、bundle 注册成功、DOM 挂载完成、无 page error——只看 `--dump-config` 不算完成本层；
+4. 行为：一条核心路径真实执行（工具插件=一次消息→工具→回复；或等价专用流程）；
+5. 包装器：核对退出码与 stdout/stderr 归属。
+
+## 第 4 步：发布语义门禁（任一不满足即停止发布）
+
+1. GitHub Release tag 必须等于 `v${package.json.version}`；
+2. 版本号是否含 prerelease 后缀（`-` 之后、`+` build metadata 之前的段），必须与 GitHub Release 的 prerelease 状态一致；
+3. prerelease 只能发布到**项目声明的非 latest dist-tag**（名称由项目自定，如 `next`、`alpha`——不写死具体名字）；无后缀的 stable 版本才进入 `latest`；
+4. stable 发布前查询现有 `latest`（`npm view <pkg> dist-tags.latest`），semver 低于现有 latest 时拒绝发布，防止把 latest 回退到更低版本。
+
+## 第 5 步：发布与回滚
+
+- 发布前：干净提交 + 打 tag；记录 lockfile 与 composition 基线 hash；
+- 发布后：以消费者身份重装一次并冒烟；
+- 回滚：优先回退发布（删 tag/重新指向旧 commit），不发布“兼容两边”的补丁掩盖问题；
+- 未发布 cohort 的 CI 见 playbook 的“CI 与发布门禁”节（缓存 cohort store、`NPM_PUBLISH_ENABLED` 开关）。
+
+## 安全边界
+
+- 发布/推 tag/写 hub 登记前必须展示计划并确认；不自动 bump 版本；
+- 不发布含凭据、`.npmrc` 内容、会话日志或私有路径的产物；
+- 不切换包管理器、不重写另一套 lockfile；失败时只回滚本次拥有的路径并报告残留。
+
+## 参考材料
+
+| 文件 | 内容 |
+|---|---|
+| [references/publish-playbook.md](references/publish-playbook.md) | 未发布 cohort 安装、双兼容写法、CI/发布门禁、真实坑位清单与回滚配方 |
+| [references/profile-dependency-management.md](references/profile-dependency-management.md) | profile 安装/更新配方：github 依赖锁缓存、包改名三处同步、junction 清理与宿主升级联动 |

--- a/skills/plugin-release/SKILL.zh-CN.md
+++ b/skills/plugin-release/SKILL.zh-CN.md
@@ -1,7 +1,3 @@
----
-name: plugin-release
-description: 打包、发布与分发 DeepSeek Harness（DSH）插件——包括 npm pack 产物校验、GitHub/npm/hub 发布轨选择、未发布 cohort（0.1.2-alpha.*）的 tarball overrides 安装、CI/发布门禁与回滚。当需要发布插件、给插件打 tarball、把插件接入 profile/hub、或处理“alpha 版本不在 npm 上怎么装”时使用；任何发布动作前必须先展示计划并取得用户确认。
----
 [English](SKILL.md) | 简体中文
 
 # plugin-release

--- a/skills/plugin-release/references/profile-dependency-management.md
+++ b/skills/plugin-release/references/profile-dependency-management.md
@@ -1,103 +1,93 @@
-# profile 依赖管理配方
+# Profile dependency management recipes
 
-> 承接 [../SKILL.md](../SKILL.md) 的发布轨选择。本文覆盖把插件装进/更新进 `$DSH_HOME/profiles/*` 时的
-> 依赖解析事实与操作配方，取自 17 个插件仓库三个版本台阶的连续迁移（0.1.0-rc.8 → 0.1.1-rc.2 → 0.1.2-alpha.1 → 0.1.2-alpha.2）。技术性迁移坑
-> （tsbuildinfo、oxc 解析等）见 [migration-hygiene](https://github.com/oh-my-dsh/dsh-plugin-upgrade-skill/blob/main/skills/plugin-upgrade/references/migration-hygiene.md)，
-> 本文不重复。
+> Carries on the release-track choice of [../SKILL.md](../SKILL.md). This document covers the dependency-resolution facts and operational recipes for installing/updating plugins into `$DSH_HOME/profiles/*`, drawn from the continuous migration of the 17 plugin repositories across three version steps (0.1.0-rc.8 → 0.1.1-rc.2 → 0.1.2-alpha.1 → 0.1.2-alpha.2). Technical migration pitfalls
+> (tsbuildinfo, oxc parsing, etc.) are covered in [migration-hygiene](https://github.com/oh-my-dsh/dsh-plugin-upgrade-skill/blob/main/skills/plugin-upgrade/references/migration-hygiene.md);
+> this document does not repeat them.
 
-## 1. 两种安装轨的解析事实
+## 1. Resolution facts for the two install tracks
 
-| 声明 | 解析行为 | 适用 |
+| Declaration | Resolution behavior | Applies to |
 |---|---|---|
-| `link:<绝对路径>` | 直接目录联接/软链到本地目录；不产生版本解析 | 本地开发、批量迁移期间 |
-| `github:owner/repo` | 解析默认分支 HEAD，锁文件记录 源码打包地址（codeload）的精确 commit | 发布安装、消费者侧 |
+| `link:<absolute path>` | Directory junction/symlink straight to the local directory; no version resolution | Local development, during batch migration |
+| `github:owner/repo` | Resolves the default-branch HEAD; the lockfile records the exact commit of the source archive URL (codeload) | Release installs, consumer side |
 
-同一 profile 里两种轨可以混用；改名、迁移或收尾时按下面各条处理。
+The two tracks can be mixed within one profile; handle renames, migration, and wrap-up per the items below.
 
-## 2. github 依赖的锁缓存坑：`Already up to date` 不代表拿到了新提交
+## 2. The github dependency lock-cache pitfall: `Already up to date` does not mean you got the new commit
 
-**症状**：远端已推送新提交，`pnpm install` 输出 `Already up to date`，锁文件里的 codeload URL 仍是旧
-commit；启动加载的仍是旧代码。
+**Symptom**: a new commit was pushed upstream, `pnpm install` prints `Already up to date`, and the codeload URL in the lockfile is still the old commit; the code loaded at startup is still the old code.
 
-**原因**：pnpm 对 github 依赖缓存了 HEAD 解析；常规 `install` 不重解析。
+**Cause**: pnpm caches HEAD resolution for github dependencies; a regular `install` does not re-resolve.
 
-**处置**：
+**Fix**:
 
 ```sh
-# 强制重新解析 github 依赖（web / headless 两个 profile 分别执行）
+# Force re-resolution of the github dependency (run for the web and headless profiles separately)
 cd "$DSH_HOME/profiles/web" && pnpm update <pkg>
-# 验证锁文件里的 commit 等于期望 HEAD
-grep 'codeload.*<pkg>' pnpm-lock.yaml   # 应为 tar.gz/<40位commit>
+# Verify that the commit in the lockfile equals the expected HEAD
+grep 'codeload.*<pkg>' pnpm-lock.yaml   # should be tar.gz/<40-char commit>
 ```
 
-批量迁移收尾时对每个 github 轨依赖做一次 `pnpm update`，再核对 commit。
+During batch-migration wrap-up, run `pnpm update` once for every github-track dependency, then verify the commit.
 
-## 3. 插件 npm 包改名（包名前缀变更）的三处同步
+## 3. Three-place sync when a plugin's npm package is renamed (package name prefix change)
 
-包名从 `@deepseek-ai/dsh-x` 改为 `@org/dsh-x` 时，以下三处必须一致，否则 Loader 解析失败：
+When the package name changes from `@deepseek-ai/dsh-x` to `@org/dsh-x`, the following three places must agree, or the Loader fails to resolve:
 
-1. profile `package.json` 的 dependencies key（安装名）；
-2. profile `dsh.profile.bundles` 条目（bundle 名）；
-3. 插件自身 `cordis.patch.yml` 里的行 `name`。
+1. the dependencies key in the profile `package.json` (install name);
+2. the profile `dsh.profile.bundles` entry (bundle name);
+3. the `name` line in the plugin's own `cordis.patch.yml`.
 
-**残留清理**：改名后 `pnpm install` 可能保留旧名字的目录联接（新旧两个目录并存）。确认锁文件只剩新名
-后，手动删除 `node_modules/@旧前缀/旧包名` 的残留目录。
+**Residue cleanup**: after a rename, `pnpm install` may keep the old-name directory junction (old and new directories coexist). After confirming that the lockfile contains only the new name, manually delete the leftover `node_modules/@old-prefix/old-package` directory.
 
-## 4. 共享回退 node_modules 与目录联接的更新语义
+## 4. Update semantics of the shared fallback node_modules and directory junctions
 
-- profile 自身的 `node_modules` 只含 profile 声明依赖；bare 行名解析不到时回退到共享的
-  `$DSH_HOME/profiles/node_modules`（里面是 app 与各 bundle 声明依赖的副本）。
-- 目录联接指向本地工作区包时，**工作区源码更新后重启 dsh 即生效**；host 半段改动必须重启，
-  client 半段才可能硬刷新（见 [migration-hygiene](https://github.com/oh-my-dsh/dsh-plugin-upgrade-skill/blob/main/skills/plugin-upgrade/references/migration-hygiene.md) 第 3 条）。
-- profile 根 `cordis.yml` 会在 boot 时被重写为 `[]`（组合事实在 patch 层）——**不要手改它**，改
-  `cordis.patch.yml`。
+- The profile's own `node_modules` contains only the profile's declared dependencies; when a bare row name fails to resolve, resolution falls back to the shared `$DSH_HOME/profiles/node_modules` (which holds copies of the app's and each bundle's declared dependencies).
+- When a directory junction points at a local workspace package, **a workspace source update takes effect once dsh is restarted**; host-half changes require a restart, and only then can the client half hard-refresh (see item 3 of [migration-hygiene](https://github.com/oh-my-dsh/dsh-plugin-upgrade-skill/blob/main/skills/plugin-upgrade/references/migration-hygiene.md)).
+- The profile root `cordis.yml` is rewritten to `[]` at boot (composition facts live in the patch layer) — **do not edit it by hand**; edit `cordis.patch.yml` instead.
 
-## 5. 宿主 tag 升级后的 profile 联动顺序
+## 5. Profile linkage order after a host tag upgrade
 
-1. checkout 检出精确 tag → `pnpm install` → `pnpm run clean` → `pnpm run build`（clean 排除
-   tsbuildinfo 假阳性）；
-2. 批量插件迁移完成并推送到各自仓库后，回到 profile：`pnpm update` 重解析 github 安装轨依赖；
-3. `dsh --profile <p> --dump-config` 核对行集；
-4. 真实冷启动：目标 tag 的 dsh 起来后，插件清单（pluginInventory）里本插件 entry `active`、
-   无 `pending`。
+1. Check out the exact tag → `pnpm install` → `pnpm run clean` → `pnpm run build` (clean rules out tsbuildinfo false positives);
+2. After the batch plugin migration is done and pushed to each repository, return to the profile: `pnpm update` re-resolves the github-track dependencies;
+3. Verify the row set with `dsh --profile <p> --dump-config`;
+4. Real cold boot: once dsh at the target tag is up, the plugin's entry in the plugin inventory (pluginInventory) is `active`, with no `pending`.
 
-## 6. 自建通道的无浏览器认证冒烟
+## 6. Browser-free authentication smoke for custom channels
 
-0.1.2-alpha.1 起 dsh web 使用 bootstrap token + 签名 Cookie 认证（见
-[DSH-0.1.2-A1-08 · Web/API 通道认证](https://github.com/oh-my-dsh/dsh-plugin-upgrade-skill/blob/main/skills/plugin-upgrade/references/v0.1.2-alpha.1.md)）。
-插件自建了 HTTP/RPC 通道（如 `/tariff/status`）时，发布前用下面流程证明「通道确实挂在统一认证后面」，
-不依赖浏览器/Playwright。已知行为：token 在同一进程可重复兑换、重启才轮换；自建 route 必须经
-`connection` 注册才会自动继承认证，裸 `ctx.webServer.register()` 不继承。
+Since 0.1.2-alpha.1, dsh web uses bootstrap-token + signed-Cookie authentication (see
+[DSH-0.1.2-A1-08 · Web/API channel authentication](https://github.com/oh-my-dsh/dsh-plugin-upgrade-skill/blob/main/skills/plugin-upgrade/references/v0.1.2-alpha.1.md)).
+When a plugin has its own HTTP/RPC channel (such as `/tariff/status`), use the flow below before publishing to prove that "the channel really sits behind the unified authentication", without relying on a browser/Playwright. Known behavior: the token can be exchanged repeatedly within the same process and only rotates on restart; a custom route inherits authentication only when registered through `connection` — a bare `ctx.webServer.register()` does not inherit.
 
-PowerShell（自带 Cookie 容器）：
+PowerShell (with its own Cookie container):
 
 ```powershell
-# 1. 从启动输出抓认证 URL：dsh web: http://127.0.0.1:3190/?token=<T>
-# 2. 兑换 Cookie
+# 1. Grab the auth URL from the startup output: dsh web: http://127.0.0.1:3190/?token=<T>
+# 2. Exchange the Cookie
 $sess = New-Object Microsoft.PowerShell.Commands.WebRequestSession
 Invoke-WebRequest "http://127.0.0.1:3190/?token=$token" -WebSession $sess -UseBasicParsing
-# 3. 带会话调用自建通道 → 断言 200
+# 3. Call the custom channel with the session → assert 200
 $body = @{ type = 'client-request'; rpcId = 'smoke'; method = 'status'; payload = $null } | ConvertTo-Json
 Invoke-WebRequest 'http://127.0.0.1:3190/tariff/status' -Method POST -ContentType 'application/json' -Body $body -WebSession $sess
-# 4. 无认证重发 → 断言 401（证明通道受保护）
+# 4. Resend without authentication → assert 401 (proves the channel is protected)
 Invoke-WebRequest 'http://127.0.0.1:3190/tariff/status' -Method POST -ContentType 'application/json' -Body $body
 ```
 
-curl 等价（`-c/-b` cookie jar）：
+curl equivalent (`-c/-b` cookie jar):
 
 ```sh
-curl -s -c jar.txt "http://127.0.0.1:3190/?token=$TOKEN" >/dev/null      # 兑换 Cookie（303→/）
+curl -s -c jar.txt "http://127.0.0.1:3190/?token=$TOKEN" >/dev/null      # exchange the Cookie (303→/)
 curl -s -b jar.txt -X POST -H 'content-type: application/json' \
   -d '{"type":"client-request","rpcId":"smoke","method":"status","payload":null}' \
-  http://127.0.0.1:3190/tariff/status        # 期望 200
+  http://127.0.0.1:3190/tariff/status        # expect 200
 curl -s -o /dev/null -w '%{http_code}\n' -X POST \
-  http://127.0.0.1:3190/tariff/status        # 期望 401
+  http://127.0.0.1:3190/tariff/status        # expect 401
 ```
 
-## 7. 验证清单
+## 7. Validation checklist
 
-- [ ] 锁文件里每个 github 依赖的 commit 等于期望 HEAD；
-- [ ] 改名插件在锁文件、bundles 列表、cordis.patch.yml 三处同名，旧目录联接已清理；
-- [ ] `--dump-config` 行集符合预期；
-- [ ] 真实冷启动 entry active；
-- [ ] 自建通道认证冒烟：无认证 401、兑换 Cookie 后 200（第 6 节流程）。
+- [ ] Every github dependency's commit in the lockfile equals the expected HEAD;
+- [ ] A renamed plugin uses the same name in the lockfile, the bundles list, and `cordis.patch.yml`, and the old directory junction has been cleaned up;
+- [ ] The `--dump-config` row set matches expectations;
+- [ ] Real cold boot leaves the entry active;
+- [ ] Custom-channel authentication smoke: 401 without authentication, 200 after exchanging the Cookie (Section 6 flow).

--- a/skills/plugin-release/references/publish-playbook.md
+++ b/skills/plugin-release/references/publish-playbook.md
@@ -1,12 +1,13 @@
-# publish-playbook · 打包、发布与分发配方
+# publish-playbook · Packaging, publishing, and distribution recipes
 
-> 按需加载的实操配方，承接 [../SKILL.md](../SKILL.md) 的决策流程。
-> 所有结论来自 omdsh-dev 组织 17 个插件仓库两轮真实发布实践（rc.2 → alpha.1 → alpha.2），
-> 场景未覆盖时以一手来源为准并标注「待确认」。
+> Load-on-demand operational recipes that carry on the decision flow of [../SKILL.md](../SKILL.md).
+> All conclusions come from two rounds of real publishing practice across the 17 plugin repositories
+> in the omdsh-dev organization (rc.2 → alpha.1 → alpha.2); where a scenario is not covered,
+> defer to primary sources and mark the item as pending confirmation.
 
-## 未发布 cohort 安装（R-01 配方）
+## Unpublished cohort installation (recipe R-01)
 
-0.1.2-alpha.* 只在 GitHub 发布，npm 查询返回 404。消费者侧的隔离安装：
+0.1.2-alpha.* is published on GitHub only; npm lookups return 404. Isolated installation on the consumer side:
 
 ```sh
 git clone https://github.com/deepseek-ai/deepseek-harness.git /tmp/dsh-build
@@ -16,23 +17,22 @@ mkdir -p ~/.dsh-cohorts/0.1.2-alpha.2
 pnpm -r exec pnpm pack --pack-destination ~/.dsh-cohorts/0.1.2-alpha.2
 ```
 
-manifest 里 range 写 `^0.1.2-alpha.2`，并用 `overrides` 钉到 `file:` tarball；正式发版后删掉 overrides 即回到 registry 解析。
+In the manifest, write the range as `^0.1.2-alpha.2` and pin it to a `file:` tarball with `overrides`; once the official release is out, removing the overrides returns resolution to the registry.
 
-> **待确认（单一实战报告，未复现）**：pnpm 11.9.0 对 file: tarball 的传递依赖在有第三方
-> peer 时会绕过 overrides 去 registry 找不存在的版本，报告称钉 `packageManager: pnpm@11.24.0`
-> 才解析正确。落地前先在目标仓库做最小复现，验证后回填结论。
+> **To be confirmed (single field report, not reproduced)**: with third-party peers present, pnpm 11.9.0
+> resolves the transitive dependencies of `file:` tarballs by bypassing overrides and looking for a
+> nonexistent version on the registry; the report says pinning `packageManager: pnpm@11.24.0` resolves
+> it correctly. Reproduce minimally in the target repository before adopting it, and backfill the
+> conclusion once verified.
 
-## 双兼容写法（alpha 时代核心策略）
+## Dual-compatibility pattern (core strategy for the alpha era)
 
-公开仓库的 devDependencies 用 npm 发布线（当前 0.1.1-rc.2）作为类型基线；代码同时要在
-GitHub tag 的本地 harness 上运行。对签名漂移的 API，按“npm 发布线类型为准、alpha 运行时
-语义不变”折中。真实案例：`rpc.handle` 第三参数在 0.1.2-alpha.1 起被移除（认证改由
-connection 统一处理），但 rc.2 类型仍要求它：
+Public repositories use the npm release line (currently 0.1.1-rc.2) as the type baseline for devDependencies, while the code must also run on the local harness at the GitHub tag. For APIs with signature drift, compromise as: "the npm release line's types are authoritative; the alpha runtime semantics stay unchanged". Real case: the third argument of `rpc.handle` was removed starting with 0.1.2-alpha.1 (authentication is now handled uniformly by the connection), but the rc.2 types still require it:
 
 ```ts
-// devDependencies 基线是 npm 发布线（rc.2），其 handle() 类型要求第三参数；
-// harness 0.1.2-alpha.1 起的 handle() 忽略该参数。保留它使仓库对 rc.2 类型
-// 可 typecheck，同时 alpha 运行时行为不变。
+// The devDependencies baseline is the npm release line (rc.2), whose handle() type requires the
+// third argument; harness handle() ignores that argument since 0.1.2-alpha.1. Keeping it lets the
+// repository typecheck against rc.2 types while the alpha runtime behavior stays unchanged.
 const dispose = connection.rpc.handle(
   '/tariff',
   handler,
@@ -40,33 +40,31 @@ const dispose = connection.rpc.handle(
 )
 ```
 
-- 只对**签名漂移且运行时忽略多余参数**的 API 用此折中；语义变化的 API 必须按
-  [plugin-upgrade](https://github.com/oh-my-dsh/dsh-plugin-upgrade-skill/blob/main/skills/plugin-upgrade/SKILL.md) 的版本卡片迁移，不做静默折中；
-- 类型导入（`import type`）编译期擦除，跨 cohort 无运行时负担；
-- 不要把本机 junction/file: 绝对路径写进提交的 manifest。
+- Use this compromise only for APIs with **signature drift where the runtime ignores the extra argument**; APIs with semantic changes must be migrated via the version cards of
+  [plugin-upgrade](https://github.com/oh-my-dsh/dsh-plugin-upgrade-skill/blob/main/skills/plugin-upgrade/SKILL.md), never silently compromised;
+- Type-only imports (`import type`) are erased at compile time and carry no runtime cost across cohorts;
+- Never write local junction/file: absolute paths into a committed manifest.
 
-## CI 与发布门禁（未发布 cohort）
+## CI and release gates (unpublished cohort)
 
-- cohort tarball 用 actions cache 物化（以 manifest hash 为 key），所有 pnpm 消费 job 共享，
-  避免 frozen lockfile 记录机器相关路径导致干净 runner 缺 store；
-- `pnpm/action-setup` 不写死 `version`，让 `packageManager` 成为唯一版本来源；
-- 发布 workflow 加 `NPM_PUBLISH_ENABLED` 开关：tag 触发仍跑全部门禁与 smoke，但跳过
-  npm publish，直到 cohort 正式发布。
+- Materialize the cohort tarballs through the actions cache (keyed by the manifest hash), shared by all pnpm consumer jobs, so that machine-specific paths recorded in a frozen lockfile do not leave a clean runner without the store;
+- `pnpm/action-setup` does not pin `version`, making `packageManager` the single version source;
+- Add an `NPM_PUBLISH_ENABLED` switch to the release workflow: tag-triggered runs still execute the full gate and smoke, but skip `npm publish` until the cohort is officially released.
 
-## 发布语义门禁配方（release workflow）
+## Release semantic gate recipe (release workflow)
 
-发布前按序跑以下检查，任一失败即停（SKILL 第 4 步的四条不变量）：
+Before publishing, run the following checks in order; stop on any failure (the four invariants of Step 4 in the SKILL):
 
 ```sh
 VERSION="$(node -p "require('./package.json').version")"
-# 1) GitHub Release tag 必须等于 v${VERSION}
+# 1) GitHub Release tag must equal v${VERSION}
 [ "$RELEASE_TAG" = "v$VERSION" ] || { echo "tag mismatch"; exit 1; }
-# 2) prerelease 状态一致（'-' 在 '+' build metadata 之前）
+# 2) prerelease state must match ('-' comes before '+' build metadata)
 V_PRERELEASE="$(node -e 'console.log(process.argv[1].split("+")[0].includes("-") ? "true" : "false")' "$VERSION")"
 [ "$RELEASE_PRERELEASE" = "$V_PRERELEASE" ] || { echo "prerelease state mismatch"; exit 1; }
-# 3) 分流 dist-tag：prerelease 只进项目声明的非 latest tag（NEXT_TAG 由项目自定），stable 才进 latest
+# 3) dist-tag routing: prereleases only go to a project-declared non-latest tag (NEXT_TAG is chosen by the project); only stable goes to latest
 if [ "$RELEASE_PRERELEASE" = "true" ]; then NPM_TAG="$NEXT_TAG"; else NPM_TAG="latest"; fi
-# 4) stable 发布前拒绝把 latest 回退到更低版本（semver 比较）
+# 4) before a stable publish, refuse to move latest backwards to a lower version (semver comparison)
 if [ "$NPM_TAG" = "latest" ]; then
   CURRENT="$(npm view "$PKG" dist-tags.latest 2>/dev/null || echo 0.0.0)"
   node -e "const semver=require('semver'); if (semver.lt(process.argv[1], process.argv[2])) { console.error('refusing to move latest backwards'); process.exit(1) }" "$VERSION" "$CURRENT"
@@ -88,34 +86,32 @@ node skills/plugin-release/scripts/verify-release.mjs \
 
 The script only validates inputs and never publishes, tags, or queries the network.
 
-- 宿主验收矩阵与发布通道一致：prerelease 通道锁 alpha 系 tag、stable 通道锁 rc 系 tag，
-  **绝不跟随 master/main 冒名验收**；
-- Web Client 插件的 publish 前 smoke 必须覆盖：宿主启动图（`window.__DSH_BOOT__`）公告的
-  bundle 入口可访问、bundle 注册成功、DOM 挂载完成、无 page error；`--dump-config` 只证明
-  row 存在，不代替本项；
-- 可复核实现参考：[dsh-genui#86](https://github.com/omdsh-dev/dsh-genui/pull/86)、
-  [dsh-annotation#40](https://github.com/omdsh-dev/dsh-annotation/pull/40)（两者实现了
-  第 1–3 条与双宿主 smoke；第 4 条 latest 回退防护为社区补充建议，参考实现中尚无）。
+- The host acceptance matrix matches the release channel: the prerelease channel pins alpha-series tags and the stable channel pins rc-series tags — **never follow master/main to masquerade as acceptance**;
+- Pre-publish smoke for Web Client plugins must cover: the bundle entry announced in the host boot manifest (`window.__DSH_BOOT__`) is reachable, the bundle registers successfully, the DOM mount completes, and there are no page errors; `--dump-config` only proves the row exists and does not replace this check;
+- Auditable reference implementations: [dsh-genui#86](https://github.com/omdsh-dev/dsh-genui/pull/86),
+  [dsh-annotation#40](https://github.com/omdsh-dev/dsh-annotation/pull/40) (both implement
+  items 1–3 and dual-host smoke; item 4, the latest-backwards protection, is a community-suggested
+  addition not present in the reference implementations).
 
-## 真实坑位清单（两轮实践）
+## Real pitfall list (two rounds of practice)
 
-| 坑 | 症状 | 处置 |
+| Pitfall | Symptom | Handling |
 |---|---|---|
-| PATH 上没有 pnpm（只有 corepack） | 构建脚本里嵌套 `pnpm --filter …` 报 `'pnpm' is not recognized` | 生成 `pnpm.cmd` shim 转发 corepack，前置到 PATH；启动/构建包装器自举该 shim |
-| Windows PowerShell 5.1 调 `npm` 解析到 `npm.ps1` | 参数错乱（`Unknown command: "pm"`） | 包装脚本显式调用 `npm.cmd` / `pnpm.cmd` |
-| PowerShell 5.1 参数默认值里 `$PSScriptRoot` 为空（带 `[CmdletBinding()]` 时） | `Join-Path` 报空字符串 | 默认值移到脚本体内解析 |
-| PowerShell 的只读自动变量 `$Host` | 参数名 `-Host` 覆盖失败 | 改名 `-BindHost` 等 |
-| `git rebase --continue` 卡编辑器 | 无 TTY 时挂起 | `GIT_EDITOR=true`（或 `core.editor=true`）再继续 |
-| 远端前进导致推送被拒 | `[ahead 1, behind 1]` | `git pull --rebase` 后 `--force-with-lease` 重推，绝不裸 `--force` |
+| pnpm not on PATH (corepack only) | Nested `pnpm --filter …` in build scripts fails with `'pnpm' is not recognized` | Generate a `pnpm.cmd` shim that forwards to corepack and prepend it to PATH; startup/build wrappers bootstrap the shim |
+| Windows PowerShell 5.1 resolves `npm` to `npm.ps1` | Arguments get mangled (`Unknown command: "pm"`) | Wrapper scripts explicitly invoke `npm.cmd` / `pnpm.cmd` |
+| `$PSScriptRoot` is empty in PowerShell 5.1 default parameter values (with `[CmdletBinding()]`) | `Join-Path` errors on an empty string | Move default-value resolution into the script body |
+| PowerShell's read-only automatic variable `$Host` | Parameter name `-Host` fails to override | Rename it, e.g. to `-BindHost` |
+| `git rebase --continue` blocks on the editor | Hangs without a TTY | Use `GIT_EDITOR=true` (or `core.editor=true`) before continuing |
+| Remote advanced and the push is rejected | `[ahead 1, behind 1]` | `git pull --rebase`, then re-push with `--force-with-lease`; never a bare `--force` |
 
-## 回滚配方
+## Rollback recipe
 
-1. 发布前打 tag 并记录 lockfile/composition 基线 hash；
-2. GitHub 直装轨：删除/移动 tag，消费者按需重新指向旧 commit；
-3. 隔离工作区（branch/worktree）做迁移与发布，不与功能改动混在一个提交；
-4. 失败时只回滚本次拥有的路径（tag、lockfile、manifest），报告第三方安装脚本的残留副作用。
+1. Tag before publishing and record the lockfile/composition baseline hashes;
+2. GitHub direct-install track: delete/move the tag; consumers re-point at the old commit as needed;
+3. Do migrations and publishing in an isolated workspace (branch/worktree), never mixed into one commit with feature changes;
+4. On failure, roll back only the paths owned by this run (tag, lockfile, manifest) and report residual side effects of third-party install scripts.
 
-## 待确认
+## Pending confirmation
 
-- 0.1.2 正式版 dist-tag 与 final tag 名发布后，复核“未发布 cohort”各条配方；
-- pnpm 版本敏感性（见上）来自单一实战报告，复现前标待确认。
+- After the 0.1.2 final dist-tag and final tag name are published, re-verify the unpublished-cohort recipes;
+- The pnpm version sensitivity (see above) comes from a single field report; keep it marked as pending confirmation until reproduced.


### PR DESCRIPTION
## Summary

English adaptation of the `plugin-release` skill, following the scheme already used by `plugin-upgrade` and `dsh-upgrade-audit` (English default + `SKILL.zh-CN.md` companion):

- `SKILL.md` — translated to English (frontmatter `description` is a faithful, trigger-oriented translation); language switcher added.
- `SKILL.zh-CN.md` — new companion containing the original Chinese SKILL.md.
- `references/publish-playbook.md`, `references/profile-dependency-management.md` — translated in place to English.

## What was preserved

- All commands, flags, package names, version tags (`0.1.1-rc.2`, `0.1.2-alpha.*`), URLs and table structures.
- All technical facts and recommendations — nothing added or softened. `待确认` markers rendered as "To be confirmed / pending confirmation".

## Verification

- `node scripts/validate.mjs` — Validation OK (5 skills, 38 cards, 95 Markdown files)
- `node scripts/validate-manifests.mjs` — passed
- `node skills/plugin-upgrade/scripts/verify-runtime.check.mjs` — all assertions passed
- Han-character scan: only the language-switcher word `简体中文` remains in the English files.

## Notes

- The `node_modules/@旧前缀/旧包名` placeholder in `profile-dependency-management.md` is rendered `node_modules/@old-prefix/old-package` (a pattern, not a real path).
