### PR TITLE
i18n(plugin-upgrade): English version cards, rollup and reference docs (validator contract sync)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@
 
 - `kind/schema/from/to/status/coverage/cardCount/idPrefix/verifiedAt` frontmatter；
 - 完整且全仓唯一的 ID，例如 `DSH-X.Y.Z-A1-01`（落地时把版本占位符替换为真实坐标）；
-- `类型/适用对象/影响触点/操作级别/症状/迁移配方/验证/来源` 全部字段；
+- `Type/Applies to/Touchpoints/Action level/Symptoms/Migration recipe/Verification/Source` 全部字段（卡片字段名已英文化）；
 - 固定 tag/commit 的一手来源；同 tag 可取得源码时，不只引用 release notes。
 
 触点编号使用 [pre-flight](skills/plugin-upgrade/references/pre-flight.md) 的 **#1–#7**。

--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -118,7 +118,7 @@ const cardFiles = (await readdir(referencesDir))
   .filter((name) => /^v.*\.md$/.test(name))
   .map((name) => join(referencesDir, name))
 const requiredMeta = ['kind', 'schema', 'from', 'to', 'status', 'coverage', 'cardCount', 'idPrefix', 'verifiedAt']
-const requiredFields = ['类型', '适用对象', '影响触点', '操作级别', '症状', '迁移配方', '验证', '来源']
+const requiredFields = ['Type', 'Applies to', 'Touchpoints', 'Action level', 'Symptoms', 'Migration recipe', 'Verification', 'Source']
 const allowedTypes = new Set(['breaking', 'behavior', 'capability', 'fix', 'security', 'privacy'])
 const allowedActions = /^(required|conditional|optional|informational|required-if-[A-Za-z0-9.-]+)$/
 const tag = /^dsh-v\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/
@@ -170,12 +170,12 @@ for (const file of cardFiles) {
     for (const field of requiredFields) {
       if (!new RegExp(`^- \\*\\*${field}\\*\\*:`, 'm').test(card)) fail(file, `${id} missing field: ${field}`)
     }
-    const type = /^- \*\*类型\*\*:\s*([^\r\n]+)/m.exec(card)?.[1]?.trim()
-    const action = /^- \*\*操作级别\*\*:\s*([^\r\n]+)/m.exec(card)?.[1]?.trim()
+    const type = /^- \*\*Type\*\*:\s*([^\r\n]+)/m.exec(card)?.[1]?.trim()
+    const action = /^- \*\*Action level\*\*:\s*([^\r\n]+)/m.exec(card)?.[1]?.trim()
     if (!allowedTypes.has(type)) fail(file, `${id} invalid type: ${type}`)
     if (!allowedActions.test(action ?? '')) fail(file, `${id} invalid action: ${action}`)
-    if (!/^- \*\*来源\*\*:[\s\S]*?https:\/\//m.test(card)) fail(file, `${id} must cite a primary URL`)
-    const sourceLine = /^- \*\*来源\*\*:([^\r\n]+)/m.exec(card)?.[1] ?? ''
+    if (!/^- \*\*Source\*\*:[\s\S]*?https:\/\//m.test(card)) fail(file, `${id} must cite a primary URL`)
+    const sourceLine = /^- \*\*Source\*\*:([^\r\n]+)/m.exec(card)?.[1] ?? ''
     for (const match of sourceLine.matchAll(/https:\/\/[^ )]+/g)) {
       if (/github\.com\/[^/]+\/[^/]+\/blob\/(main|master)([/?#]|$)/.test(match[0])) {
         fail(file, `${id} source must pin a tag or commit, got an unpinned blob link: ${match[0]}`)
@@ -210,10 +210,10 @@ for (const file of markdownFiles) {
 // The rollup is a current navigation document, not an unchecked historical snapshot.
 const rollupFile = join(referencesDir, 'rollup-0.1.2.md')
 const rollupText = await readFile(rollupFile, 'utf8')
-for (const required of ['#7 子进程']) {
+for (const required of ['#7 subprocess']) {
   if (!rollupText.includes(required)) fail(rollupFile, `missing current rollup contract: ${required}`)
 }
-if (/Consumer.*永不 reject|#6 子进程|git checkout <tag> -- pnpm-lock\.yaml/.test(rollupText)) {
+if (/Consumer.*never reject|#6 subprocess|git checkout <tag> -- pnpm-lock\.yaml/.test(rollupText)) {
   fail(rollupFile, 'contains a retired Remote, touchpoint, or rollback rule')
 }
 

--- a/skills/plugin-upgrade/SKILL.md
+++ b/skills/plugin-upgrade/SKILL.md
@@ -9,7 +9,7 @@ English | [简体中文](SKILL.zh-CN.md)
 
 Safely handle three task types: read-only update inspection, installed-plugin upgrades, and DSH host version compatibility migration. If user intent is unclear, confirm the mode first; never let "help me check for updates" slide into installing or changing code.
 
-Note: the version cards under `references/` are kept in Chinese; card IDs, field names, and cited commands are language-neutral.
+Note: the version cards and reference docs under `references/` are in English; card IDs and cited commands are language-neutral.
 
 ## Step 0: choose a mode
 

--- a/skills/plugin-upgrade/references/README.md
+++ b/skills/plugin-upgrade/references/README.md
@@ -1,37 +1,40 @@
-# references/ · 按需加载的参考材料
+# references/ · reference material loaded on demand
 
-> `SKILL.md` 只保留决策流程，版本事实与扫描模式放在这里按需加载。
+> `SKILL.md` keeps only the decision flow; version facts and scan patterns live here and load on demand.
 
-## 版本走廊索引
+## Version corridor index
 
-按表中 `from → to` 的有向边构造走廊，不要按文件名排序；`alpha.10` 的字典序会早于
-`alpha.2`。目标跨多版时先读完整走廊并计算最终净状态，再修改源码——例如字段在
-alpha.1 删除、alpha.2 恢复时，不应先删再加。
+Build corridors along the `from → to` directed edges in the table, never by filename
+order — lexicographically, `alpha.10` sorts before `alpha.2`. When the target spans
+multiple versions, read the full corridor and compute the final net state before touching
+source: if a field is removed in alpha.1 and restored in alpha.2, do not delete and re-add it.
 
-| 顺序 | 卡片文件 | from | to | 卡数 | 状态 / 覆盖 |
+| Order | Card file | from | to | Cards | Status / coverage |
 |---|---|---|---|---:|---|
 | 1 | [v0.1.1-rc.2.md](v0.1.1-rc.2.md) | `dsh-v0.1.1-rc.1` | `dsh-v0.1.1-rc.2` | 3 | reviewed / curated |
 | 2 | [v0.1.2-alpha.1.md](v0.1.2-alpha.1.md) | `dsh-v0.1.1-rc.2` | `dsh-v0.1.2-alpha.1` | 27 | reviewed / curated |
 | 3 | [v0.1.2-alpha.2.md](v0.1.2-alpha.2.md) | `dsh-v0.1.2-alpha.1` | `dsh-v0.1.2-alpha.2` | 8 | reviewed / curated |
-| — | [rollup-0.1.2.md](rollup-0.1.2.md) | `dsh-v0.1.1-rc.2` → `dsh-v0.1.2-alpha.2` 全走廊 | rollup | 非卡片文件：走廊层增量（跨 cohort 共存、未发布 cohort 安装、`RemoteResult` 错误流、迁移前 baseline 归因、boot race 有界重试、base-only preset 前置、类型面导出漂移、宿主自身安全边界、安装通道三坑、分层验证清单）；基于 alpha.2，正式版需复核 |
+| — | [rollup-0.1.2.md](rollup-0.1.2.md) | `dsh-v0.1.1-rc.2` → `dsh-v0.1.2-alpha.2` full corridor | rollup | non-card file: corridor-level increment (cross-cohort coexistence, unpublished-cohort installation, `RemoteResult` error flow, pre-migration baseline attribution, bounded retry for boot race, base-only preset precondition, type-surface export drift, host-self safety boundary, three install-channel pitfalls, layered validation checklist); based on alpha.2, subject to final-release review |
 
-`curated` 表示只收录已识别的插件相关变化，不表示完整 API diff。走廊缺边时停止
-自动迁移，向用户报告缺口；为当前任务做临时上游调研与给本仓库补卡是两件事，后者
-不应成为修改用户插件的隐式副作用。
+`curated` means only the identified plugin-relevant changes are included, not a complete
+API diff. When a corridor edge is missing, stop the automatic migration and report the gap
+to the user; one-off upstream research for the current task and adding cards to this
+repository are two different activities — the latter must not become an implicit side
+effect of modifying the user's plugin.
 
-配套材料：
+Companion material:
 
-- [pre-flight.md](pre-flight.md)：七类触点自查与迁移任务汇总；
-- [pre-flight-patterns.json](pre-flight-patterns.json)：可执行校验使用的正则真源；
-- [api-migration-0.1.2-alpha.2.md](api-migration-0.1.2-alpha.2.md)：rc.2→alpha.2 命中 API、Remote、Settings、事件、Headless、打包或 composition 接口时使用的精确迁移 ledger；
-- [host-plane-probes.md](host-plane-probes.md)：宿主平面在 `cordis.patch.yml` 里做双 cohort 探测的三种写法；
-- [migration-hygiene.md](migration-hygiene.md)：与版本无关的工具链坑（tsbuildinfo 假阳性、oxc 解析严格性、生效平面、pnpm 拦截、测试语法）；
-- [troubleshooting.md](troubleshooting.md)：迁移后症状 → 根因 → 卡片反查；
-- [examples/legacy-plugin/](../examples/legacy-plugin/)：七类触点静态夹具。
+- [pre-flight.md](pre-flight.md): the seven-class touchpoint self-check and the migration-task summary template;
+- [pre-flight-patterns.json](pre-flight-patterns.json): source of truth for the regexes used by executable checks;
+- [api-migration-0.1.2-alpha.2.md](api-migration-0.1.2-alpha.2.md): the precise migration ledger for rc.2→alpha.2 when API, Remote, Settings, events, Headless, packaging, or composition interfaces are hit;
+- [host-plane-probes.md](host-plane-probes.md): three ways for the host plane to run dual-cohort probes in `cordis.patch.yml`;
+- [migration-hygiene.md](migration-hygiene.md): version-independent toolchain pitfalls (tsbuildinfo false positives, oxc parsing strictness, the plane a change takes effect in, pnpm interception, test syntax);
+- [troubleshooting.md](troubleshooting.md): post-migration symptom → root cause → card lookup;
+- [examples/legacy-plugin/](../examples/legacy-plugin/): static fixture for the seven touchpoint classes.
 
-## 卡片文件元数据
+## Card file metadata
 
-每个 `vX.Y.Z-<suffix>.md` 以 frontmatter 声明：
+Each `vX.Y.Z-<suffix>.md` declares, in its frontmatter:
 
 ```yaml
 ---
@@ -47,28 +50,29 @@ verifiedAt: 2026-08-30
 ---
 ```
 
-版本顺序由 `from/to` 决定；`cardCount`、ID 前缀与必需字段由仓库校验脚本检查。
+Version order is determined by `from`/`to`; `cardCount`, the ID prefix, and the required
+fields are checked by the repository's validation scripts.
 
-## 单张卡片格式
+## Single-card format
 
 ```markdown
-### DSH-0.1.2-A2-01 · 标题
+### DSH-0.1.2-A2-01 · Title
 
-- **类型**: breaking | behavior | capability | fix | security | privacy
-- **适用对象**: client / server plugin / profile wrapper / packaging 等
-- **影响触点**: #1…#7，或“无（打包/隐私面）”
-- **操作级别**: required | required-if-hit | required-if-target-is-… | conditional | optional | informational
-- **症状**: 升级后什么会坏或变化
-- **迁移配方**: 可核对的步骤；旧→新 ledger（如适用）
-- **验证**: 如何证明最终行为，而不是只证明安装成功
-- **来源**: 固定 release tag / commit 的一手来源
-- **实战批注**（可选）: 可复现的真实迁移差异，注明日期、插件、平台与版本
+- **Type**: breaking | behavior | capability | fix | security | privacy
+- **Applies to**: client / server plugin / profile wrapper / packaging, etc.
+- **Touchpoints**: #1…#7, or "none (packaging/privacy surface)"
+- **Action level**: required | required-if-hit | required-if-target-is-… | conditional | optional | informational
+- **Symptoms**: what breaks or changes after the upgrade
+- **Migration recipe**: checkable steps; old→new ledger (where applicable)
+- **Verification**: how to prove the final behavior, not just that installation succeeded
+- **Source**: primary source pinned to a fixed release tag / commit
+- **Field note** (optional): reproducible real-world migration differences, noting date, plugin, platform, and version
 ```
 
-规则：
+Rules:
 
-1. ID 必须包含完整宿主版本并在仓库内唯一；
-2. 每张卡至少引用一条一手来源，同版本材料存在时优先钉在同一个 tag；
-3. release notes 只给出方向、没有 API 坐标时，配方必须要求再查目标 tag 类型，不能自造接口；
-4. 跨版本回滚/恢复用完整 ID 交叉引用；
-5. 本地观察与一手来源冲突时，先复现并并列记录差异，不静默覆盖任何一方。
+1. The ID must include the full host version and be unique within the repository;
+2. every card cites at least one primary source; when same-version material exists, prefer pinning to the same tag;
+3. when release notes give direction only, without API coordinates, the recipe must require re-checking the target tag's types — do not invent interfaces;
+4. cross-version rollbacks/restores are cross-referenced by full ID;
+5. when local observation conflicts with a primary source, reproduce first and record the difference side by side; never silently overwrite either side.

--- a/skills/plugin-upgrade/references/api-migration-0.1.2-alpha.2.md
+++ b/skills/plugin-upgrade/references/api-migration-0.1.2-alpha.2.md
@@ -1,101 +1,98 @@
-# 接口迁移实战 · 0.1.1-rc.2 → 0.1.2-alpha.2
+# API Migration in Practice · 0.1.1-rc.2 → 0.1.2-alpha.2
 
-> 定位：面向插件作者的接口 ledger。重点回答三件事：哪些接口变了、旧写法会怎样
-> 失败、目标版本的 best practice 是什么。安装流程、产品功能清单和 UI 变化不在本文展开。
+> Audience: an interface ledger for plugin authors. It answers three things: which
+> interfaces changed, how legacy patterns fail, and what the target version's best
+> practice is. Installation flows, product feature lists, and UI changes are not
+> covered here.
 >
-> 精确走廊：`dsh-v0.1.1-rc.2`
+> Exact corridor: `dsh-v0.1.1-rc.2`
 > (`b150a551b8d465e31e418e1b2eaf5e79bbb7d28e`) → `dsh-v0.1.2-alpha.1`
 > (`cd5ef8148158c3a752a658978873241fdf8e2bbc`) → `dsh-v0.1.2-alpha.2`
-> (`0a53fb55bea101816fa226bb964ae2bed71c343b`)。
+> (`0a53fb55bea101816fa226bb964ae2bed71c343b`).
 >
-> 版本状态：截至 2026-08-30，上游 `0.1.2` 系列的最新 tag 是
-> `dsh-v0.1.2-alpha.2`，尚无 `dsh-v0.1.2` final tag。正式版发布后必须重新核对
-> package exports、声明类型、实现与测试，不能把本文直接标成 final 兼容结论。
+> Version status: as of 2026-08-30, the latest tag in the upstream `0.1.2` series is
+> `dsh-v0.1.2-alpha.2`; there is no `dsh-v0.1.2` final tag yet. Once the final release
+> ships, package exports, declared types, implementations, and tests must be re-checked;
+> this document must not be directly marked as a final compatibility conclusion.
 
-## 目录
+## Table of contents
 
-- 一页结论
-- API-01 · APIProxy 按运行平面迁到领域服务或 `ctx.remote` projection
-  - Host / Web Client 最小正确写法
+- One-page conclusion
+- API-01 · APIProxy migrates by runtime plane to domain services or the `ctx.remote` projection
+  - Minimal correct patterns for Host / Web Client
   - Web Client consumer ledger
   - Best practice
-  - 按 face 验证
-- API-02 · `RemoteResult` 版本边界与 alpha.2 `RemoteError`
-  - 先把版本归属说清楚
-  - Consumer 最新写法
-  - Remote owner 最新写法
+  - Verification by face
+- API-02 · `RemoteResult` version boundaries and the alpha.2 `RemoteError`
+  - Version attribution first
+  - Current consumer pattern
+  - Current Remote owner pattern
   - Best practice
-  - 验证
-- API-03 · Settings helper 移除与 provider-owned lifecycle
-  - 升级前
-  - 升级后
+  - Verification
+- API-03 · Settings helper removal and provider-owned lifecycle
+  - Before the upgrade
+  - After the upgrade
   - Best practice
-  - 验证
-- API-04 · 固定 Host facts 统一到 `ctx.remote.$host`
-  - alpha.2 写法
+  - Verification
+- API-04 · Fixed Host facts consolidated on `ctx.remote.$host`
+  - The alpha.2 pattern
   - Best practice
-  - 验证
-- API-05 · `SessionEvent.ignorable` 恢复了，但第三方写入面还没补齐
-  - 危险旧写法
+  - Verification
+- API-05 · `SessionEvent.ignorable` is restored, but the third-party write surface is still incomplete
+  - The dangerous legacy pattern
   - Best practice
-  - 验证
-- API-06 · Headless 的 argv 与进程输出契约
-  - 正确调用与解释
+  - Verification
+- API-06 · The Headless argv and process output contract
+  - Correct invocation and interpretation
   - Best practice
-  - 最小 stub 矩阵
-- API-07 · Package export 不等于发布物存在
+  - Minimal stub matrix
+- API-07 · Package export ≠ artifact presence
   - Best practice
-  - 验证
-- API-08 · `cordis.patch.yml` 是 composition，不是源码 patch
+  - Verification
+- API-08 · `cordis.patch.yml` is composition, not a source patch
   - Best practice
-  - 验证
-- API-09 · Plugin inventory 新增可选 `agentPresets`
+  - Verification
+- API-09 · Plugin inventory gains an optional `agentPresets`
   - Best practice
-  - 验证
-- API-10 · Web Client runtime 拆包、keyed chat snapshot 与命令附件参数
-  - 精确映射
-  - 类型组合与依赖所有权
-  - 验证
-- CFG-01 · Code Mode 精确迁到 PTC mode
-  - 精确 ledger
-- Skill 输出这类迁移报告时应使用的结构
-  - <接口名>
-- 最小验证梯度
+  - Verification
+- API-10 · Web Client runtime unbundling, keyed chat snapshots, and command attachment parameters
+  - Exact mapping
+  - Type composition and dependency ownership
+  - Verification
+- CFG-01 · Code Mode migrated exactly to PTC mode
+  - Exact ledger
+- Structure the skill should use for this kind of migration report
+  - <API name>
+- Minimal validation ladder
 
-## 一页结论
+## One-Page Conclusion
 
-| 接口面 | 旧写法 | 旧写法在目标版本的症状 | alpha.2 best practice |
+| API surface | Old pattern | Symptoms of the old pattern on the target version | alpha.2 best practice |
 |---|---|---|---|
-| Host APIProxy consumer | APIProxy / `executeRemote(...)` | `apiProxy` 消失；机械改成 `remote` 会永久 pending | 跳过 Client gateway，直接注入目标 tag 已确认的 owning domain service，例如 `llm` / `settings` |
-| Web Client APIProxy consumer | APIProxy / `executeRemote(...)` | 旧 package/service 消失；猜错 namespace 或方法会装配失败 | 使用生成的 `ctx.remote.<namespace>.<method>`，声明 `remote` 与具体 namespace 注入 |
-| Unary failure | 只写 `try/catch`；解析 message；`instanceof` | `ok: false` 被当成功；跨 bundle 漏判；错误码分支失效 | 先分支 `result.ok`，按 `result.error.code` 处理；只在 stream/显式抛出等 catch boundary 用 `isRemoteFailure` |
-| Failure classes | `TypertRemoteFailure` / `TypertLookupFailure` / `RemoteStreamError` | removed export 或 typecheck 失败；无域前缀 code 不再匹配 | owner 抛 `RemoteError('<domain>/<reason>', message, details)`；details 由 code 收窄 |
-| Settings namespace | `settingsNamespace('x')` | `TS2305` / “no exported member” | 直接使用符合文法的字符串字面量，例如 `const NS = 'my-plugin'` |
-| Settings lifecycle | 独立 `installSettingsSection(...)` | removed export；只改名字会丢 provider attach/detach 生命周期 | 在 `ctx.inject(['settings'], ...)` 内调用 `settingsCtx.settings.installSection(owner, ...)` |
-| Host facts | 注入 `connection` 并读 generation snapshot | 与 transport 生命周期耦合；alpha.2 已有正式入口 | 读 `ctx.remote.$host.home/isLoopback`；重连时响应 `connection/reset` |
-| SessionEvent | 看到 alpha.2 恢复 `ignorable` 就直接 `Session.append()` 自定义事件 | 写入现场成功，cold load 时因事件无 marker 被整条拒读 | alpha.2 只恢复 envelope 字段；公开 `Session.append()` 尚不能设置它，仓库外插件改用自有 sidecar/store |
-| Headless process | `dsh headless`、`-p`、JSONL stdout、stderr 非空即失败 | argv 不被接受、JSON parse 失败、成功任务被误报 | `dsh --profile headless "task"`；stdout 是最终文本，stderr 是 reasoning/诊断，以退出码为准 |
-| Package subpath | 看到 `exports["./src/*"]` 就直接导入 | 发布包可能根本不含 `src`，运行时报 module not found | 同时核对 exports、`files` 和实际 packed artifact；优先 `.` / `/client` 等稳定入口 |
-| `cordis.patch.yml` | 按文件名当源码 patch | 误报并生成错误迁移任务 | 先按官方 Profile composition overlay 处理；只有真实替换宿主源码时才归源码 patch |
-| Structured questions answerer | `userQuestions.registerProvider({ ask })` | attach 抛 `TypeError`；提问无人 answer（`NO_PROVIDER`） | `ctx.on('user-questions/request', (req, next) => answer)`；不带 agent 的 `ask()` 在服务自身 ctx 派发，同 fiber 树其他 entry 的监听者收不到（详见 [DSH-0.1.2-A1-20](v0.1.2-alpha.1.md)） |
-| Type export drift | `CallId` / `JsonValue` / `collectSessionTitleMessages` / `todo/write` 类型声明 | typecheck 批量 TS2305 / TS2614 | 按 ledger 迁移：`ToolCallId`（dsh-llm 根导出）、`@deepseek-ai/dsh-util-values`、本地同语义折叠、本地 event-map 合并（详见 [rollup R-07](rollup-0.1.2.md)） |
-| Web Client runtime | 从已删除的 `dsh-client-runtime/client` 导入类型并通过 `useSession` 读取平铺 `nodes[]` | 包不存在；selector 变 `any`；测试仍构造旧数组；Host 命令少一个参数 | 按 owning 包组合类型；用 `useChat` 读取 `order + nodes.get()`；Host `commands.execute` 无图片时显式传 `[]` |
+| Host APIProxy consumer | APIProxy / `executeRemote(...)` | `apiProxy` is gone; mechanically switching to `remote` hangs forever | Skip the Client gateway and directly inject the owning domain service confirmed at the target tag, e.g. `llm` / `settings` |
+| Web Client APIProxy consumer | APIProxy / `executeRemote(...)` | The old package/service is gone; guessing the namespace or method wrong fails assembly | Use the generated `ctx.remote.<namespace>.<method>` and declare `remote` plus the specific namespace injections |
+| Unary failure | Only `try/catch`; parse `message`; `instanceof` | `ok: false` treated as success; misses across bundles; error-code branches stop working | Branch on `result.ok` first, then handle by `result.error.code`; use `isRemoteFailure` only at catch boundaries such as streams/explicit throws |
+| Failure classes | `TypertRemoteFailure` / `TypertLookupFailure` / `RemoteStreamError` | Removed exports or typecheck failures; unprefixed codes no longer match | Owners throw `RemoteError('<domain>/<reason>', message, details)`; details narrow by code |
+| Settings namespace | `settingsNamespace('x')` | `TS2305` / “no exported member” | Use a grammar-conforming string literal directly, e.g. `const NS = 'my-plugin'` |
+| Settings lifecycle | Standalone `installSettingsSection(...)` | Removed export; renaming alone loses the provider attach/detach lifecycle | Call `settingsCtx.settings.installSection(owner, ...)` inside `ctx.inject(['settings'], ...)` |
+| Host facts | Inject `connection` and read the generation snapshot | Coupled to the transport lifecycle; alpha.2 already has a formal entry point | Read `ctx.remote.$host.home/isLoopback`; respond to `connection/reset` on reconnect |
+| SessionEvent | Seeing that alpha.2 restored `ignorable`, directly `Session.append()` custom events | Writes succeed live, but the whole session is refused on cold load because the events have no marker | alpha.2 only restores the envelope field; the public `Session.append()` cannot set it yet, so out-of-repo plugins switch to their own sidecar/store |
+| Headless process | `dsh headless`, `-p`, JSONL stdout, non-empty stderr means failure | argv not accepted, JSON parse fails, successful tasks misreported | `dsh --profile headless "task"`; stdout is the final text, stderr is reasoning/diagnostics, and the exit code is authoritative |
+| Package subpath | Seeing `exports["./src/*"]`, import directly | The published package may not contain `src` at all; runtime module not found | Check exports, `files`, and the actual packed artifact together; prefer stable entry points such as `.` / `/client` |
+| `cordis.patch.yml` | Treat by filename as a source patch | False positives that generate wrong migration tasks | Handle as the official Profile composition overlay first; classify as a source patch only when host source is really replaced |
+| Structured questions answerer | `userQuestions.registerProvider({ ask })` | attach throws `TypeError`; questions go unanswered (`NO_PROVIDER`) | `ctx.on('user-questions/request', (req, next) => answer)`; an `ask()` without an agent dispatches on the service's own ctx, and listeners on other entries of the same fiber tree do not receive it (see [DSH-0.1.2-A1-20](v0.1.2-alpha.1.md)) |
+| Type export drift | `CallId` / `JsonValue` / `collectSessionTitleMessages` / `todo/write` type declarations | typecheck fails in bulk with TS2305 / TS2614 | Migrate per the ledger: `ToolCallId` (dsh-llm root export), `@deepseek-ai/dsh-util-values`, local same-semantics folding, local event-map merging (see [rollup R-11](rollup-0.1.2.md)) |
+| Web Client runtime | Import types from the removed `dsh-client-runtime/client` and read the flat `nodes[]` via `useSession` | Package gone; selectors become `any`; tests still build the old array; Host commands are one argument short | Compose types per owning package; read via `useChat` with `order + nodes.get()`; Host `commands.execute` takes an explicit `[]` when there are no images |
 
-## API-01 · APIProxy 按运行平面迁到领域服务或 `ctx.remote` projection
+## API-01 · APIProxy migrates by runtime plane to domain services or the `ctx.remote` projection
 
-- **适用对象**：直接消费旧 APIProxy 的 Web Client、Host 集成或启动包装层。
-- **会怎么炸**：旧 APIProxy package/service 不再存在。Host 侧把 `apiProxy` 机械替换为
-  `remote` 会永久等待只存在于 Client face 的服务；Web Client 照搬设计笔记中的 wire route
-  又容易写出目标 tag 中不存在的属性，例如 `ctx.remote.sessionTitle.rename`。
-- **核心规则**：先判定运行平面。Host 插件跳过 Client gateway，直接注入旧调用背后的
-  owning domain service；Web Client 才使用目标 tag 生成的 consumer projection，不自己拼
-  `namespace/method` 字符串。alpha.2 的 Client API Remotes assembly 来自
-  `@deepseek-ai/dsh-api-remotes/client`。
+- **Applies to**: Web Client, Host integrations, or startup wrapper layers that consume the old APIProxy directly.
+- **How it breaks**: the old APIProxy package/service no longer exists. On the Host side, mechanically replacing `apiProxy` with `remote` waits forever on a service that only exists on the Client face; a Web Client that copies the wire route from the design notes is likely to write properties that do not exist at the target tag, such as `ctx.remote.sessionTitle.rename`.
+- **Core rule**: determine the runtime plane first. Host plugins skip the Client gateway and directly inject the owning domain service behind the old call; only the Web Client uses the consumer projection generated at the target tag, without assembling `namespace/method` strings itself. On alpha.2, the Client API Remotes assembly comes from `@deepseek-ai/dsh-api-remotes/client`.
 
-### Host / Web Client 最小正确写法
+### Minimal correct patterns for Host / Web Client
 
-Host 侧直接使用 owning domain service；下例的 `llm` / `listProviders()` 已有可执行契约，
-其他旧 APIProxy 调用必须按目标 tag 逐项确认，不能从 Client Remote 表反推：
+The Host side uses the owning domain service directly; in the example below, `llm` / `listProviders()` already has an executable contract, and every other legacy APIProxy call must be confirmed item by item against the target tag — do not reverse-engineer it from the Client Remote table:
 
 ```ts
 export const inject = ['llm']
@@ -108,7 +105,7 @@ export function listHostProviders(ctx) {
 }
 ```
 
-Web Client 侧使用生成 projection：
+The Web Client side uses the generated projection:
 
 ```ts
 import type { Context } from '@deepseek-ai/cordis'
@@ -127,100 +124,83 @@ export async function renameSession(
 }
 ```
 
-这里的实际路径是 `ctx.remote.session.rename(...)`；alpha.1 架构笔记中的
-`sessionTitle/rename` 是设计过程文本，不能凌驾于同一 tag 的实现、生成 projection 和
-consumer 测试。
+The actual path here is `ctx.remote.session.rename(...)`; `sessionTitle/rename` in the alpha.1 architecture notes is design-process text and cannot override the implementation, generated projection, and consumer tests at the same tag.
 
 ### Web Client consumer ledger
 
-下表只适用于 Web Client 的生成 projection。Host 调用必须针对目标 tag 逐项确认 owning
-domain service，不得从本表反推 Host service key 或方法。
+The table below applies only to the Web Client's generated projection. Host calls must confirm the owning domain service item by item against the target tag; do not derive Host service keys or methods from this table.
 
-| rc.2 / 历史 consumer 操作 | alpha.2 consumer projection | 迁移注意点 |
+| rc.2 / legacy consumer operation | alpha.2 consumer projection | Migration notes |
 |---|---|---|
-| `connection.api.sessions.rename({ sessionId, title })` | `ctx.remote.session.rename({ sessionId, title })` | 不存在 `ctx.remote.sessionTitle.rename` |
-| `ctx.remote.commands.list(sessionId)` | 路径不变 | rc.2 已是 Remote；consumer 传 Session id，Host scope 解析 Agent |
-| `ctx.remote.commands.execute(sessionId, line, images)` | 路径不变 | rc.2 已是 Remote；`images` 必传，无图传 `[]` |
-| `connection.api.llm.providers({})` | `ctx.remote.llm.listProviders()` 和 `.listConfigurableProviders()` | 两个调用各自返回 `RemoteResult`，按 provider id 组合 live 与 configurable directory |
-| `llm.discoverModels` | `ctx.remote.llm.discoverModels(settingsNs, request)` | 不写入 settings/credentials；返回候选模型 |
-| `llm.models` | `ctx.remote.session.modelCatalog()` | 从 LLM 域移到 Session 域 |
-| `credentials.describe` | `ctx.remote.credentials.describe(refs)` | 返回描述信息，不返回 secret 值 |
-| `credentials.set/unset` | `ctx.remote.credentials.set(ref, value)` / `.unset(ref)` | secret 只在写入方向过线 |
-| `settings.describe` | `ctx.remote.settings.describe()` | 返回脱敏 namespace view |
-| `settings.update/replace/mutate` | `.update(ns, patch, expectedRevision)` / `.replace(ns, section, expectedRevision)` / `.mutate(ns, ops, expectedRevision)` | 严格 positional；不用 CAS 也显式传 `undefined`，不要整对象覆盖未知字段 |
-| `settings.openDocument` | `ctx.remote.settings.openSettingsDocument(signal)` | native open capability 由 Host 拥有 |
-| `agentPreset.read` | `ctx.remote.agentPresets.read(id)` | consumer 方法名是 `read` |
-| `agentPreset.copy` | `ctx.remote.agentPresets.copy(from, id, name?)` | `name` 可选；成功值是 `void`，旧 APIProxy 返回的 preset id 不再存在 |
-| `connection.api.agentPresets.remove({ agentPreset: id })` | `ctx.remote.agentPresets.deletePreset(id)` | 精确更名为 `deletePreset`，参数也从对象改为字符串 |
-| `agentPreset.openDocument` | `ctx.remote.settings.openAgentPresetDirectory(id, signal)` | 移到 Settings 域 |
-| `subagent.interrupt` | `ctx.remote.subagents.interruptByParent(childId, parentId, 'continuable')` | 保留 durable parent authority |
-| `connection.api.workspace.list({})` | raw：`ctx.remote.workspace.follow(signal)` | 已变为 baseline/delta stream；普通 UI 优先消费 `ctx.workspaces` projection |
-| `workspace.insertSessionBefore` | `ctx.remote.workspace.insertSessionBefore(request)` | unary mutation，处理 `RemoteResult` |
-| `workspace.archiveSession` | `ctx.remote.workspace.archiveSession(request)` | unary mutation，处理 `RemoteResult` |
-| `connection.api.skills.list({ sessionId }, signal)` | `ctx.remote.skills.list({ sessionId }, signal)` | 读取 catalog，不激活 cold Agent |
-| `ctx.remote.fileReferences.list(sessionId, query, signal)` | 路径不变 | rc.2 已是 Remote；owner 移到 Session Controller adapter |
-| `connection.api.host.openPath({ path })` | `ctx.remote.session.openWorkspacePath({ path })` | path 先由 Session-aware client 做 workspace resolution |
-| `connection.hostDescription.getSnapshot()?.home` | `ctx.remote.$host.home` / `.isLoopback` | `$host` 是普通 facts getter，不是 unary RemoteResult |
-| `session.export` | `GET/HEAD /api/session.export` | 流式 Fetch route，不是 JSON Remote；仍受 browser session/Host/Origin 认证 |
+| `connection.api.sessions.rename({ sessionId, title })` | `ctx.remote.session.rename({ sessionId, title })` | `ctx.remote.sessionTitle.rename` does not exist |
+| `ctx.remote.commands.list(sessionId)` | Path unchanged | Already a Remote in rc.2; the consumer passes the Session id, and the Host scope resolves the Agent |
+| `ctx.remote.commands.execute(sessionId, line, images)` | Path unchanged | Already a Remote in rc.2; `images` is required — pass `[]` when there are no images |
+| `connection.api.llm.providers({})` | `ctx.remote.llm.listProviders()` and `.listConfigurableProviders()` | The two calls each return a `RemoteResult`; combine the live and configurable directories by provider id |
+| `llm.discoverModels` | `ctx.remote.llm.discoverModels(settingsNs, request)` | Does not write settings/credentials; returns candidate models |
+| `llm.models` | `ctx.remote.session.modelCatalog()` | Moved from the LLM domain to the Session domain |
+| `credentials.describe` | `ctx.remote.credentials.describe(refs)` | Returns description info, not secret values |
+| `credentials.set/unset` | `ctx.remote.credentials.set(ref, value)` / `.unset(ref)` | Secrets only cross the line in the write direction |
+| `settings.describe` | `ctx.remote.settings.describe()` | Returns a redacted namespace view |
+| `settings.update/replace/mutate` | `.update(ns, patch, expectedRevision)` / `.replace(ns, section, expectedRevision)` / `.mutate(ns, ops, expectedRevision)` | Strictly positional; pass `undefined` explicitly even without CAS; do not overwrite unknown fields with a whole-object replacement |
+| `settings.openDocument` | `ctx.remote.settings.openSettingsDocument(signal)` | The native open capability is owned by the Host |
+| `agentPreset.read` | `ctx.remote.agentPresets.read(id)` | The consumer method name is `read` |
+| `agentPreset.copy` | `ctx.remote.agentPresets.copy(from, id, name?)` | `name` is optional; the success value is `void` — the preset id the old APIProxy returned no longer exists |
+| `connection.api.agentPresets.remove({ agentPreset: id })` | `ctx.remote.agentPresets.deletePreset(id)` | Renamed exactly to `deletePreset`; the argument also changed from an object to a string |
+| `agentPreset.openDocument` | `ctx.remote.settings.openAgentPresetDirectory(id, signal)` | Moved to the Settings domain |
+| `subagent.interrupt` | `ctx.remote.subagents.interruptByParent(childId, parentId, 'continuable')` | Preserves durable parent authority |
+| `connection.api.workspace.list({})` | raw: `ctx.remote.workspace.follow(signal)` | Now a baseline/delta stream; ordinary UI should prefer the `ctx.workspaces` projection |
+| `workspace.insertSessionBefore` | `ctx.remote.workspace.insertSessionBefore(request)` | Unary mutation; handle the `RemoteResult` |
+| `workspace.archiveSession` | `ctx.remote.workspace.archiveSession(request)` | Unary mutation; handle the `RemoteResult` |
+| `connection.api.skills.list({ sessionId }, signal)` | `ctx.remote.skills.list({ sessionId }, signal)` | Reads the catalog without activating a cold Agent |
+| `ctx.remote.fileReferences.list(sessionId, query, signal)` | Path unchanged | Already a Remote in rc.2; the owner moved to the Session Controller adapter |
+| `connection.api.host.openPath({ path })` | `ctx.remote.session.openWorkspacePath({ path })` | The path is first resolved as a workspace by a Session-aware client |
+| `connection.hostDescription.getSnapshot()?.home` | `ctx.remote.$host.home` / `.isLoopback` | `$host` is a plain facts getter, not a unary RemoteResult |
+| `session.export` | `GET/HEAD /api/session.export` | A streaming Fetch route, not a JSON Remote; still subject to browser session/Host/Origin authentication |
 
 ### Best practice
 
-1. 先确认代码运行在哪个 face：Host、Web Client 还是普通 Cordis plugin。
-2. Host 直接注入 owning domain service，不声明只存在于 Client face 的 `remote`；也不要把
-   Host-only package 拉进 Client bundle。
-3. Client contribution 显式声明 `remote` 和实际使用的 `remote.<namespace>`；不要依赖
-   其他插件碰巧先挂载。
-4. 以目标 tag 的 package exports、`.d.ts`、实现和 consumer 测试为准；架构笔记只解释
-   意图，不是生成 API 的替代品。
-5. `workspace.follow` 等 stream 使用 owning package 已提供的 reconnect/snapshot adapter；
-   普通 UI 使用 `ctx.workspaces`，不要自行重写 generation baseline、mutation echo/race 或定时
-   `list()`。
+1. First confirm which face the code runs on: Host, Web Client, or an ordinary Cordis plugin.
+2. The Host directly injects the owning domain service and does not declare `remote`, which only exists on the Client face; do not pull Host-only packages into the Client bundle either.
+3. Client contributions explicitly declare `remote` and the `remote.<namespace>` actually used; do not rely on another plugin having mounted first.
+4. Defer to the target tag's package exports, `.d.ts`, implementation, and consumer tests; architecture notes only explain intent and are not a substitute for the generated API.
+5. For streams such as `workspace.follow`, use the reconnect/snapshot adapter the owning package already provides; ordinary UI uses `ctx.workspaces` and must not reimplement the generation baseline, mutation echo/race handling, or a timed `list()`.
 
-### 按 face 验证
+### Verification by face
 
-Host：
+Host:
 
-- 在固定目标 tag 的真实 Host profile 中验证 entry active、不等待 `remote`，并执行一次对应
-  领域方法；
-- `examples/face-contracts` 只证明注入与控制流边界，不证明 Loader 激活或真实服务装配。
+- In a real Host profile at the pinned target tag, verify the entry is active, does not wait for `remote`, and execute one corresponding domain method;
+- `examples/face-contracts` only proves the injection and control-flow boundary, not Loader activation or real service assembly.
 
-Web Client：
+Web Client:
 
-- typecheck 必须使用真实 `Context` 与生成 projection，不能用 `ctx: any` 掩盖错误路径；
-- 每个 unary 命中至少覆盖 `ok: true` 和一个领域错误码；支持 `AbortSignal` 的调用再覆盖取消；
-- 验证 Remote contribution 未挂载时会明确暴露装配错误，而不是永久 pending；
-- stream 覆盖 opening snapshot、增量、取消、carrier reconnect 与 teardown。
+- Typecheck must use the real `Context` and the generated projection; do not mask error paths with `ctx: any`;
+- Every unary hit covers at least `ok: true` and one domain error code; calls that support `AbortSignal` additionally cover cancellation;
+- Verify that an unmounted Remote contribution surfaces an explicit assembly error instead of hanging forever;
+- Streams cover the opening snapshot, deltas, cancellation, carrier reconnect, and teardown.
 
-- **来源**：
-  [alpha.2 SessionController 实际 Remote 方法](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/api/session-controller/src/index.ts) ·
+- **Source**:
+  [alpha.2 SessionController actual Remote methods](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/api/session-controller/src/index.ts) ·
   [alpha.2 API Remotes Client assembly](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/api/remotes/src/client/index.ts) ·
   [alpha.2 Workspace Remote owner](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/api/workspace-controller/src/index.ts) ·
-  [alpha.2 实际 rename consumer](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/api/session-controller/src/client/sessions/session.ts) ·
-  [本仓库 Host / Web Client face 契约](../examples/face-contracts/README.md)
+  [alpha.2 actual rename consumer](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/api/session-controller/src/client/sessions/session.ts) ·
+  [Host / Web Client face contracts in this repo](../examples/face-contracts/README.md)
 
-## API-02 · `RemoteResult` 版本边界与 alpha.2 `RemoteError`
+## API-02 · `RemoteResult` version boundaries and the alpha.2 `RemoteError`
 
-- **适用对象**：消费 `ctx.remote` 的 Client，以及定义/转发 Remote 的 Host plugin。
-- **会怎么炸**：
-  - 只靠 `catch` 处理业务失败，会把 `{ ok: false }` 当普通成功继续执行；
-  - alpha.1 owner-side wrapper/catch 若继续读取 `error.failure.code`，换成 alpha.2
-    `RemoteError` 后会读到 `undefined`；
-  - `instanceof RemoteError` 跨 bundle、worker 或 realm 会漏判；
-  - 导入 `TypertRemoteFailure`、`TypertLookupFailure` 或 `RemoteStreamError` 会 typecheck
-    失败；
-  - 继续匹配 `internal`、`cancelled`、`session-not-found` 等无域前缀旧 code，会落入
-    default 分支。
+- **Applies to**: Clients that consume `ctx.remote`, and Host plugins that define/forward Remotes.
+- **How it breaks**:
+  - Handling business failures only with `catch` treats `{ ok: false }` as an ordinary success and keeps going;
+  - An alpha.1 owner-side wrapper/catch that still reads `error.failure.code` gets `undefined` after switching to the alpha.2 `RemoteError`;
+  - `instanceof RemoteError` misses across bundles, workers, or realms;
+  - Importing `TypertRemoteFailure`, `TypertLookupFailure`, or `RemoteStreamError` fails typecheck;
+  - Continuing to match unprefixed legacy codes such as `internal`, `cancelled`, or `session-not-found` falls into the default branch.
 
-### 先把版本归属说清楚
+### Version attribution first
 
-`RemoteResult<T>` 在 alpha.1 已经存在：生成的 unary Remote 解析为
-`{ ok: true, value } | { ok: false, error }`。alpha.2 的 breaking change 是统一
-failure vocabulary：`RemoteFailure` 变成按 code 收窄的 `RemoteError` union，code 改为
-`<domain>/<reason>`，并删除旧 wrapper/stream error surface。不要把“开始处理 `result.ok`”
-误写成 alpha.2 才需要做的迁移。Unary consumer 在 alpha.1 就应读 `result.error.code`；变化的
-是 owner/catch 不再透过旧 wrapper 的 `.failure` 读取。
+`RemoteResult<T>` already existed in alpha.1: generated unary Remotes resolve to `{ ok: true, value } | { ok: false, error }`. The alpha.2 breaking change unifies the failure vocabulary: `RemoteFailure` becomes a `RemoteError` union narrowed by code, codes become `<domain>/<reason>`, and the old wrapper/stream error surface is removed. Do not write “start handling `result.ok`” as if it were an alpha.2-only migration. Unary consumers should already read `result.error.code` in alpha.1; what changed is that owners/catches no longer read through the old wrapper's `.failure`.
 
-### Consumer 最新写法
+### Current consumer pattern
 
 ```ts
 const result = await ctx.remote.session.rename({ sessionId, title })
@@ -246,12 +226,9 @@ if (!result.ok) {
 useRenamedSession(result.value)
 ```
 
-普通业务、carrier 与取消失败进入 `ok: false`。arity、未挂载 method、缺 Context adapter
-等装配或本地编程错误仍可能 reject；不要用一个宽泛 catch 把这些缺陷伪装成可重试业务
-错误。
+Ordinary business, carrier, and cancellation failures land in `ok: false`. Assembly or local programming errors — arity, an unmounted method, a missing Context adapter — can still reject; do not use a broad catch to dress those defects up as retryable business errors.
 
-Unary consumer 主动 `throw result.error` 后，或 stream 抛出 terminal Remote failure 时，外层
-catch boundary 使用结构 guard：
+When a unary consumer deliberately `throw`s `result.error`, or a stream throws a terminal Remote failure, the outer catch boundary uses a structural guard:
 
 ```ts
 import { isRemoteFailure } from '@deepseek-ai/dsh-api-gateway/client'
@@ -267,7 +244,7 @@ try {
 }
 ```
 
-### Remote owner 最新写法
+### Current Remote owner pattern
 
 ```ts
 import { RemoteError } from '@deepseek-ai/dsh-typert-protocol'
@@ -287,41 +264,33 @@ throw new RemoteError(
 
 ### Best practice
 
-1. 分支永远读 `code`，不要解析 `message`，不要依赖 class identity。
-2. code 的声明放在每个 producer 都能看到的最低公共 package；命名使用
-   `<domain>/<reason>`。
-3. `gateway/cancelled` 结束或传播取消；`gateway/internal` 和未知码保留原始诊断并上报，
-   默认不重试。
-4. 重试必须同时满足：错误码明确瞬态、操作幂等、用户策略允许。写操作不能因 transport
-   不确定性盲目重放。
-5. 测试 double 使用真实 `RemoteError`/`RemoteResult` 形状，不返回只有 message 的普通
-   object。`RemoteError` 是真实 `Error`，断言 code/details 时优先 `toMatchObject`，不要把它
-   当成旧的普通字面量对象做完全相等比较。
+1. Always branch on `code`; do not parse `message` and do not rely on class identity.
+2. Declare codes in the lowest common package visible to every producer; name them `<domain>/<reason>`.
+3. `gateway/cancelled` ends or propagates cancellation; `gateway/internal` and unknown codes keep the original diagnostics and report them, with no retry by default.
+4. Retry only when all three hold: the error code is explicitly transient, the operation is idempotent, and user policy allows it. Write operations must not be blindly replayed because of transport uncertainty.
+5. Test doubles use the real `RemoteError`/`RemoteResult` shapes and do not return plain objects with only a `message`. `RemoteError` is a real `Error`; when asserting code/details prefer `toMatchObject` — do not treat it as the old plain literal object and compare for exact equality.
 
-### 验证
+### Verification
 
-- Consumer：成功、领域失败、`gateway/cancelled`、`gateway/internal`、未知 code；
-- Owner：code/details 的 module augmentation 能正确收窄；
-- Boundary：显式抛出的 `result.error` 可被 `isRemoteFailure` 识别；普通 Error 原样抛出；
-- 跨 bundle/worker 测试不使用 `instanceof`。
+- Consumer: success, domain failure, `gateway/cancelled`, `gateway/internal`, unknown code;
+- Owner: module augmentation of code/details narrows correctly;
+- Boundary: an explicitly thrown `result.error` is recognized by `isRemoteFailure`; ordinary Errors pass through unchanged;
+- Cross-bundle/worker tests do not use `instanceof`.
 
-- **来源**：
-  [alpha.1 已有的 `RemoteResult<T>` 定义](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/packages/typert/protocol/src/types.ts) ·
-  [alpha.2 RemoteError vocabulary 决策](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/.agents/notes/implemented/architecture/2026-08-28-ctx-remote-failure-vocabulary.md) ·
-  [alpha.2 `RemoteError` 实现](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/typert/protocol/src/remote-error.ts)
+- **Source**:
+  [alpha.1 existing `RemoteResult<T>` definition](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/packages/typert/protocol/src/types.ts) ·
+  [alpha.2 RemoteError vocabulary decision](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/.agents/notes/implemented/architecture/2026-08-28-ctx-remote-failure-vocabulary.md) ·
+  [alpha.2 `RemoteError` implementation](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/typert/protocol/src/remote-error.ts)
 
-## API-03 · Settings helper 移除与 provider-owned lifecycle
+## API-03 · Settings helper removal and provider-owned lifecycle
 
-- **适用对象**：导入 `@deepseek-ai/dsh-settings` 的 Host/settings consumer plugin。
-- **会怎么炸**：
-  - `import { settingsNamespace } ...` 或 `import { installSettingsSection } ...` 报 removed
-    export；
-  - 把 `installSettingsSection(...)` 机械替换成同名 method、却不放在
-    `ctx.inject(['settings'], ...)` 内，会破坏 optional provider attach/detach；
-  - 从 `@deepseek-ai/dsh-settings` 继续导入 `deepEqualJson` 会失败，它已移到
-    `@deepseek-ai/dsh-util-values`。
+- **Applies to**: Host/settings consumer plugins that import `@deepseek-ai/dsh-settings`.
+- **How it breaks**:
+  - `import { settingsNamespace } ...` or `import { installSettingsSection } ...` reports a removed export;
+  - Mechanically replacing `installSettingsSection(...)` with the same-named method without placing it inside `ctx.inject(['settings'], ...)` breaks the optional provider attach/detach;
+  - Continuing to import `deepEqualJson` from `@deepseek-ai/dsh-settings` fails; it moved to `@deepseek-ai/dsh-util-values`.
 
-### 升级前
+### Before the upgrade
 
 ```ts
 import {
@@ -333,7 +302,7 @@ const NS = settingsNamespace('my-plugin')
 installSettingsSection(ctx, NS, Config, config, hooks)
 ```
 
-### 升级后
+### After the upgrade
 
 ```ts
 import type { Context } from '@deepseek-ai/cordis'
@@ -373,40 +342,36 @@ export function apply(ctx: Context, config: Config): void {
 
 ### Best practice
 
-1. namespace 使用小写字母开头，后续只含小写字母、数字和 `-`；字符串字面量在
-   TypeScript 层检查，动态字符串在运行时检查。
-2. 不要用 `as SettingsNamespace` 绕过 grammar；直接传 literal，保留推断。
-3. `owner` 传消费插件自己的 `ctx`，调用 method 的对象是当前 attached
-   `settingsCtx.settings`；两者不是同一个生命周期角色。
-4. `setSource` 保存当前 authoritative getter；provider detach 后 helper 会回退到
-   composition entry。`onChange` 只重建真正依赖配置的注册事实。
-5. 需要 JSON equality/value helpers 时从 owning util package 导入，不依赖 Settings
-   package 的历史顺带导出。
+1. Namespaces start with a lowercase letter and contain only lowercase letters, digits, and `-` after that; string literals are checked at the TypeScript layer, dynamic strings at runtime.
+2. Do not use `as SettingsNamespace` to bypass the grammar; pass a literal directly and keep the inference.
+3. Pass the consuming plugin's own `ctx` as `owner`; the object the method is called on is the currently attached `settingsCtx.settings`. The two are not the same lifecycle role.
+4. `setSource` saves the current authoritative getter; after the provider detaches, the helper falls back to the composition entry. `onChange` only rebuilds registration facts that genuinely depend on the config.
+5. For JSON equality/value helpers, import from the owning util package; do not rely on the Settings package's historical incidental re-exports.
 
-### 验证
+### Verification
 
-- typecheck 不再引用三个旧导出；
-- 合法 literal 注册成功，非法动态 namespace 抛 `TypeError`；
-- settings provider attach 时读取 resolved scope，detach 时回退 composition entry；
-- consumer 自身 unload 后不执行错误 fallback；disposer 和 watcher 不泄漏。
+- Typecheck no longer references the three removed exports;
+- A valid literal registers successfully; an invalid dynamic namespace throws `TypeError`;
+- On settings provider attach, read the resolved scope; on detach, fall back to the composition entry;
+- After the consumer itself unloads, no wrong fallback runs; disposers and watchers do not leak.
 
-- **来源**：
-  [alpha.1 Settings 入口](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/packages/settings/settings/src/index.ts) ·
-  [alpha.2 Settings 入口](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/settings/settings/src/index.ts) ·
-  [alpha.2 官方 Settings README](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/settings/settings/README.md)
+- **Source**:
+  [alpha.1 Settings entry point](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/packages/settings/settings/src/index.ts) ·
+  [alpha.2 Settings entry point](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/settings/settings/src/index.ts) ·
+  [alpha.2 official Settings README](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/settings/settings/README.md)
 
-> 兼容层不等于官方接口：DSH Desktop 当前可能通过本地 compatibility patch 暂时恢复
-> 这些 deprecated helper。插件在 Desktop checkout 内 typecheck/运行通过，不能证明它兼容
-> 未打补丁的官方 alpha.2；迁移与发布验证必须再使用纯官方 package artifact。
+> A compatibility layer is not the official interface: DSH Desktop may currently restore
+> these deprecated helpers temporarily through a local compatibility patch. A plugin that
+> typechecks/runs inside the Desktop checkout does not prove it is compatible with the
+> unpatched official alpha.2; migration and release verification must additionally use the
+> pure official package artifact.
 
-## API-04 · 固定 Host facts 统一到 `ctx.remote.$host`
+## API-04 · Fixed Host facts consolidated on `ctx.remote.$host`
 
-- **适用对象**：Web Client 中只为读取 Host home 或 loopback 状态而注入
-  `connection` 的插件。
-- **会怎么炸**：把 `$host` 反投影到 alpha.1 会 typecheck 失败；在 alpha.2 继续读取
-  generation store 虽可能工作，却让业务 package 依赖 carrier 内部生命周期。
+- **Applies to**: Plugins in the Web Client that inject `connection` only to read the Host home or loopback status.
+- **How it breaks**: back-projecting `$host` to alpha.1 fails typecheck; continuing to read the generation store on alpha.2 may work, but makes business packages depend on the carrier's internal lifecycle.
 
-### alpha.2 写法
+### The alpha.2 pattern
 
 ```ts
 import type { Context } from '@deepseek-ai/cordis'
@@ -429,33 +394,26 @@ export function apply(ctx: Context): void {
 
 ### Best practice
 
-- `$host` 是 identity-stable 的普通 getter，不是 store、没有 subscribe、也没有 generation
-  counter；不要轮询。
-- 需要在重连后重读时响应 `connection/reset`，或依赖 owning domain 自己的 invalidation。
-- alpha.1 compatibility branch 只能用 generation-ready snapshot；不要让 alpha.1 与
-  alpha.2 共用一个未经 feature detection/编译隔离的源文件。
+- `$host` is an identity-stable plain getter — not a store, no subscribe, no generation counter; do not poll it.
+- To re-read after a reconnect, respond to `connection/reset` or rely on the owning domain's own invalidation.
+- An alpha.1 compatibility branch may only use a generation-ready snapshot; do not share one source file between alpha.1 and alpha.2 without feature detection/compile-time isolation.
 
-### 验证
+### Verification
 
-- ready 前 `home === undefined`，ready 后为 Host home；
-- loopback 和 non-loopback carrier 的布尔值正确；
-- 重连只触发一次业务刷新，没有轮询 timer 或重复 listener。
+- Before ready, `home === undefined`; after ready, it is the Host home;
+- The booleans are correct for loopback and non-loopback carriers;
+- A reconnect triggers exactly one business refresh; no polling timer or duplicate listeners.
 
-- **来源**：
-  [alpha.2 Gateway Client `$host` 实现](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/api/gateway/src/client/index.ts) ·
-  [Remote failure vocabulary note 的 Fixed Host facts](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/.agents/notes/implemented/architecture/2026-08-28-ctx-remote-failure-vocabulary.md)
+- **Source**:
+  [alpha.2 Gateway Client `$host` implementation](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/api/gateway/src/client/index.ts) ·
+  [Fixed Host facts in the Remote failure vocabulary note](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/.agents/notes/implemented/architecture/2026-08-28-ctx-remote-failure-vocabulary.md)
 
-## API-05 · `SessionEvent.ignorable` 恢复了，但第三方写入面还没补齐
+## API-05 · `SessionEvent.ignorable` is restored, but the third-party write surface is still incomplete
 
-- **适用对象**：想通过 `SessionEventMap` augmentation + `Session.append()` 持久化插件状态，
-  或实现 persistence/reload/transport 的插件。
-- **会怎么炸**：alpha.2 虽恢复了 event envelope 上的 `ignorable?: true`，公开
-  `Session.append()` 的参数仍只有 `type`、`data`，以及仅 surface event 可用的
-  `SurfaceIntent`；它不会把 `ignorable` 写进事件。仓库外自定义 type 因而可能 live append
-  正常、持久化正常，却在下次 cold load 时抛 `SessionFormatUnsupportedError`，整条 Session
-  拒绝恢复。这是 silent write / loud read，不能靠一次 live smoke 发现。
+- **Applies to**: Plugins that want to persist plugin state via `SessionEventMap` augmentation + `Session.append()`, or that implement persistence/reload/transport.
+- **How it breaks**: alpha.2 restores `ignorable?: true` on the event envelope, but the public `Session.append()` still only accepts `type`, `data`, and `SurfaceIntent`, which is available to surface events only; it will not write `ignorable` into the event. So an out-of-repo custom type can live-append and persist fine, yet throw `SessionFormatUnsupportedError` on the next cold load, refusing to restore the whole Session. This is a silent write / loud read that one live smoke cannot catch.
 
-### 危险旧写法
+### The dangerous legacy pattern
 
 ```ts
 declare module '@deepseek-ai/dsh-session/types' {
@@ -468,228 +426,185 @@ declare module '@deepseek-ai/dsh-session/types' {
 session.append('my-plugin/state', { value: 'x' })
 ```
 
-`ignorable` 的 envelope 语义本身仍然有效：reader 遇到不认识的 type 时，只有该事件已经
-带 `ignorable: true` 才允许继续；字段缺失意味着 required。问题是 alpha.2 尚未给普通
-第三方 producer 提供受支持的 append/registration surface，不能通过 cast、解冻对象或手改
-JSONL 绕过去。
+The envelope semantics of `ignorable` itself are still in effect: when a reader meets an unknown type, it may continue only if that event already carries `ignorable: true`; a missing field means required. The problem is that alpha.2 does not yet offer ordinary third-party producers a supported append/registration surface, and it cannot be bypassed with casts, thawing objects, or hand-editing JSONL.
 
 ### Best practice
 
-1. 仓库外插件在 alpha.2 不要用自定义 `SessionEventMap` + `Session.append()` 持久化状态；
-   使用插件自有 sidecar/store，并按 Session id 关联。
-2. 能复用已有已知 event 时只复用真实相同的语义；不要把插件状态伪装成 model-visible 或
-   core event。
-3. `ignorable: true` 只适合“没有该插件的 reader 不解释此 type，仍能正确重建 Session”的
-   附加信息。插件存在时可以消费它；但它的缺席不能改变 core/durable Session 语义。
-4. persistence/transport owner 必须端到端保留已存在的 marker；未知且无 marker 的事件继续
-   fail closed。
-5. 只有上游提供受支持的 `append(..., { ignorable: true })`，或另一种能把 omission-safety
-   marker 持久化、且不依赖当前 composition 才能判定兼容性的正式机制后，才重新评估第三方
-   持久事件。仅注册 event name 不够；不要把字段恢复写成该能力已经交付。
+1. On alpha.2, out-of-repo plugins should not persist state with a custom `SessionEventMap` + `Session.append()`; use a plugin-owned sidecar/store keyed by Session id.
+2. When reusing an existing known event, reuse only its real, identical semantics; do not disguise plugin state as a model-visible or core event.
+3. `ignorable: true` fits only auxiliary information where a reader without that plugin does not interpret the type and can still rebuild the Session correctly. Consumers may use it when the plugin is present, but its absence must not change core/durable Session semantics.
+4. Persistence/transport owners must preserve existing markers end-to-end; unknown events without a marker keep failing closed.
+5. Re-evaluate third-party persistent events only after upstream ships a supported `append(..., { ignorable: true })` or another formal mechanism that persists the omission-safety marker and decides compatibility without depending on the current composition. Registering an event name alone is not enough; do not write up the field restoration as if that capability had shipped.
 
-### 验证
+### Verification
 
-- 对任何现有自定义 append 做真正的 persist → process restart/cold load 测试，不能只测 live
-  append；
-- alpha.2 仓库外插件若命中这一路径，应把 cold-load refusal 当成迁移阻断并撤掉该持久化
-  方案，而不是接受或吞掉错误；
-- persistence/transport owner 仍需覆盖“已有 marker 的未知 event 可读”和“无 marker 的未知
-  required event 明确拒绝”。
+- For any existing custom append, run a real persist → process restart/cold load test; do not test only live append;
+- If an out-of-repo plugin on alpha.2 hits this path, treat the cold-load refusal as a migration blocker and remove that persistence scheme rather than accepting or swallowing the error;
+- Persistence/transport owners still need to cover “unknown events with a marker are readable” and “unknown required events without a marker are explicitly refused”.
 
-- **来源**：
-  [alpha.2 `SessionEvent` 类型](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/core/session/src/types.ts) ·
-  [alpha.2 `Session.append()` 实现](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/core/session/src/index.ts) ·
+- **Source**:
+  [alpha.2 `SessionEvent` type](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/core/session/src/types.ts) ·
+  [alpha.2 `Session.append()` implementation](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/core/session/src/index.ts) ·
   [cold-load unknown event guard](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/session/session-persistence/src/coordinator.ts) ·
-  [恢复 ignorable 的实现决策](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/.agents/notes/implemented/architecture/2026-08-30-retain-ignorable-external-session-events.md)
+  [implementation decision restoring ignorable](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/.agents/notes/implemented/architecture/2026-08-30-retain-ignorable-external-session-events.md)
 
-## API-06 · Headless 的 argv 与进程输出契约
+## API-06 · The Headless argv and process output contract
 
-- **适用对象**：CLI wrapper、CI runner、subprocess bridge、stdout/stderr parser。
-- **会怎么炸**：
-  - `dsh headless ...`、`dsh --profile headless -p ...` 不是目标版本的命令形状；
-  - 对 stdout 做 `JSON.parse` 会在普通最终文本上失败；
-  - “stderr 非空即失败”会把含 reasoning 的成功执行误报为失败；
-  - 忽略退出码会把无完成回合或直接启动失败当成功。
+- **Applies to**: CLI wrappers, CI runners, subprocess bridges, stdout/stderr parsers.
+- **How it breaks**:
+  - `dsh headless ...` and `dsh --profile headless -p ...` are not command shapes of the target version;
+  - `JSON.parse` on stdout fails on ordinary final text;
+  - Treating any non-empty stderr as failure misreports successful runs that contain reasoning;
+  - Ignoring the exit code treats runs with no completed turn or direct startup failures as success.
 
-### 正确调用与解释
+### Correct invocation and interpretation
 
 ```sh
 dsh --profile headless "run the tests"
 ```
 
-Launcher flags 必须放在 task 之前；第一个非 launcher token 之后的内容属于 app/task：
+Launcher flags must come before the task; everything after the first non-launcher token belongs to the app/task:
 
 ```sh
 dsh --profile headless --patch ./plugin.patch.yml "verify the plugin"
 ```
 
-不要写成 `dsh --profile headless "verify the plugin" --patch ...`，否则 `--patch` 会进入 task
-文本，而不是 composition overlay。
+Do not write `dsh --profile headless "verify the plugin" --patch ...`; `--patch` would then go into the task text instead of being a composition overlay.
 
-| 通道 | alpha.2 契约 |
+| Channel | alpha.2 contract |
 |---|---|
-| stdout | 最终 assistant 文本；不是 JSONL，不含中间 tool output |
-| stderr | 非空 reasoning delta 以 `dsh: reasoning:` 开头；失败为 `dsh: <code>: <message>` |
-| exit 0 | task 完成 |
-| exit 1 | abort、error 或没有完成回合 |
+| stdout | Final assistant text; not JSONL, no intermediate tool output |
+| stderr | Non-empty reasoning deltas start with `dsh: reasoning:`; failures are `dsh: <code>: <message>` |
+| exit 0 | Task completed |
+| exit 1 | Abort, error, or no completed turn |
 
-另外，`SIGINT` 映射为 130；alpha.2 supervisor 将 `SIGTERM` 的普通停止映射为 0。调用方仍应
-记录终止 signal，不要只看 stderr 文本猜测状态。`--dump-config` 是不启动 app 的 composition
-检查，不能同时携带 task/app args。
+Also, `SIGINT` maps to 130; the alpha.2 supervisor maps an ordinary `SIGTERM` stop to 0. Callers should still record the termination signal instead of guessing the state from stderr text alone. `--dump-config` is a composition check that does not start the app and cannot carry task/app args.
 
 ### Best practice
 
-1. 使用 argv 数组和 `spawn`/`execFile`，不要 shell 拼接用户 task。
-2. 退出码是成功判据；stderr 是受控的 reasoning/诊断流。reasoning 可能敏感，明确日志
-   retention 与访问范围。
-3. 同时消费 stdout/stderr，处理取消、signal、spawn error 和 teardown；不要等进程结束后
-   才读取可能塞满的 pipe。
-4. 默认验证用 stub subprocess，不要求真实 API key 或模型调用。
+1. Use argv arrays with `spawn`/`execFile`; do not shell-concatenate a user task.
+2. The exit code is the success criterion; stderr is the controlled reasoning/diagnostic stream. Reasoning can be sensitive — state log retention and access scope explicitly.
+3. Consume stdout and stderr concurrently; handle cancellation, signals, spawn errors, and teardown. Do not wait for process exit before reading pipes that may fill up.
+4. Default verification uses a stub subprocess and does not require a real API key or model calls.
 
-### 最小 stub 矩阵
+### Minimal stub matrix
 
-| 场景 | stdout | stderr | exit | 预期 |
+| Scenario | stdout | stderr | exit | Expected |
 |---|---|---|---:|---|
-| 普通成功 | final text | empty | 0 | 成功 |
-| reasoning 成功 | final text | `dsh: reasoning: ...` | 0 | 成功，reasoning 单独展示/记录 |
-| task 失败 | empty 或换行 | `dsh: <code>: ...` | 1 | 失败 |
-| spawn error | none | local diagnostic | 无 | wrapper 报启动失败并 teardown |
+| Ordinary success | final text | empty | 0 | success |
+| Reasoning success | final text | `dsh: reasoning: ...` | 0 | success; reasoning shown/logged separately |
+| Task failure | empty or newline | `dsh: <code>: ...` | 1 | failure |
+| Spawn error | none | local diagnostic | none | wrapper reports startup failure and tears down |
 
-- **来源**：
+- **Source**:
   [alpha.2 Headless README](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/bundle/headless/README.md) ·
   [rc.2 Headless README](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.1-rc.2/packages/bundle/headless/README.md)
 
-## API-07 · Package export 不等于发布物存在
+## API-07 · Package export ≠ artifact presence
 
-- **适用对象**：从 `@deepseek-ai/*/src/*`、`/internal` 或其他深层 subpath 导入的插件。
-- **会怎么炸**：仅检查 source checkout 的 `package.json#exports`，可能认为路径公开可用；
-  但实际 registry tarball 不含目标文件，安装后出现 `ERR_MODULE_NOT_FOUND`、bundler
-  resolution failure 或缺少 `.d.ts`。
+- **Applies to**: Plugins that import from `@deepseek-ai/*/src/*`, `/internal`, or other deep subpaths.
+- **How it breaks**: checking only the source checkout's `package.json#exports` can make a path look publicly available, but the actual registry tarball does not contain the target file, so after installation you get `ERR_MODULE_NOT_FOUND`, a bundler resolution failure, or missing `.d.ts`.
 
-alpha.2 的 `@deepseek-ai/dsh-client-ui-conversation` 是一个典型风险信号：export map
-包含 `"./src/*": "./src/*"`，但 `files` 只列出 `lib/index.js`、`lib/invariant.js`、
-`lib/client.js` 与 `lib/types/**/*.d.ts`。因此“export map 里有”本身不能证明 registry
-artifact 可解析 raw source subpath。
+The alpha.2 `@deepseek-ai/dsh-client-ui-conversation` is a typical risk signal: its export map contains `"./src/*": "./src/*"`, but `files` lists only `lib/index.js`, `lib/invariant.js`, `lib/client.js`, and `lib/types/**/*.d.ts`. So “it is in the export map” by itself does not prove the registry artifact resolves a raw source subpath.
 
-| 断裂边界 | 典型症状 |
+| Break boundary | Typical symptom |
 |---|---|
-| 文件物理存在，但 subpath 未进入 `exports` | `ERR_PACKAGE_PATH_NOT_EXPORTED` |
-| `exports` 声明了 target，但 target 未进入 tarball | `ERR_MODULE_NOT_FOUND` |
-| runtime `.js` 存在，但对应 types target / `.d.ts` 缺失 | TypeScript 或 bundler type-resolution failure |
-| manifest 声明 `dsh.bundle.patch`，但 patch 未进入 tarball | 安装可被识别，Loader/dump 读取 overlay 时以缺文件失败 |
+| File physically exists, but the subpath is not in `exports` | `ERR_PACKAGE_PATH_NOT_EXPORTED` |
+| `exports` declares the target, but the target did not make it into the tarball | `ERR_MODULE_NOT_FOUND` |
+| Runtime `.js` exists, but the matching types target / `.d.ts` is missing | TypeScript or bundler type-resolution failure |
+| Manifest declares `dsh.bundle.patch`, but the patch did not make it into the tarball | The install is recognized, but the Loader/dump fails with a missing file when reading the overlay |
 
 ### Best practice
 
-1. 证据顺序：目标已安装/packed artifact → 目标 tag 的 exports 与声明类型 → 目标实现与
-   测试 → release notes/历史说明。
-2. 优先使用 `.`、`/client`、`/types`、`/remote` 等 package owner 明确维护的入口。
-3. 必须保留 raw source seam 时，固定精确目标版本，检查 pack file list，并把它视为高波动
-   coupling；不能因为带 `src` 就自动判私有，也不能因为 export map 存在就判可发布。
-4. typecheck 和 source checkout build 通过后，还要从实际 tarball/安装目录做一次 package
-   smoke。
+1. Evidence order: installed/packed artifact of the target → exports and declared types at the target tag → target implementation and tests → release notes/historical notes.
+2. Prefer entry points the package owner explicitly maintains, such as `.`, `/client`, `/types`, `/remote`.
+3. When a raw source seam must be kept, pin the exact target version, check the pack file list, and treat it as a high-volatility coupling; do not automatically call something private because it has `src`, nor publishable because an export map exists.
+4. After typecheck and a source-checkout build pass, also run one package smoke against the actual tarball/install directory.
 
-### 验证
+### Verification
 
-- 构建前检查 `package.json#exports` 与 `files`；
-- 用仓库既有包管理器生成 pack 清单（例如先审计构建需求，再运行
-  `npm pack --dry-run --json --ignore-scripts`）；未知 lifecycle script 未经授权不执行；
-- 从干净临时目录安装/解析实际 artifact，验证 runtime JS 与 `.d.ts` 均存在；
-- 若 manifest 声明 `dsh.bundle.patch`，逐项确认目标 patch 也在 pack 清单和 tarball 中；
-- 不在迁移中顺手把 package manager 或 lockfile 换掉。
+- Check `package.json#exports` and `files` before building;
+- Generate a pack manifest with the repository's existing package manager (for example, audit build requirements first, then run `npm pack --dry-run --json --ignore-scripts`); unknown lifecycle scripts are not executed without authorization;
+- Install/resolve the actual artifact from a clean temp directory and verify that both the runtime JS and `.d.ts` exist;
+- If the manifest declares `dsh.bundle.patch`, verify item by item that the target patch is also in the pack manifest and the tarball;
+- Do not switch the package manager or lockfile as a side effect of the migration.
 
-- **来源**：
+- **Source**:
   [alpha.2 ui-conversation package manifest](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/client/ui-conversation/package.json)
 
-## API-08 · `cordis.patch.yml` 是 composition，不是源码 patch
+## API-08 · `cordis.patch.yml` is composition, not a source patch
 
-- **适用对象**：扫描 `patch`、`patch.yml`、`cordis.patch.yml` 或 Loader row 的迁移工具。
-- **会怎么炸**：仅按文件名把正常 Profile composition 判为 monkey/source patch，随后要求
-  rebase 不存在的源码 hunk、删除有效 bundle row，或错误修改宿主源码。
+- **Applies to**: Migration tools that scan `patch`, `patch.yml`, `cordis.patch.yml`, or Loader rows.
+- **How it breaks**: judging a normal Profile composition as a monkey/source patch by filename alone leads to rebasing source hunks that do not exist, deleting valid bundle rows, or wrongly modifying host source.
 
 ### Best practice
 
-1. `cordis.patch.yml` 默认按 DSH Profile/Bundle 的官方 Loader composition overlay 分类。
-2. 只有出现真实 diff、`patch-package`/`patchedDependencies`、替换宿主实现、直接写发布
-   artifact 等证据时，才进入“源码 patch”迁移。
-3. composition 迁移核对 row、id、inject、config replacement 语义；源码 patch 迁移核对
-   target file、semantic marker、合成结果和行为测试。两者用不同验证路径。
-4. 作为 Bundle 发布时，manifest 的 `dsh.bundle.patch` 必须指向安全的包内相对路径，且该
-   `cordis.patch.yml` 必须真的进入 packed artifact；Node `exports` 不能替代这条边界。
-5. patch row 命中已有 `id` 时，`config` 是整个 replacement，不是 deep merge；后置 layer
-   覆盖前置 layer，因此要重写所有仍需保留的配置字段。
+1. Classify `cordis.patch.yml` by default as the official Loader composition overlay for a DSH Profile/Bundle.
+2. Only enter the “source patch” migration when there is evidence such as a real diff, `patch-package`/`patchedDependencies`, a replaced host implementation, or direct writes to published artifacts.
+3. Composition migrations check row, id, inject, and config-replacement semantics; source-patch migrations check the target file, semantic markers, the composed result, and behavior tests. The two use different verification paths.
+4. When publishing as a Bundle, the manifest's `dsh.bundle.patch` must point to a safe in-package relative path, and that `cordis.patch.yml` must actually make it into the packed artifact; Node `exports` cannot replace this boundary.
+5. When a patch row matches an existing `id`, `config` is the whole replacement, not a deep merge; later layers override earlier ones, so rewrite every config field that must be kept.
 
-alpha.2 的 composition 优先级从低到高是：
+On alpha.2, composition precedence, from lowest to highest, is:
 
-1. Profile manifest 的 `dsh.profile.bundles` 所列 bundle patches（按列表顺序）；
-2. `$DSH_HOME/profiles/<name>/cordis.patch.yml`；
-3. `$DSH_HOME/cordis.patch.yml`；
-4. CLI 中按 argv 顺序提供的 `--patch` overlays。
+1. Bundle patches listed in the Profile manifest's `dsh.profile.bundles` (in list order);
+2. `$DSH_HOME/profiles/<name>/cordis.patch.yml`;
+3. `$DSH_HOME/cordis.patch.yml`;
+4. `--patch` overlays given on the CLI in argv order.
 
-后层胜于前层。这解释了为什么迁移某个高层 row 时必须先看完整 composed result，而不能只看
-它自己的 YAML 片段。
+Later layers win over earlier ones. That is why migrating a high-level row requires looking at the full composed result first, not just its own YAML snippet.
 
-### 验证
+### Verification
 
-- 普通 `cordis.patch.yml` fixture 必须能被扫描器标成 public/negative control；
-- 真正的 `.patch`/source replacement 能被识别并分类为 clean apply、needs rebase、
-  upstreamed-remove 或 obsolete/conflicting；
-- `npm pack --dry-run --json --ignore-scripts` 或等价 no-scripts pack 清单确认 manifest 指向的
-  patch 实际存在；
-- 用隔离 Profile 执行 `dsh --profile <name> --dump-config`，核对 layer、row id/name、whole-config
-  replacement 与 unmatched-target diagnostics，不启动 GUI 或模型；
-- 不以命中数量决定风险。
+- An ordinary `cordis.patch.yml` fixture must be labeled a public/negative control by the scanner;
+- Real `.patch`/source replacements are recognized and classified as clean apply, needs rebase, upstreamed-remove, or obsolete/conflicting;
+- An `npm pack --dry-run --json --ignore-scripts` or equivalent no-scripts pack manifest confirms that the patch the manifest points to actually exists;
+- Run `dsh --profile <name> --dump-config` with an isolated Profile and check layers, row id/name, whole-config replacement, and unmatched-target diagnostics, without starting the GUI or a model;
+- Do not decide risk by hit count.
 
-- **来源**：
-  [alpha.2 Headless bundle 的 `cordis.patch.yml` 定位](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/bundle/headless/README.md) ·
-  [官方插件发布与 patch composition 文档](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/docs/user/develop/basic/publish.md) ·
+- **Source**:
+  [cordis.patch.yml placement in the alpha.2 Headless bundle](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/bundle/headless/README.md) ·
+  [official plugin publishing and patch composition docs](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/docs/user/develop/basic/publish.md) ·
   [alpha.2 CLI Profile/Bundle layer reference](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/apps/cli/reference/README.md)
 
-## API-09 · Plugin inventory 新增可选 `agentPresets`
+## API-09 · Plugin inventory gains an optional `agentPresets`
 
-- **适用对象**：消费 `pluginInventory/list`、序列化 `PluginInventorySnapshot`，或使用严格
-  closed schema 的 Client plugin。
-- **会怎么炸**：拒绝未知字段的 decoder 会在 alpha.2 收到 `agentPresets` 时失败；手工
-  重建整对象又可能静默丢掉该字段及未来扩展。
+- **Applies to**: Client plugins that consume `pluginInventory/list`, serialize `PluginInventorySnapshot`, or use a strict closed schema.
+- **How it breaks**: a decoder that rejects unknown fields fails when alpha.2 sends `agentPresets`; hand-rebuilding the whole object can silently drop that field and future extensions.
 
 ### Best practice
 
-- 把 `agentPresets` 当 optional 字段；缺失时保持旧 `entries` view。
-- 需要显示 preset 分组时再解析 `trust`、rows 与 `boolean | 'conditional'` enablement。
-- decoder 对新增字段前向兼容，业务写回只 patch 自己拥有的路径，不整对象覆盖。
+- Treat `agentPresets` as an optional field; when absent, keep the old `entries` view.
+- Only parse `trust`, rows, and `boolean | 'conditional'` enablement when preset grouping needs to be displayed.
+- Decoders stay forward-compatible with new fields; business writes back only patch the paths they own instead of overwriting the whole object.
 
-### 验证
+### Verification
 
-- 无 preset roster 时字段可缺失；
-- 多 preset、conditional row 能解析；
-- 旧 entries 行为不变，round-trip 不丢未知字段。
+- The field may be absent when there is no preset roster;
+- Multiple presets and conditional rows parse;
+- The old `entries` behavior is unchanged, and round-trips do not drop unknown fields.
 
-- **来源**：
-  [alpha.2 PluginInventorySnapshot 类型](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/host/plugin-inventory/src/types.ts)
+- **Source**:
+  [alpha.2 PluginInventorySnapshot type](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/host/plugin-inventory/src/types.ts)
 
-## API-10 · Web Client runtime 拆包、keyed chat snapshot 与命令附件参数
+## API-10 · Web Client runtime unbundling, keyed chat snapshots, and command attachment parameters
 
-- **适用对象**：仍依赖 `@deepseek-ai/dsh-client-runtime/client`、消费会话 transcript、扩展
-  chat command row，或直接调用 Host `ctx.commands.execute` 的插件源码仓。
-- **会怎么炸**：alpha.1 起 `dsh-client-runtime` 已删除。只把 `ClientContext` 改成 Cordis
-  `Context` 仍不够：合并到 Context 的 client facets 由各 owning 包提供；缺直接类型依赖时，
-  `skipLibCheck: true` 可能把 `useChat` selector 或回调参数悄悄传播成 `any`。alpha.2
-  `ChatSnapshot.nodes` 是 keyed store，不是旧 `ConversationNode[]`；Host 命令执行又在
-  `line` 与 `signal` 之间增加了 image attachments。
+- **Applies to**: Plugin source repositories that still depend on `@deepseek-ai/dsh-client-runtime/client`, consume session transcripts, extend chat command rows, or call the Host `ctx.commands.execute` directly.
+- **How it breaks**: `dsh-client-runtime` has been removed since alpha.1. Changing `ClientContext` to the Cordis `Context` alone is not enough: the client facets merged into Context come from their owning packages; without direct type dependencies, `skipLibCheck: true` can silently propagate `useChat` selectors or callback parameters to `any`. On alpha.2, `ChatSnapshot.nodes` is a keyed store, not the old `ConversationNode[]`; Host command execution also gained image attachments between `line` and `signal`.
 
-### 精确映射
+### Exact mapping
 
-| rc / runtime 聚合面 | alpha.2 owning 面 |
+| rc / runtime aggregation surface | alpha.2 owning surface |
 |---|---|
-| `ClientContext` | `Context` from `@deepseek-ai/cordis`，再按实际使用 import owning package 的 `type {}` augmentation |
+| `ClientContext` | `Context` from `@deepseek-ai/cordis`, plus `type {}` augmentations imported from owning packages per actual use |
 | `SessionId` | `@deepseek-ai/dsh-session/types` |
 | `ConversationNode` | `@deepseek-ai/dsh-client-ui-conversation/client` |
 | `CommandRowProps` | `@deepseek-ai/dsh-client-ui-chat/client` |
 | `useSession(session => session?.nodes)` | `useChat(chat => ...)` |
-| `ConversationSnapshot.nodes[]` | `ChatSnapshot.order` 保序遍历，逐 id 调 `snapshot.nodes.get(id)` |
-| `ctx.commands.execute(agent, line, signal)` | `ctx.commands.execute(agent, line, [], signal)`；有图时传真实 attachments |
+| `ConversationSnapshot.nodes[]` | Iterate `ChatSnapshot.order` in order, calling `snapshot.nodes.get(id)` per id |
+| `ctx.commands.execute(agent, line, signal)` | `ctx.commands.execute(agent, line, [], signal)`; pass real attachments when there are images |
 
-`snapshot.legacy.nodes` 只适合有明确双宿主需求的分阶段兼容，不应成为 alpha.2-only
-插件的新主数据面。alpha.2-only 的最小读取形态：
+`snapshot.legacy.nodes` is only for staged compatibility with an explicit dual-host requirement; it should not become the new primary data surface for alpha.2-only plugins. The minimal read shape for alpha.2-only:
 
 ```ts
 import type { Context } from '@deepseek-ai/cordis'
@@ -709,62 +624,49 @@ export function useOrderedNodes(ctx: Context) {
 }
 ```
 
-读取 assistant step 最终节点时，按 discriminant 收窄到 `type === 'assistant-step'` 后读取
-`data.finalNode`；不要在测试里用 `as unknown as ChatSnapshot` 掩盖旧数组夹具。
+To read an assistant step's final node, narrow by discriminant to `type === 'assistant-step'` and then read `data.finalNode`; do not mask old array fixtures in tests with `as unknown as ChatSnapshot`.
 
-### 类型组合与依赖所有权
+### Type composition and dependency ownership
 
-1. `dsh.client.inject` 只写运行时真正需要宿主注入的 client services；删掉已不存在的
-   `dsh-client-runtime`。
-2. 源码直接 import/消费的声明所有者必须是插件自己的 direct dev/peer dependency。发布包的
-   `devDependencies` 不会传递安装给 consumer；例如 ui-chat 的声明会引用
-   `dsh-client-store`、ui primitives、session/commands/conversation 等类型。
-3. 用 type-only import 激活 Context augmentation，并只补实际命中的 owning 包；不要靠旧
-   runtime 聚合包或偶然 hoist。
-4. 首次迁移至少跑一次 `tsc --skipLibCheck false`（或等价临时配置）定位缺失声明链，再恢复
-   仓库既有策略。任何新增 implicit `any` 都是迁移失败，不是可忽略 warning。
+1. List only the client services the runtime actually needs injected by the host in `dsh.client.inject`; remove the no-longer-existing `dsh-client-runtime`.
+2. The owner of any declaration the source directly imports/consumes must be the plugin's own direct dev/peer dependency. A published package's `devDependencies` are not transitively installed for consumers; for example, ui-chat's declarations reference types from `dsh-client-store`, ui primitives, session/commands/conversation, and so on.
+3. Activate Context augmentation with type-only imports and add only the owning packages actually hit; do not rely on the old runtime aggregation package or accidental hoisting.
+4. On first migration, run `tsc --skipLibCheck false` (or an equivalent temporary config) at least once to locate the missing declaration chain, then restore the repository's existing policy. Any newly introduced implicit `any` is a migration failure, not an ignorable warning.
 
-### 验证
+### Verification
 
-- lockfile 不含旧 cohort 或 `dsh-client-runtime`；所有 DSH packages 落在精确目标 cohort；
-- `skipLibCheck: false` 诊断无缺声明，正式 typecheck/build 通过且无新增 implicit `any`；
-- client tests 用真实 `ChatNodeStore` 形状（`order` + keyed `get`），覆盖缺失 id 和 assistant
-  final node；Host command test 断言第三参 images（无图为 `[]`）；
-- pack 后核对 tarball 名和 manifest 的插件自身版本，再在隔离 profile 做 Web token→Cookie、
-  boot entry、公告资源、注册/挂载、remove 全链路。
+- The lockfile contains no old cohort or `dsh-client-runtime`; all DSH packages land on the exact target cohort;
+- `skipLibCheck: false` diagnostics show no missing declarations; the formal typecheck/build passes with no new implicit `any`;
+- Client tests use the real `ChatNodeStore` shape (`order` + keyed `get`), covering missing ids and the assistant final node; the Host command test asserts the third-argument images (`[]` when there are none);
+- After packing, check the tarball name and the plugin's own version in the manifest, then run the full Web chain in an isolated profile: token→Cookie, boot entry, advertised resources, registration/mount, and remove.
 
-**来源**：[rc.2 runtime 聚合导出](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.1-rc.2/packages/client/runtime/src/client/index.ts) · [alpha.2 ChatSnapshot / ChatNodeStore](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/client/ui-chat/src/client/contract/snapshot.ts) · [alpha.2 `useChat` 与 `CommandRowProps`](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/client/ui-chat/src/client/contract/slots.ts) · [alpha.2 client slot 基础 Context augmentation](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/client/ui-slots/src/index.ts) · [alpha.2 Host commands `execute`](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/interaction/commands/src/index.ts) · [alpha.2 ui-chat package declarations](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/client/ui-chat/package.json)
+**Source**: [rc.2 runtime aggregation exports](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.1-rc.2/packages/client/runtime/src/client/index.ts) · [alpha.2 ChatSnapshot / ChatNodeStore](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/client/ui-chat/src/client/contract/snapshot.ts) · [alpha.2 `useChat` and `CommandRowProps`](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/client/ui-chat/src/client/contract/slots.ts) · [alpha.2 client slot base Context augmentation](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/client/ui-slots/src/index.ts) · [alpha.2 Host commands `execute`](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/interaction/commands/src/index.ts) · [alpha.2 ui-chat package declarations](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/client/ui-chat/package.json)
 
-## CFG-01 · Code Mode 精确迁到 PTC mode
+## CFG-01 · Code Mode migrated exactly to PTC mode
 
-- **适用对象**：读取 tool presentation mode、preset id、dispatch 类型或 prompt rule 的
-  插件/包装器。
-- **会怎么炸**：`tools.mode: 'code'`、preset `code`、`CodeDispatch*` 或
-  `tools:code-only` 不再匹配；全局替换 `code` 又会破坏 `run_code`、参数名与历史事件。
+- **Applies to**: Plugins/wrappers that read the tool presentation mode, preset id, dispatch type, or prompt rules.
+- **How it breaks**: `tools.mode: 'code'`, preset `code`, `CodeDispatch*`, or `tools:code-only` no longer match; a global replace of `code` would also break `run_code`, parameter names, and historical events.
 
-### 精确 ledger
+### Exact ledger
 
-| 旧值 | 新值 |
+| Old value | New value |
 |---|---|
 | `tools.mode: 'code'` | `tools.mode: 'ptc'` |
-| preset id/目录 `code` | `ptc` |
+| preset id/directory `code` | `ptc` |
 | `tools/code-dispatch-log` | `tools/ptc-dispatch-log` |
 | `CodeDispatch*` | `PtcDispatch*` |
 | `tools:code-only` | `tools:ptc-only` |
-| UI 文案 `Code Mode` | `PTC mode` / `PTC 模式` |
+| UI copy `Code Mode` | `PTC mode` / `PTC 模式` |
 
-保持不变：`run_code`、它的 `code` 参数、`CodeSdkLanguage`、`CodeRunFailedError`、
-`dsh-code-runtime*` package、持久事件 `tool/code-dispatch*`、`tools-code-mode` plugin name
-和 sub-call id 中的 `:code:`。
+Unchanged: `run_code`, its `code` parameter, `CodeSdkLanguage`, `CodeRunFailedError`, the `dsh-code-runtime*` packages, the persistent `tool/code-dispatch*` events, the `tools-code-mode` plugin name, and `:code:` in sub-call ids.
 
-- **验证**：目标配置接受新值；旧 Session 日志仍可加载；剩余旧词都能解释为明确保留，
-  没有盲目全局替换。
-- **来源**：
+- **Verification**: the target configuration accepts the new values; old Session logs still load; every remaining legacy token is explainable as an explicit keep, with no blind global replace.
+- **Source**:
   [alpha.1 PTC rename ledger](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/.agents/notes/implemented/architecture/2026-08-25-rename-code-mode-to-ptc.md)
 
-## Skill 输出这类迁移报告时应使用的结构
+## Structure the skill should use for this kind of migration report
 
-不要只输出“需要升级 API”。每个真实命中至少给出下列字段：
+Do not just output “the API needs upgrading”. For every real hit, provide at least the following fields:
 
 ```markdown
 ### <接口名>
@@ -778,26 +680,21 @@ export function useOrderedNodes(ctx: Context) {
 - 一手来源：<目标 tag 的 exports/type/source/test URL>
 ```
 
-最终汇总表：
+Final summary table:
 
-| 命中位置 | 旧接口 | 典型症状 | 目标接口 | 必须改 / 条件改 | 验证状态 |
+| Hit location | Old interface | Typical symptom | Target interface | Required / conditional change | Verification status |
 |---|---|---|---|---|---|
 |  |  |  |  |  |  |
 
-如果目标 tag 的实际类型与本文冲突，必须以目标 tag 为准并把冲突标为知识库缺口；不要
-为了“套卡片”而把可编译代码改坏。
+If the actual types at the target tag conflict with this document, the target tag wins and the conflict must be flagged as a knowledge-base gap; do not break compilable code just to “fit a card”.
 
-## 最小验证梯度
+## Minimal validation ladder
 
-1. **静态 inventory**：精确 package/resolved version、imports、exports、removed symbol、
-   Remote namespace 与 face；
-2. **typecheck/build**：使用真实 Context/projection，不用 `any`；
-3. **focused tests**：每个 unary 的 success/domain failure/cancel/assembly fault，stream 的
-   snapshot/reconnect/teardown；
-4. **artifact smoke**：从实际 pack/install 产物解析 entry 与 types；
-5. **headless-safe Loader/config smoke**：使用隔离 `DSH_HOME`/临时 Profile，不要求凭据；
-6. **显式授权后的行为验证**：只有用户要求并提供环境时，才启动真实 Profile、GUI、长期
-   服务或模型调用。
+1. **Static inventory**: exact package/resolved version, imports, exports, removed symbols, Remote namespaces, and face;
+2. **typecheck/build**: use the real Context/projection, not `any`;
+3. **Focused tests**: success/domain failure/cancel/assembly fault for each unary, and snapshot/reconnect/teardown for streams;
+4. **Artifact smoke**: resolve entries and types from the actual pack/install artifact;
+5. **Headless-safe Loader/config smoke**: use an isolated `DSH_HOME`/temporary Profile, no credentials required;
+6. **Behavior verification after explicit authorization**: start a real Profile, GUI, long-running service, or model calls only when the user asks and provides the environment.
 
-每次报告必须区分“typecheck 通过”“Loader 挂载通过”“真实行为通过”；三者不是同一个
-完成状态。
+Every report must distinguish “typecheck passed”, “Loader mount passed”, and “real behavior passed”; the three are not the same completion state.

--- a/skills/plugin-upgrade/references/host-plane-probes.md
+++ b/skills/plugin-upgrade/references/host-plane-probes.md
@@ -1,9 +1,9 @@
-# 宿主平面的双 cohort 探测（`cordis.patch.yml` 里的 `!!js`）
+# Host-plane dual-cohort probes (`!!js` in `cordis.patch.yml`)
 
-承接 [rollup R-02](rollup-0.1.2.md)。宿主平面插件（TUI 一类）不改产物，把 cohort 差异放进组合层的 `!!js` 探测。三种形态，取自 [dsh-TUI #622](https://github.com/ccch1mneyyy/dsh-TUI/pull/622) 的真实 patch：
+Builds on [rollup R-02](rollup-0.1.2.md). Host-plane plugins (the TUI kind) do not change artifacts; instead they push the cohort difference into `!!js` probes at the composition layer. Three forms, taken from the real patch in [dsh-TUI #622](https://github.com/ccch1mneyyy/dsh-TUI/pull/622):
 
 ```yaml
-# 1. 新宿主才有的子路径：resolve 得到才插入，否则整行自禁用；官方同名行启用时也让位
+# 1. Subpath that exists only on the new host: insert only if resolve succeeds, otherwise the whole row self-disables; also yield when the official row with the same id is enabled
 - id: dsh-tui-subagent-model-selection-settings
   name: '@deepseek-ai/dsh-tool-subagent/model-selection-settings'
   disabled: !!js >-
@@ -13,7 +13,7 @@
       return [...ctx.loader.entries()].some(entry => entry.options.id === 'subagent-model-selection-settings' && !entry.disabled)
     })()
 
-# 2. 能力被 shipped preset 接管：读目标 tag 真实存在的 preset 文件判断，宿主行让位
+# 2. Capability taken over by a shipped preset: decide by reading a preset file that really exists in the target tag; the host row yields
 - id: command-goal
   disabled: !!js >-
     (() => {
@@ -25,7 +25,7 @@
       } catch { return false }
     })()
 
-# 3. 配置形态随 cohort 变：探测包目录决定给不给 roots（见 DSH-0.1.2-A1-21）
+# 3. Config shape varies by cohort: probe the package directory to decide whether to provide roots (see DSH-0.1.2-A1-21)
 - id: dsh-tui-agent-presets
   name: '@deepseek-ai/dsh-agent-presets'
   config: !!js >-
@@ -36,10 +36,10 @@
         const manifest = require.resolve('@deepseek-ai/dsh-agent-presets/package.json')
         if (fs.existsSync(path.join(path.dirname(manifest), 'presets'))) return { default: 'standard' }
       } catch {}
-      return { default: 'standard', roots: [{ path: /* rc.2 的 dsh CLI config/agent-presets 目录 */ '', trust: 'system' }] }
+      return { default: 'standard', roots: [{ path: /* the dsh CLI config/agent-presets directory in rc.2 */ '', trust: 'system' }] }
     })()
 ```
-两条纪律：
+Two disciplines:
 
-1. 探测目标必须是目标 tag 真实存在的东西——`require.resolve` 子路径、包内文件、包目录。拿别的 loader 行当"能力标记"会在那一行被改动时静默失效（dsh-TUI 第一版用 `plugin-package-inventory-deepseek` 代表 alpha，review 后改掉）。
-2. 探测结果进快照：`!!js` 表达式在 rc.2 和 alpha 两个基线上分别求值后比对（dsh-TUI 的 `verify:patch-surface` 用 `@deepseek-ai/cordis-plugin-loader` 的 `evaluate` 按 `baseUrl` 求值，快照记有效状态而不是 YAML 原文）。
+1. The probe target must be something that really exists in the target tag — a `require.resolve` subpath, a file inside the package, or a package directory. Using another loader row as a "capability marker" silently stops working the moment that row changes (the first dsh-TUI version used `plugin-package-inventory-deepseek` to stand for alpha and was changed after review).
+2. Probe results go into snapshots: evaluate the `!!js` expression on each of the rc.2 and alpha baselines and compare (dsh-TUI's `verify:patch-surface` evaluates with `evaluate` from `@deepseek-ai/cordis-plugin-loader` against `baseUrl`; the snapshot records the effective state, not the raw YAML).

--- a/skills/plugin-upgrade/references/migration-hygiene.md
+++ b/skills/plugin-upgrade/references/migration-hygiene.md
@@ -1,37 +1,37 @@
-# 迁移卫生 · 与版本无关的工具链坑
+# Migration hygiene · version-independent toolchain pitfalls
 
-> 取自 6 个真实插件批量迁移（rc.1 → 0.1.2-alpha.1，见 [example 06](../examples/06-real-world-batch-migration.md)）的一手记录。这些坑不属于任何版本卡——它们在任何走廊段都可能吃掉迁移者半小时以上。
+> First-hand record from a batch migration of 6 real plugins (rc.1 → 0.1.2-alpha.1, see [example 06](../examples/06-real-world-batch-migration.md)). None of these pitfalls belongs to a version card — any of them can cost a migrator half an hour or more on any corridor segment.
 
-## 1. 增量 tsbuildinfo 假阳性
+## 1. Incremental tsbuildinfo false positives
 
-症状：改完源码后 typecheck 报与本次改动无关的老错误（如 TS2305），或构建期 oxc/rolldown 报 `MISSING_EXPORT` 类导出缺失（那是构建缓存假阳性，不是 tsc 的报错），或增量检查直接骗过、clean 后才暴露真实错误链。
+Symptom: after editing source, typecheck reports old errors unrelated to the change (e.g. TS2305), or the oxc/rolldown build reports a `MISSING_EXPORT`-class missing export (that is a build-cache false positive, not a tsc error), or the incremental check passes outright and the real error chain only surfaces after a clean.
 
-解法：迁移验证前一律 `pnpm run clean` 再 build。看到可疑 TS2305/TS2614 类导出缺失，先 clean 排除缓存，再 grep 真实引用（见 [A1-21 实战批注](v0.1.2-alpha.1.md)）。
+Fix: always run `pnpm run clean` before build during migration validation. On a suspicious TS2305/TS2614-class missing export, clean first to rule out the cache, then grep the real references (see the [A1-21 field note](v0.1.2-alpha.1.md)).
 
-## 2. oxc / vite 解析器比 tsc 严格
+## 2. The oxc / vite parser is stricter than tsc
 
-症状：tsc 通过，构建期报「Did you mean {'>'}」类解析错误。已知触发：未闭合的 JSX 标签、跨行三元表达式里带箭头函数。
+Symptom: tsc passes, but the build reports a "Did you mean {'>'}"-class parse error. Known triggers: unclosed JSX tags, arrow functions inside multi-line ternary expressions.
 
-解法：按解析器提示重写该表达式——预计算变量、拆语句。不要绕，也不要以 tsc 通过为准。
+Fix: rewrite the expression as the parser suggests — precompute a variable, split the statement. Do not work around it, and do not treat a passing tsc as sufficient.
 
-## 3. client 硬刷新 vs host 重启的生效平面
+## 3. Which plane a change takes effect in: client hard refresh vs host restart
 
-症状：改完代码浏览器刷新无变化，或 host 行为像旧版。
+Symptom: after changing code, a browser refresh shows no change, or the host still behaves like the old version.
 
-规则：改动落进 `lib/client.js`（client 半段）→ 浏览器硬刷新即生效；落进 `lib/index.js`（host 半段）→ 必须重启 dsh。与 [host-plane-probes.md](host-plane-probes.md) 的平面视角对应：先判断插件形态与改动落点，再决定验证动作。
+Rule: a change landing in `lib/client.js` (client half) takes effect on a browser hard refresh; a change landing in `lib/index.js` (host half) requires restarting dsh. This corresponds to the plane view in [host-plane-probes.md](host-plane-probes.md): decide the plugin shape and where the change lands first, then pick the validation action.
 
-## 4. pnpm 拦截依赖构建脚本（10.0 起默认）
+## 4. pnpm blocks dependency build scripts (default since 10.0)
 
-症状：新环境安装插件报 node-pty 等构建被拒。
+Symptom: installing the plugin in a fresh environment fails with a build rejection such as node-pty.
 
-解法：在 profile 目录执行 `pnpm approve-builds --all`。建议插件 README 直接写明这一步。
+Fix: run `pnpm approve-builds --all` in the profile directory. Plugin READMEs should state this step explicitly.
 
-## 5. 测试代码的 readonly 与 as-in-JSX
+## 5. readonly and as-in-JSX in test code
 
-症状：迁移后测试文件编译失败，但源码 typecheck 干净。
+Symptom: after migration, test files fail to compile while the source typechecks clean.
 
-已知触发：fiber 上 `dispose` 等字段变 readonly（测试不能再赋值模拟，改间接观察）；测试文件里 `as` 断言在 JSX 解析路径上不支持（改变量预收窄）。
+Known triggers: fields such as `dispose` on the fiber become readonly (tests can no longer assign mocks — switch to indirect observation); `as` assertions in test files are unsupported on the JSX parsing path (pre-narrow into a variable instead).
 
-## 验证纪律
+## Validation discipline
 
-每个迁移改动跑完整链：`pnpm run clean && pnpm run build && pnpm run typecheck && pnpm run test`，然后实机 boot（`dsh --profile web` + 硬刷新；host 半段有改动则重启）。只跑增量检查的结论不可信，见第 1 条。
+Run the full chain for every migration change: `pnpm run clean && pnpm run build && pnpm run typecheck && pnpm run test`, then boot for real (`dsh --profile web` + hard refresh; restart when the host half changed). Conclusions from incremental checks alone are not trustworthy — see item 1.

--- a/skills/plugin-upgrade/references/pre-flight-patterns.json
+++ b/skills/plugin-upgrade/references/pre-flight-patterns.json
@@ -5,7 +5,7 @@
     {
       "id": 1,
       "slug": "source-patch",
-      "name": "源码 patch / monkey patch",
+      "name": "source patch / monkey patch",
       "patterns": [
         "(?<!cordis\\.)patch\\.yml|patchedDependencies|patch-package",
         "DSH_HARNESS_SOURCE_ROOT|patch-surface|monkeypatch|monkey-patch"
@@ -14,7 +14,7 @@
     {
       "id": 2,
       "slug": "internal-events",
-      "name": "内部事件名与持久事件",
+      "name": "internal event names and persistent events",
       "patterns": [
         "SessionEvent|session/event|ctx\\.on\\(|subscribe\\(",
         "tool/code-dispatch|tools-code-mode|connection/reset"
@@ -23,7 +23,7 @@
     {
       "id": 3,
       "slug": "internal-services",
-      "name": "内部服务探测 / Remote",
+      "name": "internal service probes / Remote",
       "patterns": [
         "APIProxy|apiProxy|ctx\\.get\\(|ctx\\.remote|@Remote",
         "@deepseek-ai/dsh-api-.+/client|/internal"
@@ -32,7 +32,7 @@
     {
       "id": 4,
       "slug": "host-filesystem",
-      "name": "直接读写宿主目录",
+      "name": "direct host directory reads/writes",
       "patterns": [
         "DSH_HOME|\\.dsh[/\\\\]|profiles[/\\\\]|homedir\\(",
         "readFile|writeFile|mkdir|openPath"
@@ -41,7 +41,7 @@
     {
       "id": 5,
       "slug": "internal-ui-commands",
-      "name": "内部 UI / 命令 / 工具注册",
+      "name": "internal UI / commands / tool registration",
       "patterns": [
         "registerCommand|registerView|contributes|ctx\\.tools|commands\\.execute",
         "dsh-client-runtime|PropsRuntime|ctx\\.slots|useSession|useChat|/internal",
@@ -51,7 +51,7 @@
     {
       "id": 6,
       "slug": "custom-channel",
-      "name": "自建 HTTP / WS / RPC / DOM / CSS 通道",
+      "name": "custom HTTP / WS / RPC / DOM / CSS channels",
       "patterns": [
         "createServer\\(|WebSocket|MutationObserver|insertRule",
         "127\\.0\\.0\\.1|localhost|router\\.(get|post|put|delete)\\(|/api/",
@@ -61,7 +61,7 @@
     {
       "id": 7,
       "slug": "subprocess-output",
-      "name": "子进程 / stdout / stderr 解析",
+      "name": "subprocess / stdout / stderr parsing",
       "patterns": [
         "node:child_process|spawn\\(|exec(File)?Sync\\(|execa|Bun\\.spawn",
         "headless|--profile"

--- a/skills/plugin-upgrade/references/pre-flight.md
+++ b/skills/plugin-upgrade/references/pre-flight.md
@@ -1,99 +1,104 @@
-# Pre-flight · 宿主升级前触点自查
+# Pre-flight · touchpoint self-check before a host upgrade
 
-> 这是启发式扫描，不是兼容性证明。七类零命中只表示“未被当前模式发现”，仍须检查
-> 依赖/配置并执行 build、真实挂载和功能烟测。
+> This is a heuristic scan, not proof of compatibility. Zero hits across the seven classes
+> only means "not detected by the current patterns"; you must still check
+> dependencies/configuration and run a build, a real mount, and functional smoke tests.
 
-前六类沿用 [dsh-community-standard 迁移指南](https://github.com/oh-my-dsh/dsh-community-standard/blob/main/guides/migration.md)
-的分类；本 skill 另加 #7 子进程/输出解析。机器校验读取
-[pre-flight-patterns.json](pre-flight-patterns.json)。下列 `rg` 仅为示例；Agent 应优先
-使用当前环境提供的内容搜索工具。
+The first six classes follow the classification of the [dsh-community-standard migration guide](https://github.com/oh-my-dsh/dsh-community-standard/blob/main/guides/migration.md);
+this skill adds #7, subprocess/output parsing. Executable checks read
+[pre-flight-patterns.json](pre-flight-patterns.json). The `rg` commands below are examples
+only; an Agent should prefer the content-search tools provided by the current environment.
 
-## 目录
+## Table of contents
 
-- 0. 先做配置与依赖盘点
-- 1. 构造版本走廊
-- #1 源码 patch / monkey patch
-- #2 内部事件名与持久事件
-- #3 内部服务探测 / Remote
-- #4 直接读写宿主目录
-- #5 内部 UI / 命令 / 工具注册
-- #6 自建 HTTP / WS / RPC / DOM / CSS 通道
-- #7 子进程 / stdout / stderr 解析
-- 特殊面
-- 汇总模板
-- 触点体检（<插件>，<from> → <to>）
+- 0. Configuration and dependency inventory first
+- 1. Build the version corridor
+- #1 source patch / monkey patch
+- #2 internal event names and persistent events
+- #3 internal service probes / Remote
+- #4 direct host directory reads/writes
+- #5 internal UI / commands / tool registration
+- #6 custom HTTP / WS / RPC / DOM / CSS channels
+- #7 subprocess / stdout / stderr parsing
+- Special surfaces
+- Summary template
+- Touchpoint checkup (<plugin>, <from> → <to>)
 
-## 0. 先做配置与依赖盘点
+## 0. Configuration and dependency inventory first
 
-扫描全部受跟踪的源码、测试、脚本、CI 和根配置，排除生成物、vendor 与
-`node_modules`。至少记录：
+Scan all tracked source, tests, scripts, CI, and root configuration, excluding generated
+artifacts, vendor, and `node_modules`. Record at least:
 
-- `package.json` 的插件版本、`peerDependencies`、`engines` 与 `@deepseek-ai/*` 导入；
-- resolved 版本与 lockfile（只认仓库正在使用的包管理器）；
-- 标准 manifest `dsh-plugin.json`（若存在）；
-- profile composition：`cordis.patch.yml`、`agent.cordis.yml`、历史 `cordis.yml`；
-- 实际安装轨：registry 包、Git checkout、workspace/junction 或复制安装。
+- the plugin version, `peerDependencies`, `engines`, and `@deepseek-ai/*` imports in `package.json`;
+- the resolved version and lockfile (trust only the package manager the repository actually uses);
+- the standard manifest `dsh-plugin.json` (if present);
+- profile composition: `cordis.patch.yml`, `agent.cordis.yml`, legacy `cordis.yml`;
+- the actual install track: registry package, Git checkout, workspace/junction, or copied install.
 
-这些文件所有权不同，不能统一称为 manifest，也不能整对象重写未知字段。
+These files have different ownership, so they cannot all be called manifests, and unknown
+fields must not be rewritten whole-object.
 
-## 1. 构造版本走廊
+## 1. Build the version corridor
 
-1. 用精确 tag 确认 from/to；
-2. 按 [版本走廊索引](README.md#版本走廊索引) 的 `from → to` 边连接，禁止按文件名字典序；
-3. 先读完整走廊并折叠“移除后又恢复”等净变化，再生成修改计划；
-4. 缺卡时报告 unsupported gap，先做一手来源调研，不凭记忆自动改插件。
+1. Confirm from/to with exact tags;
+2. connect edges by the `from → to` entries in the [version corridor index](README.md#version-corridor-index) — never by filename lexicographic order;
+3. read the full corridor first and fold net changes such as "removed then restored" before producing the change plan;
+4. when cards are missing, report an unsupported gap and research primary sources first; do not change the plugin from memory.
 
-## #1 源码 patch / monkey patch
+## #1 source patch / monkey patch
 
 ```sh
 rg -n "(^|[^.])patch\.yml|patchedDependencies|patch-package" .
 rg -n "DSH_HARNESS_SOURCE_ROOT|patch-surface|monkeypatch|monkey-patch" .
 ```
 
-命中后逐个记录宿主目标路径与替换意图；目标 tag 中找不到等价 owning 模块时标
-「待确认」，不猜路径。普通 `cordis.patch.yml` 是 profile composition，必须按
-[API-08](api-migration-0.1.2-alpha.2.md#api-08--cordispatchyml-是-composition不是源码-patch)
-归类，不能仅因文件名包含 `patch` 就命中本类。
+For each hit, record the host target path and the replacement intent; when no equivalent
+owning module exists in the target tag, mark it "pending confirmation" — do not guess
+paths. An ordinary `cordis.patch.yml` is profile composition and must be classified per
+[API-08](api-migration-0.1.2-alpha.2.md#api-08--cordispatchyml-is-composition-not-a-source-patch);
+a filename containing `patch` alone is not a hit for this class.
 
-**关联卡**: `DSH-0.1.2-A1-03`
+**Related cards**: `DSH-0.1.2-A1-03`
 
-## #2 内部事件名与持久事件
+## #2 internal event names and persistent events
 
 ```sh
 rg -n "SessionEvent|session/event|ctx\.on\(|subscribe\(" .
 rg -n "tool/code-dispatch|tools-code-mode|connection/reset" .
 ```
 
-区分 producer、persistence、reload、transport 与普通 observer；未知 required 事件不能
-因白名单而被放过。
+Distinguish producer, persistence, reload, transport, and plain observer roles; an unknown
+required event must not slip through just because it is on a whitelist.
 
-**关联卡**: `DSH-0.1.2-A1-02`、`DSH-0.1.2-A1-06`、`DSH-0.1.2-A2-01`
+**Related cards**: `DSH-0.1.2-A1-02`, `DSH-0.1.2-A1-06`, `DSH-0.1.2-A2-01`
 
-## #3 内部服务探测 / Remote
+## #3 internal service probes / Remote
 
 ```sh
 rg -n "APIProxy|apiProxy|ctx\.get\(|ctx\.remote|@Remote" .
 rg -n "@deepseek-ai/dsh-api-.+/client|/internal" .
 ```
 
-同时记录调用所在 face（Host、Web Client、普通 Cordis plugin）与包入口；内部架构迁移
-不能直接当成所有插件的公开 API 建议。
+Also record the face the call lives in (Host, Web Client, ordinary Cordis plugin) and the
+package entry point; an internal architecture migration must not be passed off as a
+public-API recommendation for every plugin.
 
-**关联卡**: `DSH-0.1.2-A1-01`、`DSH-0.1.2-A1-06`、`DSH-0.1.2-A1-11`、`DSH-0.1.2-A1-20`、`DSH-0.1.2-A1-21`、`DSH-0.1.2-A1-22`、`DSH-0.1.2-A1-25`、`DSH-0.1.2-A1-27`、`DSH-0.1.2-A1-30`、`DSH-0.1.2-A1-31`、`DSH-0.1.2-A2-02`、`DSH-0.1.2-A2-05`、`DSH-0.1.2-A2-06`、`DSH-0.1.2-A2-08`、`DSH-0.1.2-A2-10`
+**Related cards**: `DSH-0.1.2-A1-01`, `DSH-0.1.2-A1-06`, `DSH-0.1.2-A1-11`, `DSH-0.1.2-A1-20`, `DSH-0.1.2-A1-21`, `DSH-0.1.2-A1-22`, `DSH-0.1.2-A1-25`, `DSH-0.1.2-A1-27`, `DSH-0.1.2-A1-30`, `DSH-0.1.2-A1-31`, `DSH-0.1.2-A2-02`, `DSH-0.1.2-A2-05`, `DSH-0.1.2-A2-06`, `DSH-0.1.2-A2-08`, `DSH-0.1.2-A2-10`
 
-## #4 直接读写宿主目录
+## #4 direct host directory reads/writes
 
 ```sh
 rg -n "DSH_HOME|\.dsh[/\\]|profiles[/\\]|homedir\(" .
 rg -n "readFile|writeFile|mkdir|openPath" .
 ```
 
-同一行搜索无法发现数据流；命中路径构造函数后继续追踪变量来源与写入目标。不得打印
-配置内容、token、`.npmrc` 或会话日志。
+A line-level search cannot reveal data flow; once a path-construction call is hit, keep
+tracing where the variables come from and where output is written. Never print
+configuration contents, tokens, `.npmrc`, or session logs.
 
-**关联卡**: `DSH-0.1.2-A1-04`、`DSH-0.1.2-A1-13`、`DSH-0.1.2-A1-21`
+**Related cards**: `DSH-0.1.2-A1-04`, `DSH-0.1.2-A1-13`, `DSH-0.1.2-A1-21`
 
-## #5 内部 UI / 命令 / 工具注册
+## #5 internal UI / commands / tool registration
 
 ```sh
 rg -n "registerCommand|registerView|contributes|ctx\.tools|commands\.execute" .
@@ -101,13 +106,14 @@ rg -n "dsh-client-runtime|PropsRuntime|ctx\.slots|useSession|useChat|/internal" 
 rg -n "__ModuleLoader__|PLUGIN_ID" .
 ```
 
-将公开 seam 与内部路径分开；命中旧 client runtime、session/chat selector 或 slot augmentation
-时，继续检查 `dsh.client.inject`、直接类型依赖、keyed snapshot 形状和 type-only Context
-augmentation。机会型 capability 只建议、不自动采用。
+Separate public seams from internal paths; when an old client runtime, a session/chat
+selector, or a slot augmentation is hit, keep checking `dsh.client.inject`, direct type
+dependencies, keyed snapshot shape, and type-only Context augmentation. Opportunistic
+capabilities are suggestions only — never adopt them automatically.
 
-**关联卡**: `DSH-0.1.2-A1-03`、`DSH-0.1.2-A1-06`、`DSH-0.1.2-A1-09`、`DSH-0.1.2-A1-10`、`DSH-0.1.2-A1-11`、`DSH-0.1.2-A1-26`、`DSH-0.1.2-A1-28`、`DSH-0.1.2-A1-29`；详细接口映射见 [API-10](api-migration-0.1.2-alpha.2.md#api-10--web-client-runtime-拆包keyed-chat-snapshot-与命令附件参数)
+**Related cards**: `DSH-0.1.2-A1-03`, `DSH-0.1.2-A1-06`, `DSH-0.1.2-A1-09`, `DSH-0.1.2-A1-10`, `DSH-0.1.2-A1-11`, `DSH-0.1.2-A1-26`, `DSH-0.1.2-A1-28`, `DSH-0.1.2-A1-29`; detailed interface mapping in [API-10](api-migration-0.1.2-alpha.2.md#api-10--web-client-runtime-unbundling-keyed-chat-snapshots-and-command-attachment-parameters)
 
-## #6 自建 HTTP / WS / RPC / DOM / CSS 通道
+## #6 custom HTTP / WS / RPC / DOM / CSS channels
 
 ```sh
 rg -n "createServer\(|WebSocket|MutationObserver|insertRule" .
@@ -115,42 +121,44 @@ rg -n "127\.0\.0\.1|localhost|router\.(get|post|put|delete)\(|/api/" .
 rg -n "contenteditable|setSelectionRange|data-input-scroll" .
 ```
 
-检查认证、Host/Origin、端口生命周期和 teardown；不能因“只监听 loopback”就跳过认证。
+Check authentication, Host/Origin, port lifecycle, and teardown; "listening on loopback
+only" is not a reason to skip authentication.
 
-**关联卡**: `DSH-0.1.2-A1-08`、`DSH-0.1.2-A1-28`
+**Related cards**: `DSH-0.1.2-A1-08`, `DSH-0.1.2-A1-28`
 
-## #7 子进程 / stdout / stderr 解析
+## #7 subprocess / stdout / stderr parsing
 
 ```sh
 rg -n "node:child_process|spawn\(|exec(File)?Sync\(|execa|Bun\.spawn" .
 rg -n "headless|--profile" .
 ```
 
-记录 argv、cwd、env、取消、退出码、stdout/stderr 所有权；不要只验证进程能启动。
+Record argv, cwd, env, cancellation, exit codes, and stdout/stderr ownership; verifying
+that the process can start is not enough.
 
-**关联卡**: `DSH-0.1.2-A1-04`、`DSH-0.1.2-A1-05`、`DSH-0.1.2-A1-06`、`DSH-0.1.2-A1-13`、`DSH-0.1.2-A2-04`
+**Related cards**: `DSH-0.1.2-A1-04`, `DSH-0.1.2-A1-05`, `DSH-0.1.2-A1-06`, `DSH-0.1.2-A1-13`, `DSH-0.1.2-A2-04`
 
-## 特殊面
+## Special surfaces
 
-- 权限/审批：另查 `DSH-0.1.2-A1-07`；
-- 打包/依赖：另查 `DSH-0.1.2-A1-24`、`DSH-0.1.2-A2-03`；
-- 隐私/数据出境：另查 `DSH-0.1.2-A1-12`、`DSH-0.1.2-A1-14`、`DSH-0.1.2-A1-23`。
+- Permissions/approval: see also `DSH-0.1.2-A1-07`;
+- Packaging/dependencies: see also `DSH-0.1.2-A1-24`, `DSH-0.1.2-A2-03`;
+- Privacy/cross-border data: see also `DSH-0.1.2-A1-12`, `DSH-0.1.2-A1-14`, `DSH-0.1.2-A1-23`.
 
-## 汇总模板
+## Summary template
 
 ```markdown
-## 触点体检（<插件>，<from> → <to>）
+## Touchpoint checkup (<plugin>, <from> → <to>)
 
-| 触点 | 命中 | 文件/行 | 适用卡 | 置信说明 |
+| Touchpoint | Hit | File/line | Applicable card | Confidence note |
 |---|---:|---|---|---|
 | #1 patch | | | | |
-| #2 事件 | | | | |
-| #3 服务/Remote | | | | |
-| #4 文件系统 | | | | |
-| #5 UI/命令/工具 | | | | |
-| #6 自建通道 | | | | |
-| #7 子进程/输出 | | | | |
+| #2 events | | | | |
+| #3 services/Remote | | | | |
+| #4 filesystem | | | | |
+| #5 UI/commands/tools | | | | |
+| #6 custom channel | | | | |
+| #7 subprocess/output | | | | |
 
-未命中说明：<扫描范围、排除目录、依赖/配置另行检查结果>
-必须验证：<build/typecheck、真实 profile 挂载、功能路径>
+No-hit notes: <scan scope, excluded directories, dependency/configuration checked separately>
+Must verify: <build/typecheck, real profile mount, functional path>
 ```

--- a/skills/plugin-upgrade/references/rollup-0.1.2.md
+++ b/skills/plugin-upgrade/references/rollup-0.1.2.md
@@ -1,65 +1,65 @@
-# Rollup · 0.1.1 → 0.1.2 走廊
+# Rollup · 0.1.1 → 0.1.2 Corridor
 
-> 状态: 基于 `dsh-v0.1.2-alpha.2`。0.1.2 正式版尚未发布——npm dist-tags 实测 `latest`/`next` = `0.1.1-rc.2`，`alpha` = `0.1.2-alpha.2`。正式发版后本文件需按 final tag 复核转正（[issue #1](https://github.com/oh-my-dsh/dsh-plugin-upgrade-skill/issues/1) 的原始 caveat）。
-> 定位: 本文件不重复版本卡片。逐条变更以卡片为准，这里只写走廊层的增量——跨 cohort 共存、未发布 cohort 安装、CI/发布连带、迁移前盘点与 baseline 归因、boot race 处置、安装通道三坑、类型面导出漂移、宿主自身安全边界、分层验证清单。
-> 卡片格式见 [README.md](README.md)。触点编号对应 [pre-flight 清单](pre-flight.md)。
+> Status: based on `dsh-v0.1.2-alpha.2`. The 0.1.2 final release is not out yet — measured on npm dist-tags, `latest`/`next` = `0.1.1-rc.2` and `alpha` = `0.1.2-alpha.2`. Once the final release ships, this file must be re-verified and promoted against the final tag (the original caveat in [issue #1](https://github.com/oh-my-dsh/dsh-plugin-upgrade-skill/issues/1)).
+> Scope: this file does not repeat the version cards. Each change is governed by its card; this file only covers corridor-level increments — cross-cohort coexistence, unpublished-cohort installation, CI/release coupling, pre-migration inventory and baseline attribution, boot-race handling, the three install-channel pitfalls, type-surface export drift, the host's own safety boundary, and the layered validation checklist.
+> Card format: see [README.md](README.md). Touchpoint numbers correspond to the [pre-flight checklist](pre-flight.md).
 
-## 目录
+## Table of contents
 
-- 怎么用这份 rollup
-- 卡片索引（按触点）
-- Remote 调用的错误流
-- 走廊层增量
-  - R-01 · 目标 cohort 的依赖包未完整发布 npm
-  - R-02 · 跨 cohort 共存（旧宿主升不到未发布 cohort）
-  - R-03 · 第三方预构建插件搭不上你的 shim
-  - R-04 · CI 与发布管线连带
-  - R-05 · 迁移前盘点被删包的下游
-  - R-06 · 迁移前 baseline 归因——先立豁免清单，再动迁移
-  - R-07 · 启动服务竞态：有界重试，不延迟、不加 inject wait
-  - R-08 · 安装通道三坑：镜像延迟、pnpm 11 供应链规则、peer 下限 prerelease 语义
-  - R-09 · 插件进 profile 的 `link:` 本地安装轨
-  - R-10 · base-only profile 挂 shipped preset 的新前置（Host scope 服务与同名遮蔽）
-  - R-11 · 0.1.2 类型面导出漂移（未入 release notes 的 ledger）
-  - R-12 · 升级对象可能就是当前运行宿主
-  - R-13 · 客户端产品文案迁到本地化 seat 后，按默认语言显示文本锚定宿主 UI 的插件会静默失效
-- 分层验证清单
-- 回退
-- 待确认
+- How to use this rollup
+- Card index (by touchpoint)
+- Remote call error flow
+- Corridor-level increments
+  - R-01 · Target cohort dependency packages not fully published to npm
+  - R-02 · Cross-cohort coexistence (old host cannot upgrade to an unpublished cohort)
+  - R-03 · Third-party prebuilt plugins don't fit your shim
+  - R-04 · CI and release pipeline coupling
+  - R-05 · Pre-migration inventory of removed-package consumers
+  - R-06 · Pre-migration baseline attribution — establish the exemption list first, then migrate
+  - R-07 · Service boot race: bounded retry — no delay, no inject wait
+  - R-08 · The three install-channel pitfalls: mirror lag, pnpm 11 supply-chain rules, peer-floor prerelease semantics
+  - R-09 · The `link:` local install track for adding a plugin to a profile
+  - R-10 · New precondition for mounting a shipped preset on a base-only profile (Host-scope services and same-name shadowing)
+  - R-11 · 0.1.2 type-surface export drift (ledger not in the release notes)
+  - R-12 · The upgrade target may be the currently running host
+  - R-13 · After client product copy moves to localized seats, plugins that anchor to host UI by displayed text fail silently
+- Layered validation checklist
+- Rollback
+- Pending confirmation
 
-## 怎么用这份 rollup
+## How to use this rollup
 
-0. 迁移动手前，先按 R-06 采集 baseline（即分层验证清单第 0 层）；
-1. 先按 [pre-flight.md](pre-flight.md) 测出命中的触点类；
-2. 按 `from → to` 读完整走廊并先计算净状态：[v0.1.2-alpha.1.md](v0.1.2-alpha.1.md) → [v0.1.2-alpha.2.md](v0.1.2-alpha.2.md)（各文件张数见 [README.md](README.md) 索引）；
-3. 回到本文件处理走廊层问题——这些跨越单版本，卡片里没有；
-4. 按本文件末尾的分层验证清单收工。
+0. Before starting the migration, collect the baseline per R-06 (i.e., layer 0 of the layered validation checklist);
+1. First run [pre-flight.md](pre-flight.md) to find the touchpoint classes you hit;
+2. Read the full corridor along `from → to` and compute the net state first: [v0.1.2-alpha.1.md](v0.1.2-alpha.1.md) → [v0.1.2-alpha.2.md](v0.1.2-alpha.2.md) (per-file card counts are in the [README.md](README.md) index);
+3. Return to this file for corridor-level problems — these span single versions and are not covered by the cards;
+4. Finish with the layered validation checklist at the end of this file.
 
-## 卡片索引（按触点）
+## Card index (by touchpoint)
 
-| 触点 | 相关卡片 |
+| Touchpoint | Related cards |
 |---|---|
-| #1 源码 patch | [DSH-0.1.2-A1-03](v0.1.2-alpha.1.md) |
-| #2 事件 / 持久事件 | [DSH-0.1.2-A1-02](v0.1.2-alpha.1.md) → [DSH-0.1.2-A2-01](v0.1.2-alpha.2.md)，另见 [DSH-0.1.2-A1-06](v0.1.2-alpha.1.md) |
-| #3 服务 / Remote | [DSH-0.1.2-A1-01](v0.1.2-alpha.1.md)、[DSH-0.1.2-A1-06](v0.1.2-alpha.1.md)、[DSH-0.1.2-A1-11](v0.1.2-alpha.1.md)、[DSH-0.1.2-A1-20](v0.1.2-alpha.1.md)、[DSH-0.1.2-A1-21](v0.1.2-alpha.1.md)、[DSH-0.1.2-A1-22](v0.1.2-alpha.1.md)、[DSH-0.1.2-A1-30](v0.1.2-alpha.1.md)、[DSH-0.1.2-A1-31](v0.1.2-alpha.1.md)、[DSH-0.1.2-A2-02](v0.1.2-alpha.2.md)、[DSH-0.1.2-A2-05](v0.1.2-alpha.2.md)、[DSH-0.1.2-A2-06](v0.1.2-alpha.2.md)、[DSH-0.1.2-A2-08](v0.1.2-alpha.2.md)、[DSH-0.1.2-A2-10](v0.1.2-alpha.2.md)、[DSH-0.1.2-A1-25](v0.1.2-alpha.1.md)、[DSH-0.1.2-A1-27](v0.1.2-alpha.1.md) |
-| #4 宿主目录读写 | [DSH-0.1.2-A1-04](v0.1.2-alpha.1.md)、[DSH-0.1.2-A1-13](v0.1.2-alpha.1.md)、[DSH-0.1.2-A1-21](v0.1.2-alpha.1.md) |
-| #5 UI / 命令 / 工具 | [DSH-0.1.2-A1-03](v0.1.2-alpha.1.md)、[DSH-0.1.2-A1-06](v0.1.2-alpha.1.md)、[DSH-0.1.2-A1-09](v0.1.2-alpha.1.md)、[DSH-0.1.2-A1-10](v0.1.2-alpha.1.md)、[DSH-0.1.2-A1-11](v0.1.2-alpha.1.md)、[DSH-0.1.2-A1-29](v0.1.2-alpha.1.md)、[DSH-0.1.2-A1-26](v0.1.2-alpha.1.md)、[DSH-0.1.2-A1-28](v0.1.2-alpha.1.md) |
-| #6 自建 HTTP/WS/RPC/DOM/CSS | [DSH-0.1.2-A1-08](v0.1.2-alpha.1.md)、[DSH-0.1.2-A1-28](v0.1.2-alpha.1.md) |
-| #7 子进程 / stdout / stderr | [DSH-0.1.2-A1-04](v0.1.2-alpha.1.md)、[DSH-0.1.2-A1-05](v0.1.2-alpha.1.md)、[DSH-0.1.2-A1-06](v0.1.2-alpha.1.md)、[DSH-0.1.2-A1-13](v0.1.2-alpha.1.md)、[DSH-0.1.2-A2-04](v0.1.2-alpha.2.md) |
-| #6/#7 Web 启动与验收 | [DSH-0.1.2-A1-19](v0.1.2-alpha.1.md)（认证 URL、启动图资源发现与真实挂载） |
-| 特殊面 | 权限 [DSH-0.1.2-A1-07](v0.1.2-alpha.1.md)；隐私 [DSH-0.1.2-A1-12](v0.1.2-alpha.1.md) / [DSH-0.1.2-A1-14](v0.1.2-alpha.1.md) / [DSH-0.1.2-A1-23](v0.1.2-alpha.1.md)；打包 [DSH-0.1.2-A1-24](v0.1.2-alpha.1.md) / [DSH-0.1.2-A2-03](v0.1.2-alpha.2.md) |
+| #1 source patches | [DSH-0.1.2-A1-03](v0.1.2-alpha.1.md) |
+| #2 events / persistent events | [DSH-0.1.2-A1-02](v0.1.2-alpha.1.md) → [DSH-0.1.2-A2-01](v0.1.2-alpha.2.md), also [DSH-0.1.2-A1-06](v0.1.2-alpha.1.md) |
+| #3 services / Remote | [DSH-0.1.2-A1-01](v0.1.2-alpha.1.md), [DSH-0.1.2-A1-06](v0.1.2-alpha.1.md), [DSH-0.1.2-A1-11](v0.1.2-alpha.1.md), [DSH-0.1.2-A1-20](v0.1.2-alpha.1.md), [DSH-0.1.2-A1-21](v0.1.2-alpha.1.md), [DSH-0.1.2-A1-22](v0.1.2-alpha.1.md), [DSH-0.1.2-A1-30](v0.1.2-alpha.1.md), [DSH-0.1.2-A1-31](v0.1.2-alpha.1.md), [DSH-0.1.2-A2-02](v0.1.2-alpha.2.md), [DSH-0.1.2-A2-05](v0.1.2-alpha.2.md), [DSH-0.1.2-A2-06](v0.1.2-alpha.2.md), [DSH-0.1.2-A2-08](v0.1.2-alpha.2.md), [DSH-0.1.2-A2-10](v0.1.2-alpha.2.md), [DSH-0.1.2-A1-25](v0.1.2-alpha.1.md), [DSH-0.1.2-A1-27](v0.1.2-alpha.1.md) |
+| #4 host directory read/write | [DSH-0.1.2-A1-04](v0.1.2-alpha.1.md), [DSH-0.1.2-A1-13](v0.1.2-alpha.1.md), [DSH-0.1.2-A1-21](v0.1.2-alpha.1.md) |
+| #5 UI / commands / tools | [DSH-0.1.2-A1-03](v0.1.2-alpha.1.md), [DSH-0.1.2-A1-06](v0.1.2-alpha.1.md), [DSH-0.1.2-A1-09](v0.1.2-alpha.1.md), [DSH-0.1.2-A1-10](v0.1.2-alpha.1.md), [DSH-0.1.2-A1-11](v0.1.2-alpha.1.md), [DSH-0.1.2-A1-29](v0.1.2-alpha.1.md), [DSH-0.1.2-A1-26](v0.1.2-alpha.1.md), [DSH-0.1.2-A1-28](v0.1.2-alpha.1.md) |
+| #6 custom HTTP/WS/RPC/DOM/CSS | [DSH-0.1.2-A1-08](v0.1.2-alpha.1.md), [DSH-0.1.2-A1-28](v0.1.2-alpha.1.md) |
+| #7 subprocess / stdout / stderr | [DSH-0.1.2-A1-04](v0.1.2-alpha.1.md), [DSH-0.1.2-A1-05](v0.1.2-alpha.1.md), [DSH-0.1.2-A1-06](v0.1.2-alpha.1.md), [DSH-0.1.2-A1-13](v0.1.2-alpha.1.md), [DSH-0.1.2-A2-04](v0.1.2-alpha.2.md) |
+| #6/#7 Web startup and acceptance | [DSH-0.1.2-A1-19](v0.1.2-alpha.1.md) (auth URL, boot resource discovery, and real mount) |
+| Special surfaces | permissions [DSH-0.1.2-A1-07](v0.1.2-alpha.1.md); privacy [DSH-0.1.2-A1-12](v0.1.2-alpha.1.md) / [DSH-0.1.2-A1-14](v0.1.2-alpha.1.md) / [DSH-0.1.2-A1-23](v0.1.2-alpha.1.md); packaging [DSH-0.1.2-A1-24](v0.1.2-alpha.1.md) / [DSH-0.1.2-A2-03](v0.1.2-alpha.2.md) |
 
-> 跨版本回滚型变更先读完整走廊再动手：字段或语义在中间版本删除、后续版本又恢复
-> （典型如 `ignorable` 的 [DSH-0.1.2-A1-02](v0.1.2-alpha.1.md) → [DSH-0.1.2-A2-01](v0.1.2-alpha.2.md) 一删一复）。
-> 迁移时必须先折叠走廊的净状态再修改源码——不要在 alpha.1 删一次、到 alpha.2 又加回来；
-> 若最终目标已恢复该语义，旧版适配里的防御代码应当删除而不是保留。
+> For cross-version revert-style changes, read the full corridor before touching anything: a field or its semantics may be removed in an intermediate version and restored in a later one
+> (the canonical example is `ignorable`, removed by [DSH-0.1.2-A1-02](v0.1.2-alpha.1.md) and restored by [DSH-0.1.2-A2-01](v0.1.2-alpha.2.md)).
+> When migrating, fold the corridor into its net state before modifying source — do not delete once for alpha.1 and then add it back for alpha.2;
+> if the final target restores that semantics, defensive code in old-version adaptations should be removed rather than kept.
 
-## Remote 调用的错误流
+## Remote call error flow
 
-承接 [DSH-0.1.2-A1-01](v0.1.2-alpha.1.md) 与
-[DSH-0.1.2-A2-02](v0.1.2-alpha.2.md)。unary Remote 从 rc.2 起就返回
-`Promise<RemoteResult<T>>`，alpha.2 改的是 `error` 的类型和错误码命名空间：业务/载体失败走 `ok: false`；参数个数、未挂载方法、缺少
-Context adapter 等装配/编程错误仍可能 reject，应暴露修复而不是吞掉重试。
+Follows on from [DSH-0.1.2-A1-01](v0.1.2-alpha.1.md) and
+[DSH-0.1.2-A2-02](v0.1.2-alpha.2.md). Unary Remote has returned
+`Promise<RemoteResult<T>>` since rc.2; what alpha.2 changes is the `error` type and the error-code namespace: business/transport failures surface as `ok: false`; assembly/programming errors — wrong argument count, unmounted methods, a missing
+Context adapter — can still reject, and should be exposed for fixing rather than swallowed and retried.
 
 ```typescript
 const result = await ctx.remote.session.list({ limit: 10 })
@@ -77,23 +77,23 @@ if (!result.ok) {
 return result.value
 ```
 
-只有上层接住主动 `throw result.error` 的值时，才用
-`isRemoteFailure`（`@deepseek-ai/dsh-api-gateway/client`）区分 Remote failure 与本地
-缺陷；本地缺陷继续抛出。禁止跨 realm 使用 `instanceof RemoteError`。`gateway/internal`
-和未知码不证明请求未执行，默认保留原始 `code/details` 并上报，不盲重试。
+Only when an upper layer catches the value from the explicit `throw result.error` should you use
+`isRemoteFailure` (from `@deepseek-ai/dsh-api-gateway/client`) to tell a Remote failure from a local
+defect; local defects keep propagating. Never use `instanceof RemoteError` across realms. `gateway/internal`
+and unknown codes do not prove the request never executed; by default keep the original `code`/`details` and report them — do not blind-retry.
 
-来源：[DSH-0.1.2-A2-02](v0.1.2-alpha.2.md) 与
-[ctx-remote-failure-vocabulary](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/.agents/notes/implemented/architecture/2026-08-28-ctx-remote-failure-vocabulary.md)。
+Source: [DSH-0.1.2-A2-02](v0.1.2-alpha.2.md) and
+[ctx-remote-failure-vocabulary](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/.agents/notes/implemented/architecture/2026-08-28-ctx-remote-failure-vocabulary.md).
 
-## 走廊层增量
+## Corridor-level increments
 
-以下问题跨越单个版本或落在卡片之外，来自社区实战（[discussion #5120](https://github.com/deepseek-ai/deepseek-harness/discussions/5120)，dsh-web 约 20 个包的迁移）与迁移管线实践。
+The following problems span single versions or fall outside the cards; they come from community practice ([discussion #5120](https://github.com/deepseek-ai/deepseek-harness/discussions/5120), the dsh-web migration of about 20 packages) and migration-pipeline experience.
 
-### R-01 · 目标 cohort 的依赖包未完整发布 npm
+### R-01 · Target cohort dependency packages not fully published to npm
 
-- **类型**: process
-- **症状**: 根包或 dist-tag 可用不代表插件直接依赖的每个内部 cohort 包都已发布；只有实际 registry 查询返回缺失时，才进入本配方。
-- **配方**: 先记录缺失的精确包名/版本。确认 registry 确实不可用后，在隔离 worktree 从官方 tag 构建并 `pnpm pack`，用 `overrides` 钉到 `file:` tarball；不要把所有 `0.1.2-alpha.*` 一概描述成 404。
+- **Type**: process
+- **Symptoms**: the root package or dist-tag being available does not mean every internal cohort package the plugin depends on directly has been published; enter this recipe only when an actual registry query reports a missing package.
+- **Migration recipe**: record the exact missing package names/versions first. After confirming the registry is truly unavailable, build from the official tag in an isolated worktree and run `pnpm pack`, pinning to `file:` tarballs via `overrides`; do not describe every `0.1.2-alpha.*` as 404 wholesale.
 
   ```sh
   git clone https://github.com/deepseek-ai/deepseek-harness.git /tmp/dsh-build
@@ -103,18 +103,18 @@ return result.value
   pnpm -r exec pnpm pack --pack-destination ~/.dsh-cohorts/0.1.2-alpha.2
   ```
 
-  manifest 里 range 写 `^0.1.2-alpha.2`，将来正式发布删掉 overrides 段即回到 registry 解析。
-- **注意（待确认）**: 以下 pnpm 版本钉点来自单一实战报告，尚未在其他仓库复现验证——报告称 `11.9.0` 对 file: tarball 的传递依赖在有第三方 peer 时会绕过 overrides 去 registry 找不存在的版本，钉 `packageManager: pnpm@11.24.0` 才解析正确。落地前先在目标仓库做最小复现确认，验证通过后回填结果并把本条目转正（与本文件末尾「待确认」小节同步更新）。
-- **npm 实况**（2026-08-31）: `@deepseek-ai/dsh-*` 各包在 npm 只有 `0.1.1-rc.1`、`0.1.1-rc.2`、`0.1.2-alpha.2`，alpha.1 从未发布。rc.2 → alpha.1 只能从 GitHub tag 构建；目标 alpha.2 先查 registry。
-- **只验证不安装**（[dsh-TUI #622](https://github.com/ccch1mneyyy/dsh-TUI/pull/622)）: 安装基线留 rc.2，CI 检出上游 tag，用其 `tsconfig.base.json` 的 `paths` 映射到源码跑 `tsc --noEmit`。证明类型面，运行时另做；[dsh-TUI #647](https://github.com/ccch1mneyyy/dsh-TUI/pull/647) 在 alpha.2 上 npm 后仍保留这条车道。
-- **验证**: `pnpm list --depth 0 | grep @deepseek-ai` 全部指向目标版本，无混合。
-- **来源**: [#5120](https://github.com/deepseek-ai/deepseek-harness/discussions/5120) 第 1 条。未在官方 release notes 覆盖范围内，属社区实践。
+  In the manifest, write the range as `^0.1.2-alpha.2`; once the final release ships, deleting the overrides section returns to registry resolution.
+- **Note (pending confirmation)**: the pnpm version pin below comes from a single field report and has not been reproduced in other repositories — the report says `11.9.0` bypasses overrides for file: tarball transitive dependencies when third-party peers are present, looking for nonexistent versions on the registry; pinning `packageManager: pnpm@11.24.0` resolves correctly. Before adopting it, run a minimal reproduction in the target repository; once verified, backfill the results and promote this entry (keep it in sync with the "Pending confirmation" section at the end of this file).
+- **npm reality** (2026-08-31): on npm, the `@deepseek-ai/dsh-*` packages only have `0.1.1-rc.1`, `0.1.1-rc.2`, and `0.1.2-alpha.2`; alpha.1 was never published. rc.2 → alpha.1 can only be built from a GitHub tag; for the alpha.2 target, query the registry first.
+- **Verify-only, no install** ([dsh-TUI #622](https://github.com/ccch1mneyyy/dsh-TUI/pull/622)): keep the install baseline at rc.2; CI checks out the upstream tag and runs `tsc --noEmit` with the `paths` mapping from its `tsconfig.base.json` pointing at the source. This proves the type surface; runtime is verified separately — [dsh-TUI #647](https://github.com/ccch1mneyyy/dsh-TUI/pull/647) kept this lane even after going npm on alpha.2.
+- **Verification**: `pnpm list --depth 0 | grep @deepseek-ai` all points at the target version, with no mixture.
+- **Source**: item 1 of [#5120](https://github.com/deepseek-ai/deepseek-harness/discussions/5120). Not covered by the official release notes; community practice.
 
-### R-02 · 跨 cohort 共存（旧宿主升不到未发布 cohort）
+### R-02 · Cross-cohort coexistence (old host cannot upgrade to an unpublished cohort)
 
-- **类型**: breaking（组合效应）
-- **症状**: rc.2 宿主不可能升到未发布的 alpha，插件必须在两个 cohort 上都跑。两条硬耦合会浮出来：客户端 bundle 求值期硬 `require` 平台模块，在没有该模块表项的宿主上报 `missed the module table`；只在新宿主注册的服务被写进硬 `inject` 清单，旧宿主上入口永久 `pending (waiting for service: …)`。
-- **配方**: 一个产物 + 运行时解析 cohort 表面。
+- **Type**: breaking (combined effect)
+- **Symptoms**: an rc.2 host cannot be upgraded to an unpublished alpha, so the plugin must run on both cohorts. Two hard couplings surface: a client bundle that hard-`require`s platform modules during evaluation reports `missed the module table` on hosts that have no module-table entry for them; services registered only on the new host get written into a hard `inject` list, leaving the entry permanently `pending (waiting for service: …)` on old hosts.
+- **Migration recipe**: one artifact + runtime resolution of the cohort surface.
 
   ```typescript
   // 共享 build 预设里生成 shim：不再 externalize 值导入，求值期用注入的 require 解析
@@ -126,9 +126,9 @@ return result.value
   }
   ```
 
-  只转共享的值表面——cohort 独有导出绝不能 re-export，否则新值导入会在 build 时报 missing-export 而不是静默坏掉。类型导入照旧（编译期擦除）。
+  Only forward the shared value surface — cohort-specific exports must never be re-exported, otherwise new value imports fail at build time with missing-export instead of breaking silently. Type imports stay as before (erased at compile time).
 
-  注入服务从硬 inject 清单拿掉，在使用点探测；cordis `remote` 代理对未注入属性是 throw 而非返回 undefined，所以必须 try/catch 再回落：
+  Take injected services out of the hard inject list and probe them at the use site; the cordis `remote` proxy throws for uninjected properties instead of returning undefined, so you must try/catch and fall back:
 
   ```typescript
   let presets
@@ -136,122 +136,118 @@ return result.value
   const roster = presets ?? ctx.connection.api.agentPresets
   ```
 
-- **宿主平面（Cordis 组合）的等价写法**: 产物不动，cohort 差异放进 `cordis.patch.yml` 的 `!!js` 探测——子路径 resolve、读 preset 文件、探测包目录三种形态和两条纪律见 [host-plane-probes.md](host-plane-probes.md)（[dsh-TUI #622](https://github.com/ccch1mneyyy/dsh-TUI/pull/622)）。
-- **被否决的替代**: per-consumer try/catch 重复污染源码；按宿主 cohort 出不同产物（重新引入有状态构建）；硬等 inject wait（旧宿主永久 pending）。
-- **验证**: 同一份产物分别 link 到旧宿主与新宿主，各跑一次冷启动 + 完整一轮对话。
-- **来源**: [#5120](https://github.com/deepseek-ai/deepseek-harness/discussions/5120) 第 3、4 条。
+- **Host-plane (Cordis composition) equivalent**: keep the artifact unchanged and put the cohort differences into `!!js` probes in `cordis.patch.yml` — the three forms (subpath resolve, reading preset files, probing package directories) and the two disciplines are in [host-plane-probes.md](host-plane-probes.md) ([dsh-TUI #622](https://github.com/ccch1mneyyy/dsh-TUI/pull/622)).
+- **Rejected alternatives**: per-consumer try/catch duplicated through the source; emitting different artifacts per host cohort (reintroduces stateful builds); hard-waiting on inject wait (old hosts pending forever).
+- **Verification**: link the same artifact to both an old host and a new host, and run one cold boot + one full conversation round on each.
+- **Source**: items 3 and 4 of [#5120](https://github.com/deepseek-ai/deepseek-harness/discussions/5120).
 
-### R-03 · 第三方预构建插件搭不上你的 shim
+### R-03 · Third-party prebuilt plugins don't fit your shim
 
-- **类型**: breaking
-- **症状**: 预构建 npm 内容进入 profile，硬 require 旧说明符，在新宿主同样 `missed the module table`。你不构建它，build 预设的 shim 帮不到。
-- **配方**: 仓库自持 `pnpm patch`（`patchedDependencies`），把那一条 require 改写成同样的双 cohort 探测。别忘了 profile 的父层链接——link 脚本可能把链接重指回未打补丁实例，需指到 `patch_hash=…` 实例。
-- **验证**: 打补丁后冷启动，确认该插件的 UI 贡献点可见可用。
-- **来源**: [#5120](https://github.com/deepseek-ai/deepseek-harness/discussions/5120) 第 7 条。
+- **Type**: breaking
+- **Symptoms**: prebuilt npm content enters the profile, hard-requires the old specifier, and hits `missed the module table` on the new host just the same. Since you don't build it, the build preset's shim can't help.
+- **Migration recipe**: keep `pnpm patch` (`patchedDependencies`) in the repository and rewrite that one require as the same dual-cohort probe. Don't forget the profile's parent-layer link — the link script may point the link back at the unpatched instance; it needs to point at the `patch_hash=…` instance.
+- **Verification**: cold boot after patching and confirm the plugin's UI contribution points are visible and usable.
+- **Source**: item 7 of [#5120](https://github.com/deepseek-ai/deepseek-harness/discussions/5120).
 
-### R-04 · CI 与发布管线连带
+### R-04 · CI and release pipeline coupling
 
-- **类型**: process
-- **症状**: overrides 用 file: tarball 后，frozen lockfile 记录机器相关绝对路径，每个 runner `pnpm install --frozen-lockfile` 缺 store。另外 cohort 未发布期间，版本 tag 一旦触发 npm publish，会发出 `@deepseek-ai/*` range 无法从 registry 解析的包，且对该版本不可逆。
-- **配方**:
-  - 加一个脚本在任何机器 materialize tarball store（解析 overrides；store 已存在则秒退），用以 `pnpm-workspace.yaml`（或 `package.json`）hash 为 key 的 actions cache 服务所有 pnpm 消费 job；
-  - `pnpm/action-setup` 删掉 `version` 输入，让 `packageManager` 成为唯一版本来源，避免与钉点冲突；
-  - release workflow 加 `NPM_PUBLISH_ENABLED` 开关：tag 仍跑全部门禁与 smoke，跳过 npm publish，直到 cohort 正式发布；
-  - **插件自身发版的 dist-tag**（实测 2026-08-30）: 适配 alpha cohort 的插件版本用 prerelease 号（如 `0.18.0-alpha.0`）发布到 npm **`alpha` dist-tag**，`latest` 留给 stable 宿主兼容线——否则 stable 宿主用户会被自动升级到 peer 不兼容的新版。可在 release workflow 里按版本号是否含 `-` 自动选 `--tag alpha|latest`；
-  - CI 挂载 lane 钉住与目标 cohort 一致的 dsh CLI 版本，scratch profile 引导时写 `minimumReleaseAgeExclude`（见 R-08），alpha 发布后首日的 CI 才不会因拒装新鲜包而挂。
-- **验证**: 干净 runner 上 `--frozen-lockfile` 安装成功；tag 演练确认未产生 publish。
-- **来源**: [#5120](https://github.com/deepseek-ai/deepseek-harness/discussions/5120) 第 8、9 条。
+- **Type**: process
+- **Symptoms**: once overrides point at file: tarballs, the frozen lockfile records machine-dependent absolute paths, and every runner's `pnpm install --frozen-lockfile` is missing the store. Also, while the cohort is unpublished, a version tag that triggers npm publish ships a package whose `@deepseek-ai/*` ranges cannot resolve from the registry — and that is irreversible for that version.
+- **Migration recipe**:
+  - Add a script that materializes the tarball store on any machine (resolves overrides; exits immediately if the store already exists), backing all pnpm-consuming jobs with an actions cache keyed by the `pnpm-workspace.yaml` (or `package.json`) hash;
+  - Drop the `version` input from `pnpm/action-setup` so `packageManager` becomes the single source of version, avoiding conflicts with the pin;
+  - Add an `NPM_PUBLISH_ENABLED` switch to the release workflow: tags still run all gates and smoke, but skip npm publish until the cohort ships officially;
+  - **dist-tag for the plugin's own releases** (measured 2026-08-30): publish plugin versions that adapt an alpha cohort under a prerelease number (e.g. `0.18.0-alpha.0`) to the npm **`alpha` dist-tag**, keeping `latest` for the stable-host compatibility line — otherwise stable-host users get auto-upgraded to a new version with incompatible peers. The release workflow can pick `--tag alpha|latest` automatically from whether the version contains `-`;
+  - CI mount lanes pin a dsh CLI version matching the target cohort, and write `minimumReleaseAgeExclude` when bootstrapping scratch profiles (see R-08), so CI on the first day after an alpha release does not fail by refusing to install fresh packages.
+- **Verification**: `--frozen-lockfile` install succeeds on a clean runner; a tag rehearsal confirms no publish is produced.
+- **Source**: items 8 and 9 of [#5120](https://github.com/deepseek-ai/deepseek-harness/discussions/5120).
 
-### R-05 · 迁移前盘点被删包的下游
+### R-05 · Pre-migration inventory of removed-package consumers
 
-- **类型**: process
-- **症状**: 依赖被删 SDK 包才能构建的插件（承接 [DSH-0.1.2-A1-01](v0.1.2-alpha.1.md)），迁移中途才发现无法构建，只能随迁移退役。
-- **配方**: 迁移前先对全部插件跑一次「import 了哪些被删包」的盘点，把「必须退役」与「可迁移」分开排期，而不是边迁边发现。
-- **被删包清单**（按各 tag `packages/*/*/package.json` 的 `name` 比对，2026-08-31）: rc.2 → alpha.1 删除 5 个：`@deepseek-ai/dsh-acp-demo`、`dsh-acp-snapshot`、`dsh-client-runtime`、`dsh-host-apiproxy`、`dsh-sdk-jsonrpc-demo`；新增 25 个。alpha.1 → alpha.2 无删除，新增 `dsh-client-ui-schedule`、`dsh-deque`、`dsh-util-time`、`dsh-util-values`。盘点先 grep 这 5 个名字。
-- **验证**: 盘点清单与实际迁移结果一致，无中途新增退役项。
-- **来源**: [#5120](https://github.com/deepseek-ai/deepseek-harness/discussions/5120) 第 10 条。
+- **Type**: process
+- **Symptoms**: a plugin that builds only because it depends on a removed SDK package (continuing from [DSH-0.1.2-A1-01](v0.1.2-alpha.1.md)) is discovered mid-migration to be unbuildable and can only be retired along with the migration.
+- **Migration recipe**: before migrating, run an inventory of "which removed packages are imported" across all plugins, and schedule "must retire" and "migratable" separately instead of discovering them mid-migration.
+- **List of removed packages** (compared by the `name` in each tag's `packages/*/*/package.json`, 2026-08-31): rc.2 → alpha.1 removes 5 — `@deepseek-ai/dsh-acp-demo`, `dsh-acp-snapshot`, `dsh-client-runtime`, `dsh-host-apiproxy`, `dsh-sdk-jsonrpc-demo` — and adds 25. alpha.1 → alpha.2 removes none and adds `dsh-client-ui-schedule`, `dsh-deque`, `dsh-util-time`, `dsh-util-values`. Start the inventory by grepping these 5 names.
+- **Verification**: the inventory matches the actual migration results, with no new retirement items discovered mid-way.
+- **Source**: item 10 of [#5120](https://github.com/deepseek-ai/deepseek-harness/discussions/5120).
 
-### R-06 · 迁移前 baseline 归因——先立豁免清单，再动迁移
+### R-06 · Pre-migration baseline attribution — establish the exemption list first, then migrate
 
-- **类型**: process
-- **症状**: 插件仓库在迁移前就存在失败（旧 cohort 上测试/typecheck 已挂）。迁移后跑
-  机械套件一片红，无法区分「迁移引入」与「本来就有」：顺手把预存失败修掉，会污染
-  迁移 diff、掩盖真实回归；不修不报，则会把预存失败误报为迁移破坏。两个方向都真实
-  发生过：干净树 + 红套件被当回归上报；脏树 + 绿门禁掩盖运行时断链（本文件分层验证
-  清单针对后者，本条针对前者）。
-- **配方**:
-  1. 在任何迁移写入之前，于仓库自身依赖状态（不 pin 目标 cohort、不设目标
-     env 变量）跑一次机械套件（build / typecheck / tests），记录失败清单与失败指纹
-     ——此即 baseline。同时固定环境证据：`HEAD`、工作树状态、lockfile 哈希、解析后
-     的依赖与工具版本、完整命令与退出码（时间戳只是辅助——迁移可能先改完才首次
-     提交，时间戳证不了先后）。
-  2. baseline 失败进入不修豁免清单：迁移过程绝不顺手修复预存失败——那是另一个
-     PR 的事。
-  3. 迁移后对比失败指纹（按命令、测试标识、规范化路径与诊断消息聚合；裸错误行只是
-     近似——移行与堆栈变化会引入噪声）：只有相对 baseline 新增的失败计入迁移
-     失败；测试清单不得无依据减少（删测试让集合缩小不算变绿）。
-  4. 修复循环（若进入）：每轮输入 = 差异报告 + 新增失败（不是全量日志）+ 历史修复
-     报告 + baseline 豁免清单；最小变更，新增失败清零即停——预存失败按定义出局。
-  5. 最终报告按 SKILL.md「验证与报告」的固定分栏输出：pre-existing 出自 baseline
-     （未触碰、不归因于本次迁移）；迁移引入的变化按触点逐项列入「已完成」；残留
-     宿主 patch 连同上游 issue/PR 链接列入「待确认/残留风险」（来源格式同
-     [README.md](README.md) 卡片规范）。
-- **验证**: baseline 采集于任何迁移写入之前（以记录的 `HEAD`/lockfile 哈希等环境
-  证据为准）；终局 diff 不含对 baseline 失败文件的顺手修复；报告能对每条失败回答
-  「迁移前是否已存在」。
-- **来源**: dsh-migrate-bot 无人值守管线的 pre-migration baseline 阶段（机械 pin →
-  A/B 审查 → 修复循环 → 补丁报告之上的本地扩展，专管失败归因；撰写时该阶段尚未
-  公开推送，公开后请复核此说明——见文末「待确认」）。[#5120](https://github.com/deepseek-ai/deepseek-harness/discussions/5120)
-  未覆盖此做法；互补关系：#5120 证明「静态门禁全绿 ≠ 运行时绿」，本条解决另一半
-  ——「静态红 ≠ 迁移的错」。
+- **Type**: process
+- **Symptoms**: the plugin repository already has failures before the migration (tests/typecheck already red on the old cohort). After the migration the
+   mechanical suite is all red, and you cannot tell "introduced by the migration" from "already there": fixing pre-existing failures along the way pollutes
+   the migration diff and masks real regressions; not fixing and not reporting misattributes pre-existing failures to the migration. Both directions have
+   actually happened: a clean tree with a red suite was reported as a regression; a dirty tree with green gates masked a runtime break (the layered validation
+   checklist in this file targets the latter; this entry targets the former).
+- **Migration recipe**:
+  1. Before any migration writes, run the mechanical suite (build / typecheck / tests) in the repository's own dependency state (no target-cohort pin, no target
+     env vars) and record the failure list and failure fingerprints — this is the baseline. Also pin down environment evidence: `HEAD`, working-tree state,
+     lockfile hash, resolved dependency and tool versions, full commands and exit codes (timestamps are only auxiliary — the migration may be fully edited
+     before its first commit, so timestamps cannot prove order).
+  2. Baseline failures go into a do-not-fix exemption list: never fix pre-existing failures along the way during the migration — that belongs in another PR.
+  3. After the migration, compare failure fingerprints (aggregated by command, test identifier, normalized path, and diagnostic message; bare error lines are
+     only an approximation — moved lines and stack changes introduce noise): only failures new relative to the baseline count as migration failures; the test
+     list must not shrink without justification (removing tests so the set gets smaller is not turning green).
+  4. Fix loop (if entered): each round's input = the diff report + newly added failures (not full logs) + the fix history + the baseline exemption list; make
+     minimal changes and stop as soon as new failures hit zero — pre-existing failures are out by definition.
+  5. The final report follows the fixed sections of "Validation and reporting" in SKILL.md: pre-existing comes from the baseline (untouched, not attributed to
+     this migration); migration-introduced changes are listed per touchpoint under "Completed"; residual host patches, together with upstream issue/PR links,
+     go under "Pending/residual risk" (source format per the card spec in [README.md](README.md)).
+- **Verification**: the baseline is collected before any migration writes (per the recorded environment evidence such as `HEAD`/lockfile hash); the final
+  diff contains no incidental fixes to baseline-failing files; the report can answer "did this failure already exist before the migration" for every failure.
+- **Source**: the pre-migration baseline stage of the dsh-migrate-bot unattended pipeline (a local extension on top of mechanical pin →
+  A/B review → fix loop → patch report, dedicated to failure attribution; that stage had not been pushed publicly at the time of writing — re-check this
+  description once it is public; see "Pending confirmation" at the end of this file). [#5120](https://github.com/deepseek-ai/deepseek-harness/discussions/5120)
+  does not cover this practice; they are complementary: #5120 proves "all-green static gates ≠ runtime green", and this entry solves the other half
+  — "static red ≠ the migration's fault".
 
-### R-07 · 启动服务竞态：有界重试，不延迟、不加 inject wait
+### R-07 · Service boot race: bounded retry — no delay, no inject wait
 
-- **类型**: process
-- **症状**: 插件启动即轮询依赖服务，与宿主服务就绪窗口竞态；冷启动出现
-  `service-unavailable` 循环。分层验证清单第 4 层要求观察此症状，但未给处置配方——
-  本条补齐。
-- **配方**: 仅限启动期轮询预期终将就绪的依赖服务、且被轮询操作只读幂等的场景：
-  对 `code: 'service-unavailable'` 做有界重试——约 5 次、2 秒退避，总次数与
-  总时长有上限，重试参数可注入覆盖（便于测试）；耗尽后明确失败并上报，不无限等待。
-  重试前提同 SKILL.md 安全边界：错误可重试、操作幂等、策略允许。若服务在该 cohort
-  上根本不存在（永久缺失而非未就绪），走 R-02 的运行时探测回落，不是重试。
-- **被否决的替代**: 盲目延迟首次轮询（掩盖竞态而非解决）；把服务加回 inject wait
-  （旧 cohort 上入口永久 `pending`，见 R-02）。
-- **验证**: 冷启动日志无 `service-unavailable` 循环；注入的重试策略在测试中生效。
-- **来源**: [#5120](https://github.com/deepseek-ai/deepseek-harness/discussions/5120)
-  第 6 条（dsh-web 迁移记录，boot race 处置；帖内提及决策笔记
-  `2026-08-28-task-board-roster-poll-boot-race.md`，未在仓库中定位到公开副本，故不附直链）。
-  配方出自原帖作者 zhu1090093659，此处仅按 rollup 格式收录并致谢。
+- **Type**: process
+- **Symptoms**: the plugin polls a dependent service immediately at startup and races the host's service-ready window; cold boot shows a
+  `service-unavailable` loop. Layer 4 of the layered validation checklist requires observing this symptom but gives no handling recipe —
+  this entry fills the gap.
+- **Migration recipe**: only for the scenario where startup polls a dependent service expected to become ready, and the polled operation is read-only and idempotent:
+  apply bounded retry to `code: 'service-unavailable'` — about 5 attempts with 2-second backoff, with caps on both total attempts and total duration, and retry
+  parameters overridable by injection (for testability); after exhaustion, fail explicitly and report instead of waiting forever. The retry preconditions are the
+  same as SKILL.md's safety boundaries: the error is retryable, the operation is idempotent, and policy allows. If the service does not exist on that cohort at all
+  (permanently missing, not not-ready), use R-02's runtime-probe fallback rather than retrying.
+- **Rejected alternatives**: blindly delaying the first poll (masks the race instead of solving it); putting the service back into inject wait
+  (entry permanently `pending` on old cohorts, see R-02).
+- **Verification**: no `service-unavailable` loop in the cold-boot logs; the injected retry policy takes effect in tests.
+- **Source**: [#5120](https://github.com/deepseek-ai/deepseek-harness/discussions/5120)
+  item 6 (dsh-web migration record, boot-race handling; the post mentions a decision note
+  `2026-08-28-task-board-roster-poll-boot-race.md`, for which no public copy was located in the repository, so no direct link is attached).
+  The recipe comes from the original post's author, zhu1090093659, recorded here in rollup format with thanks.
 
-### R-08 · 安装通道三坑：镜像延迟、pnpm 11 供应链规则、peer 下限 prerelease 语义
+### R-08 · The three install-channel pitfalls: mirror lag, pnpm 11 supply-chain rules, peer-floor prerelease semantics
 
-- **类型**: process
-- **症状**: cohort 包**已发布**（alpha.2 起，npm `alpha` dist-tag）仍装不上或装不干净，三种独立机制：
-  1. 第三方镜像（npmmirror 等）对新鲜 `@deepseek-ai/*` 发布（含传递依赖）同步滞后数小时以上，安装报 E404/ETARGET；
-  2. pnpm 11 默认的 `minimumReleaseAge`（24h 供应链规则）拒装发布不足一天的新包——alpha 发布当日跑 lane 必撞；另一触发面是旧 lockfile 钉着已从 registry 消失的版本（如 `@deepseek-ai/*@0.0.1-rc.1`）或 `link:` 本地包的依赖，报同类 404/拒装；
-  3. peer 下限写 `^0.1.0-rc.8` 这类旧 range 时，npm semver 的 prerelease 匹配规则（comparator 须同元组且带 prerelease）判定它**不匹配** `0.1.2-alpha.2`——安装期 peer 警告/拒装，且与宿主实际兼容与否无关。
-- **配方**:
-  - 镜像延迟：CLI 安装与 profile 内 pnpm 都显式走官方源 `export npm_config_registry=https://registry.npmjs.org`；
-  - 供应链规则：优先**按作用域豁免**而非全局关闭——消费方 workspace（仓库根**和** scratch/用户 profile 的 `pnpm-workspace.yaml`）加 `minimumReleaseAgeExclude: ['@deepseek-ai/*', <你的插件名>]`；旧 lockfile 钉已消失版本时删除 `pnpm-lock.yaml` 重建；`minimumReleaseAge: 0` 会整仓放行供应链保护，仅作最后手段；
-  - peer 下限：升 cohort 时显式改写为 `^0.1.2-alpha.2`（改写后安装期 `Issues with peer dependencies` 警告消失，可作为落位信号）。
-- **验证**: `pnpm list --depth 0 | grep @deepseek-ai` 全部指向目标版本；`npm view @deepseek-ai/dsh dist-tags` 确认目标版本所属 dist-tag 与安装通道一致；安装日志无 peer 警告。
-- **来源**: 实测（2026-08-30，dsh-better-sidebar [PR #472](https://github.com/omdsh-dev/DSH-better-sidebar/pull/472)：镜像 E404、alpha 发布当日 CI 依赖豁免跑通、peer 下限改写后警告消失）。**未在官方 release notes 覆盖范围内**，属社区实践。
+- **Type**: process
+- **Symptoms**: cohort packages **are published** (on the npm `alpha` dist-tag since alpha.2) yet still fail to install or install uncleanly, through three independent mechanisms:
+  1. Third-party mirrors (npmmirror and the like) lag fresh `@deepseek-ai/*` publications (transitive dependencies included) by hours or more, and installs report E404/ETARGET;
+  2. pnpm 11's default `minimumReleaseAge` (the 24h supply-chain rule) refuses packages released less than a day ago — running a lane on the day an alpha ships hits this for sure; another trigger is an old lockfile pinned to versions that have vanished from the registry (e.g. `@deepseek-ai/*@0.0.1-rc.1`) or dependencies on `link:` local packages, reporting the same kind of 404/refusal;
+  3. when the peer floor is written as an old range like `^0.1.0-rc.8`, npm semver's prerelease matching rules (the comparator must share the same tuple and carry a prerelease) judge it **not to match** `0.1.2-alpha.2` — install-time peer warning/refusal, regardless of actual host compatibility.
+- **Migration recipe**:
+  - Mirror lag: both CLI installs and pnpm inside profiles explicitly use the official registry via `export npm_config_registry=https://registry.npmjs.org`;
+  - Supply-chain rules: prefer **per-scope exemption** over globally disabling — the consuming workspace (the repository root **and** the `pnpm-workspace.yaml` of scratch/user profiles) adds `minimumReleaseAgeExclude: ['@deepseek-ai/*', <your plugin name>]`; when an old lockfile pins vanished versions, delete `pnpm-lock.yaml` and regenerate; `minimumReleaseAge: 0` relaxes supply-chain protection repo-wide and is a last resort only;
+  - Peer floor: when bumping cohorts, explicitly rewrite it to `^0.1.2-alpha.2` (after the rewrite, the install-time `Issues with peer dependencies` warning disappears and can serve as the landed signal).
+- **Verification**: `pnpm list --depth 0 | grep @deepseek-ai` all points at the target version; `npm view @deepseek-ai/dsh dist-tags` confirms the target version's dist-tag matches the install channel; the install log has no peer warnings.
+- **Source**: measured (2026-08-30, dsh-better-sidebar [PR #472](https://github.com/omdsh-dev/DSH-better-sidebar/pull/472): mirror E404, CI dependency exemption working on the day of the alpha release, warnings gone after the peer-floor rewrite). **Not covered by the official release notes**; community practice.
 
-### R-09 · 插件进 profile 的 `link:` 本地安装轨
+### R-09 · The `link:` local install track for adding a plugin to a profile
 
-- **类型**: process
-- **症状**: cohort 未发布 npm 时，[R-01](#r-01--目标-cohort-的依赖包未完整发布-npm) 解决的是插件仓库对 `@deepseek-ai/*` 的依赖；插件本体也要装进 profile 才能做 staging 验证，registry 安装同样不可用（镜像延迟、pnpm 供应链规则与 peer prerelease 语义等 registry 侧坑见安装通道三坑条目）。
-- **配方**: profile 级依赖用 `link:`：在 `profiles/<name>/package.json` 的 dependencies 写 `"<插件包名>": "link:<插件目录绝对路径>"`，`pnpm install` 生成 junction。配套两件事：装配行 `name` 用裸包名（[DSH-0.1.2-A1-26](v0.1.2-alpha.1.md)）；验证一律起独立 staging 实例（`dsh --profile <name> --port 30xx`，token 打在 stdout），不动生产实例。安装轨解析事实与 github 轨坑见 plugin-release skill 的 「profile 依赖管理配方」（#67）。
-- **验证**: junction 生成；`dsh --profile <name> --dump-config` 行名正确、无 pending；boot 图含插件；功能 e2e 通过。
-- **来源**: 社区实战（dsh-input-history 0.1.1 → 0.2.0 迁移，2026-08）；安装轨事实来自 plugin-release 的 profile 依赖管理配方（#67，2026-08-31 已合入）。
+- **Type**: process
+- **Symptoms**: when a cohort is not published to npm, [R-01](#r-01--target-cohort-dependency-packages-not-fully-published-to-npm) covers the plugin repository's dependencies on `@deepseek-ai/*`; the plugin itself also has to be installed into a profile for staging verification, and registry installation is equally unavailable (registry-side pitfalls — mirror lag, pnpm supply-chain rules, peer prerelease semantics — are covered in the install-channel-pitfalls entry).
+- **Migration recipe**: use `link:` for profile-level dependencies — write `"<plugin package name>": "link:<absolute path to the plugin directory>"` into the `dependencies` of `profiles/<name>/package.json`, and `pnpm install` creates a junction. Two things go with it: the composition row's `name` uses the bare package name ([DSH-0.1.2-A1-26](v0.1.2-alpha.1.md)); verification always starts a separate staging instance (`dsh --profile <name> --port 30xx`, with the token printed to stdout) and never touches the production instance. Install-track resolution facts and GitHub-track pitfalls are in the plugin-release skill's "profile dependency management recipe" (#67).
+- **Verification**: the junction is created; `dsh --profile <name> --dump-config` shows the correct row name with nothing pending; the boot graph includes the plugin; functional e2e passes.
+- **Source**: community practice (dsh-input-history 0.1.1 → 0.2.0 migration, 2026-08); the install-track facts come from plugin-release's profile dependency management recipe (#67, merged 2026-08-31).
 
-### R-10 · base-only profile 挂 shipped preset 的新前置（Host scope 服务与同名遮蔽）
+### R-10 · New precondition for mounting a shipped preset on a base-only profile (Host-scope services and same-name shadowing)
 
-- **类型**: behavior
-- **症状**: 仅组合 `dsh-base`（+ 自家 bundle）的 profile 上，挂 shipped `standard` preset 失败：`tool-subagent: modelSelectionSettings requires @deepseek-ai/dsh-tool-subagent/model-selection-settings in the Host scope`；用自定义 root 里同名空 preset 想遮蔽 shipped 时，遮蔽不生效——发现顺序 shipped 优先。
-- **配方**:
-  - Host composition（bundle 的 `cordis.patch.yml`）补一行 `@deepseek-ai/dsh-tool-subagent/model-selection-settings`（官方 web-app bundle 有此行，`dsh-base` 没有）：
+- **Type**: behavior
+- **Symptoms**: on a profile that composes only `dsh-base` (+ your own bundle), mounting the shipped `standard` preset fails: `tool-subagent: modelSelectionSettings requires @deepseek-ai/dsh-tool-subagent/model-selection-settings in the Host scope`; and when you try to shadow the shipped preset with a same-named empty preset in a custom root, the shadowing does not take effect — discovery order favors shipped.
+- **Migration recipe**:
+  - Host composition (the bundle's `cordis.patch.yml`) needs one more line, `@deepseek-ai/dsh-tool-subagent/model-selection-settings` (the official web-app bundle has this line, `dsh-base` does not):
 
     ```yaml
     - insert:
@@ -259,104 +255,104 @@ return result.value
           name: '@deepseek-ai/dsh-tool-subagent/model-selection-settings'
     ```
 
-  - 测试/受控面想用自己的同名 preset 时，agent-presets 配置加 `includeShippedRoot: false`，否则自定义 root 的同名行被 shipped 行遮蔽。
-- **验证**: base-only profile 冷启动无「启动默认预设未生效」警告且 `composedPreset` 返回 standard；`includeShippedRoot: false` 下自定义同名 preset 确实被挂载（而非 shipped 版本）。
-- **来源**: [alpha.2 discovery.ts 健康检查](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/preset/agent-presets/src/discovery.ts) · [alpha.2 standard preset 的 tool-subagent 行](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/preset/agent-presets/presets/standard/agent.cordis.yml) · [官方 web-app bundle 宿主行](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/bundle/web-app/cordis.patch.yml) · dsh-tui 实测（2026-08-30，cordis.patch.yml + preset-join composition 测试）
+  - When a test/controlled surface wants its own same-named preset, add `includeShippedRoot: false` to the agent-presets configuration; otherwise the same-named row in the custom root is shadowed by the shipped row.
+- **Verification**: a base-only profile cold-boots without the "startup default preset did not take effect" warning and `composedPreset` returns standard; with `includeShippedRoot: false` the custom same-named preset is what gets mounted (not the shipped version).
+- **Source**: [alpha.2 discovery.ts health check](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/preset/agent-presets/src/discovery.ts) · [the alpha.2 standard preset's tool-subagent row](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/preset/agent-presets/presets/standard/agent.cordis.yml) · [the official web-app bundle's host row](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/bundle/web-app/cordis.patch.yml) · dsh-tui measurement (2026-08-30, cordis.patch.yml + preset-join composition test)
 
-### R-11 · 0.1.2 类型面导出漂移（未入 release notes 的 ledger）
+### R-11 · 0.1.2 type-surface export drift (ledger not in the release notes)
 
-- **类型**: breaking（typecheck 面）
-- **症状**: rc.2 可直接导入的多个类型/函数在 alpha.2 移包或移出公开面，typecheck 批量 TS2305/TS2614；运行时不一定同步崩，属于「静态漂移」。
-- **配方**（ledger，2026-08-30 按 npm tarball 导出比对；2026-08-31 按三个 tag 源码补齐，每行标了发生在哪条边）:
+- **Type**: breaking (typecheck surface)
+- **Symptoms**: several types/functions directly importable in rc.2 move packages or leave the public surface by alpha.2, and typecheck fails in bulk with TS2305/TS2614; runtime does not necessarily break in sync — this is "static drift".
+- **Migration recipe** (ledger; exports compared from npm tarballs on 2026-08-30, completed against the source of the three tags on 2026-08-31; each row marks which edge it happens on):
 
-  | 旧 | 新 |
+  | Old | New |
   |---|---|
-  | `CallId` from `@deepseek-ai/dsh-llm`（rc.2 → alpha.1，`src/brand.ts:31`） | `ToolCallId`（同包根导出，branded） |
-  | `ClientContext` / `SessionId` / `ConversationNode` / `CommandRowProps` from 已删除的 `dsh-client-runtime/client`（rc.2 → alpha.1） | 分别迁到 Cordis `Context`、`@deepseek-ai/dsh-session/types`、`dsh-client-ui-conversation/client`、`dsh-client-ui-chat/client`；按 owning 包做 type-only augmentation，见 [API-10](api-migration-0.1.2-alpha.2.md#api-10--web-client-runtime-拆包keyed-chat-snapshot-与命令附件参数) |
-  | `useSession` 读取 `ConversationSnapshot.nodes[]`（rc.2 → alpha.1） | alpha.2 用 `useChat`，按 `ChatSnapshot.order` 保序并 `nodes.get(id)`；alpha.2-only 代码不以 `legacy.nodes` 为主数据面 |
-  | Host `ctx.commands.execute(agent, line, signal)`（rc.2 → alpha.1） | `ctx.commands.execute(agent, line, images, signal)`；无图片显式传 `[]` |
-  | `JsonValue`、`isJsonValue`、`snapshotJsonValue` from `@deepseek-ai/dsh-session`，以及 `dsh-tools` 对 `JsonValue` 的再导出（alpha.1 → alpha.2） | 新包 `@deepseek-ai/dsh-util-values`（补直接依赖，见 [DSH-0.1.2-A2-03](v0.1.2-alpha.2.md)） |
-  | `deepFreeze`、`assertNever` from `@deepseek-ai/dsh-llm`（alpha.1 → alpha.2） | `@deepseek-ai/dsh-util-values` |
-  | `collectSessionTitleMessages` from `@deepseek-ai/dsh-session-title`（alpha.1 → alpha.2，`src/index.ts:167` 转私有） | 移出公开面——按 rc.2 同语义本地折叠（首条 `source.kind === 'user'` 的 `user/message` 文本）或走 `foldSessionTitle` |
-  | `'todo/write'` 的 `SessionEventMap` 类型声明（rc.2 → alpha.1；rc.2 在 `core/session/src/invariant.ts:150` 直接 switch） | 只在 `@deepseek-ai/dsh-tool-todo` 内合并；不依赖该包时本地按官方 `TodoItem` 结构补 `declare module '@deepseek-ai/dsh-session/types'`（runtime 事件词汇未变，`known-event-types` 仍收录） |
-  | `settingsNamespace()`、`installSettingsSection()`、`deepEqualJson()` from `@deepseek-ai/dsh-settings`（alpha.1 → alpha.2） | 全部删除。命名空间改普通字符串字面量，`SettingsProvider.register<const Namespace extends string, T>(ns: Namespace & SettingsNamespaceInput<Namespace>, …)` 编译期校验（`src/index.ts:419`）；`installSettingsSection` → `SettingsProvider.installSection(owner, ns, schema, entry, hooks)`；`deepEqualJson` → `dsh-util-values`。要一份源码同时编译过 alpha.1 和 alpha.2，把常量写成 `'my-ns' as SettingsNamespace`——brand 只在类型层，运行时值相同 |
-  | `InvalidPresetIdError`、`PresetExistsError`、`PresetNotWritableError`、`PresetLockedError`、`PresetMountError`、`UnknownPresetError`、`AgentPresetError`、`AgentPresetErrorDetailsMap` from `@deepseek-ai/dsh-agent-presets`（alpha.1 → alpha.2） | 删除，改 `RemoteError<'agent-preset/not-found' \| 'agent-preset/invalid' \| 'agent-preset/read-only' \| 'agent-preset/locked'>`（`src/types.ts:37-43`）；`instanceof XxxError` 改按 `code` 分支，见 [DSH-0.1.2-A2-02](v0.1.2-alpha.2.md) |
-  | `LlmModelDiscoveryError` from `@deepseek-ai/dsh-llm`（code `model-discovery-failed`；alpha.1 → alpha.2） | `RemoteError<'llm/model-discovery-rejected'>`（`src/types.ts:261`） |
-  | `FIRST_PARTY_SECTION_ORDER`、`PERSONA_ORDER` from `@deepseek-ai/dsh-system-prompt`（alpha.1 → alpha.2） | 删除，改 `systemPrompt.getSectionOrder(name)` / `getContextOrder(name)`（参数类型 `PromptSectionOrderName` / `PromptContextOrderName`） |
-  | `TypertRemoteFailure`、`TypertLookupFailure` from `@deepseek-ai/dsh-typert-protocol`；`RemoteStreamError` from `@deepseek-ai/dsh-api-gateway/client`；`RpcErrorDetailsMap`、`RpcErrorCode`、`RpcError` from `@deepseek-ai/dsh-client-connection`（alpha.1 → alpha.2） | 删除，统一 `RemoteError`，见 [DSH-0.1.2-A2-02](v0.1.2-alpha.2.md) |
+  | `CallId` from `@deepseek-ai/dsh-llm` (rc.2 → alpha.1, `src/brand.ts:31`) | `ToolCallId` (same package, root export, branded) |
+  | `ClientContext` / `SessionId` / `ConversationNode` / `CommandRowProps` from the removed `dsh-client-runtime/client` (rc.2 → alpha.1) | moved to Cordis `Context`, `@deepseek-ai/dsh-session/types`, `dsh-client-ui-conversation/client`, and `dsh-client-ui-chat/client` respectively; do type-only augmentation per owning package — see [API-10](api-migration-0.1.2-alpha.2.md#api-10--web-client-runtime-unbundling-keyed-chat-snapshots-and-command-attachment-parameters) |
+  | `useSession` reading `ConversationSnapshot.nodes[]` (rc.2 → alpha.1) | on alpha.2 use `useChat`, keeping order via `ChatSnapshot.order` with `nodes.get(id)`; alpha.2-only code must not treat `legacy.nodes` as the primary data surface |
+  | Host `ctx.commands.execute(agent, line, signal)` (rc.2 → alpha.1) | `ctx.commands.execute(agent, line, images, signal)`; pass `[]` explicitly when there are no images |
+  | `JsonValue`, `isJsonValue`, `snapshotJsonValue` from `@deepseek-ai/dsh-session`, plus `dsh-tools`' re-export of `JsonValue` (alpha.1 → alpha.2) | the new package `@deepseek-ai/dsh-util-values` (add it as a direct dependency — see [DSH-0.1.2-A2-03](v0.1.2-alpha.2.md)) |
+  | `deepFreeze`, `assertNever` from `@deepseek-ai/dsh-llm` (alpha.1 → alpha.2) | `@deepseek-ai/dsh-util-values` |
+  | `collectSessionTitleMessages` from `@deepseek-ai/dsh-session-title` (alpha.1 → alpha.2, made private at `src/index.ts:167`) | moved off the public surface — fold locally with rc.2-equivalent semantics (the text of the first `user/message` whose `source.kind === 'user'`) or use `foldSessionTitle` |
+  | the `SessionEventMap` type declaration for `'todo/write'` (rc.2 → alpha.1; rc.2 switches directly at `core/session/src/invariant.ts:150`) | merged only inside `@deepseek-ai/dsh-tool-todo`; if you don't depend on that package, add a local `declare module '@deepseek-ai/dsh-session/types'` matching the official `TodoItem` structure (the runtime event vocabulary is unchanged and `known-event-types` still lists it) |
+  | `settingsNamespace()`, `installSettingsSection()`, `deepEqualJson()` from `@deepseek-ai/dsh-settings` (alpha.1 → alpha.2) | all deleted. Namespaces become plain string literals validated at compile time by `SettingsProvider.register<const Namespace extends string, T>(ns: Namespace & SettingsNamespaceInput<Namespace>, …)` (`src/index.ts:419`); `installSettingsSection` → `SettingsProvider.installSection(owner, ns, schema, entry, hooks)`; `deepEqualJson` → `dsh-util-values`. To have one source compile on both alpha.1 and alpha.2, write constants as `'my-ns' as SettingsNamespace` — the brand exists only at the type level; the runtime value is the same |
+  | `InvalidPresetIdError`, `PresetExistsError`, `PresetNotWritableError`, `PresetLockedError`, `PresetMountError`, `UnknownPresetError`, `AgentPresetError`, `AgentPresetErrorDetailsMap` from `@deepseek-ai/dsh-agent-presets` (alpha.1 → alpha.2) | deleted, replaced by `RemoteError<'agent-preset/not-found' \| 'agent-preset/invalid' \| 'agent-preset/read-only' \| 'agent-preset/locked'>` (`src/types.ts:37-43`); switch `instanceof XxxError` to branching on `code` — see [DSH-0.1.2-A2-02](v0.1.2-alpha.2.md) |
+  | `LlmModelDiscoveryError` from `@deepseek-ai/dsh-llm` (code `model-discovery-failed`; alpha.1 → alpha.2) | `RemoteError<'llm/model-discovery-rejected'>` (`src/types.ts:261`) |
+  | `FIRST_PARTY_SECTION_ORDER`, `PERSONA_ORDER` from `@deepseek-ai/dsh-system-prompt` (alpha.1 → alpha.2) | deleted, replaced by `systemPrompt.getSectionOrder(name)` / `getContextOrder(name)` (parameter types `PromptSectionOrderName` / `PromptContextOrderName`) |
+  | `TypertRemoteFailure`, `TypertLookupFailure` from `@deepseek-ai/dsh-typert-protocol`; `RemoteStreamError` from `@deepseek-ai/dsh-api-gateway/client`; `RpcErrorDetailsMap`, `RpcErrorCode`, `RpcError` from `@deepseek-ai/dsh-client-connection` (alpha.1 → alpha.2) | deleted, unified into `RemoteError` — see [DSH-0.1.2-A2-02](v0.1.2-alpha.2.md) |
 
-- **验证**: typecheck 全绿且不靠 `@ts-ignore`；本地合并的声明与官方结构逐字段一致；运行时事件流与 rc.2 相同。
-- **来源**: 各包 `0.1.2-alpha.2` tarball 导出比对 + [alpha.2 todo 工具 types.ts](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/todo/tool-todo/src/types.ts) · [alpha.2 `dsh-util-values`](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/util/values/src/index.ts) · [alpha.2 settings `register` 签名](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/settings/settings/src/index.ts) · [alpha.2 agent-presets 错误码](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/preset/agent-presets/src/types.ts) · [alpha.2 system-prompt](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/core/system-prompt/src/index.ts) · [alpha.2 llm types](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/llm/llm/src/types.ts) · [rc.2 `CallId`](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.1-rc.2/packages/llm/llm/src/brand.ts) · dsh-tui 实测（2026-08-30）· [dsh-TUI #647](https://github.com/ccch1mneyyy/dsh-TUI/pull/647)（`settingsNamespace` 是 alpha.1 → alpha.2 唯一的编译中断）
-### R-12 · 升级对象可能就是当前运行宿主
+- **Verification**: typecheck all green without relying on `@ts-ignore`; locally merged declarations match the official structures field by field; the runtime event flow is the same as rc.2.
+- **Source**: comparison of each package's `0.1.2-alpha.2` tarball exports + [alpha.2 todo tool types.ts](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/todo/tool-todo/src/types.ts) · [alpha.2 `dsh-util-values`](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/util/values/src/index.ts) · [alpha.2 settings `register` signature](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/settings/settings/src/index.ts) · [alpha.2 agent-presets error codes](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/preset/agent-presets/src/types.ts) · [alpha.2 system-prompt](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/core/system-prompt/src/index.ts) · [alpha.2 llm types](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/llm/llm/src/types.ts) · [rc.2 `CallId`](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.1-rc.2/packages/llm/llm/src/brand.ts) · dsh-tui measurement (2026-08-30) · [dsh-TUI #647](https://github.com/ccch1mneyyy/dsh-TUI/pull/647) (`settingsNamespace` is the only compile break in alpha.1 → alpha.2)
 
-- **类型**: security
-- **症状**:
-  在 DSH 内部开发或升级插件时，被修改的插件、preset、runtime 组件或其依赖，可能同时就是当前正在运行的 Harness 的一部分。
+### R-12 · The upgrade target may be the currently running host
 
-  因此，一些普通的升级操作可能直接影响正在执行升级任务本身的运行环境，例如停止或重启 DSH、修改当前使用的 preset、修改 Harness runtime，或卸载当前运行环境正在依赖的插件。
+- **Type**: security
+- **Symptoms**:
+   When developing or upgrading plugins inside DSH itself, the plugin, preset, runtime component, or dependency being modified may also be part of the Harness that is currently running.
 
-- **配方**:
-  在执行可能影响运行宿主的操作前，先确认升级目标是否属于当前 session / profile / Harness host。
+   As a result, ordinary upgrade operations can directly affect the runtime environment that is executing the upgrade task itself — for example, stopping or restarting DSH, modifying the preset currently in use, modifying the Harness runtime, or uninstalling a plugin the current runtime depends on.
 
-  至少确认：
-  1. 目标插件是否正在当前 profile 中运行；
-  2. 目标 preset 是否就是当前 Agent 使用的 preset；
-  3. 被修改的 runtime / dependency 是否支撑当前 Harness；
-  4. 准备卸载的插件是否仍被当前运行环境依赖。
+- **Migration recipe**:
+   Before performing an operation that could affect the running host, first confirm whether the upgrade target belongs to the current session / profile / Harness host.
 
-  如果目标同时属于当前运行宿主，不应让 Agent 无条件执行可能导致宿主失效的操作。优先交回用户确认，或通过外部 / 人工路径完成恢复。
+   At minimum, confirm:
+   1. whether the target plugin is running in the current profile;
+   2. whether the target preset is the preset the current Agent uses;
+   3. whether the runtime / dependency being modified underpins the current Harness;
+   4. whether the plugin about to be uninstalled is still depended on by the current runtime.
 
-  对 `stop → start` 一类操作，尽量把整个切换视为一个原子操作，并确保存在独立的恢复路径。
+   If the target also belongs to the currently running host, the Agent must not unconditionally perform operations that could take the host down. Hand control back to the user for confirmation, or complete recovery through an external / manual path.
 
-- **验证**:
-  升级前能够识别当前 Harness 与升级目标之间的依赖关系。
+   For operations like `stop → start`, treat the whole switch as one atomic operation where possible, and make sure an independent recovery path exists.
 
-  对可能影响宿主的操作，应确认：
-  - 当前宿主不会在仍依赖目标时被直接卸载或破坏；
-  - 重启操作存在明确的恢复入口；
-  - 宿主失效后仍有独立方式完成恢复或回滚。
+- **Verification**:
+   Before the upgrade, be able to identify the dependency relationship between the current Harness and the upgrade target.
 
-  本条属于升级前的安全检查，不以“插件成功加载”作为充分验证条件。
+   For operations that may affect the host, confirm:
+   - the current host is not directly uninstalled or broken while it still depends on the target;
+   - the restart operation has a clear recovery entry point;
+   - there is still an independent way to recover or roll back if the host fails.
 
-- **来源**:
-  来自 [DeepSeek Harness Discussion #5120](https://github.com/deepseek-ai/deepseek-harness/discussions/5120) 的社区升级讨论背景，以及此前在 DSH 内部进行插件开发和升级时的实际观察。
+   This entry is a pre-upgrade safety check; "the plugin loaded successfully" is not a sufficient verification condition.
 
-### R-13 · 客户端产品文案迁到本地化 seat 后，按默认语言显示文本锚定宿主 UI 的插件会静默失效
+- **Source**:
+   The background of the community upgrade discussion in [DeepSeek Harness Discussion #5120](https://github.com/deepseek-ai/deepseek-harness/discussions/5120), plus observations from earlier plugin development and upgrades done inside DSH itself.
 
-- **类型**: behavior（组合效应）
-- **症状**: 此走廊几乎把全部 client 包的产品文案迁到 typed `t` / 字典（client-locale full rollout）。宿主 UI 中原本硬编码/固定英文的按钮、导航、预设标签改为按 locale 渲染（如「Session log」→「Session 日志」、权限预设「Full access」→「完全权限」、`access.fullLabel` 删除、新增 `access.preset.readOnly/workspaceWrite/fullAccess`）。凡是**按宿主控件显示文本**定位/匹配宿主 UI 的插件，默认语言正则不再命中 → 定位返回 `null` → 注入项（分享入口、标签等）静默消失，无报错、无 console 异常。
-- **配方**:
-  1. 定位宿主 UI 容器**优先用稳定 slot / data-slot 锚点**（如 `[data-slot="conversation.session.header.utilities"]`），不要依赖显示文本；
-  2. 确需文本匹配时**覆盖所有语言变体**（例 `/session\s*(?:log|日志)/i`），并限定长度/作用域，避免命中无关按钮；
-  3. 注入后**显式断言注入项真的渲染**（存在、非空、同排），把「定位返回 null → 元素静默缺失」变成可观测失败；
-  4. 提供本地化资源的 UI 插件用宿主公开语言注册座位，替代自建 i18n patch，见 [DSH-0.1.2-A1-10](v0.1.2-alpha.1.md)。
-- **验证**: 切非英文语言后硬刷新，断言注入项仍出现在宿主工具区、与宿主按钮同排、点击可用；中英文各跑一遍。
-- **来源**: [client-locale-full-rollout note](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/.agents/notes/implemented/architecture/2026-07-30-client-locale-full-rollout.md) · [alpha.2 `HeaderAction.tsx`（`t('header.action')`）](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/session-query/session-log-export/src/client/HeaderAction.tsx) · [alpha.2 `PermissionSelect.tsx`（`access.preset.*`）](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/client/ui-conversation/src/client/skeleton/PermissionSelect.tsx) · [alpha.2 `locales.ts`（access 文案）](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/client/ui-conversation/src/client/locales.ts)
+### R-13 · After client product copy moves to localized seats, plugins that anchor to host UI by displayed text fail silently
 
-## 分层验证清单
+- **Type**: behavior (combined effect)
+- **Symptoms**: this corridor moves almost all client-package product copy to typed `t` / dictionaries (client-locale full rollout). Buttons, navigation, and preset labels in the host UI that were previously hardcoded/fixed English now render per locale (e.g. "Session log" → "Session 日志", the permission preset "Full access" → "完全权限", `access.fullLabel` removed, `access.preset.readOnly/workspaceWrite/fullAccess` added). Any plugin that locates/matches host UI **by the displayed text of host controls** no longer hits with the default-language regex → the lookup returns `null` → injected items (share entries, labels, etc.) disappear silently, with no error and no console exception.
+- **Migration recipe**:
+  1. When locating host-UI containers, **prefer stable slot / data-slot anchors** (e.g. `[data-slot="conversation.session.header.utilities"]`) over displayed text;
+  2. when text matching is truly needed, **cover all language variants** (e.g. `/session\s*(?:log|日志)/i`) and constrain the length/scope so unrelated buttons are not matched;
+  3. after injection, **explicitly assert the injected item actually renders** (present, non-empty, same row), turning "lookup returns null → element silently missing" into an observable failure;
+  4. UI plugins that provide localized resources should register through the host's public language seat instead of a self-built i18n patch — see [DSH-0.1.2-A1-10](v0.1.2-alpha.1.md).
+- **Verification**: switch to a non-English language and hard-refresh, then assert the injected item still appears in the host tool area, sits in the same row as host buttons, and is clickable; run it once in Chinese and once in English.
+- **Source**: [client-locale-full-rollout note](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/.agents/notes/implemented/architecture/2026-07-30-client-locale-full-rollout.md) · [alpha.2 `HeaderAction.tsx` (`t('header.action')`)](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/session-query/session-log-export/src/client/HeaderAction.tsx) · [alpha.2 `PermissionSelect.tsx` (`access.preset.*`)](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/client/ui-conversation/src/client/skeleton/PermissionSelect.tsx) · [alpha.2 `locales.ts` (access copy)](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/client/ui-conversation/src/client/locales.ts)
 
-按顺序跑（第 0 层仅采集基线，不设通过门槛）；此后前一层不过不进下一层：
+## Layered validation checklist
 
-0. **baseline（迁移动手前）**: 在仓库自身依赖状态跑机械套件，记录失败指纹与豁免
-   清单（见 R-06）。第 2、3 层（静态与卡片级单测）的失败判定以「相对 baseline
-   新增」为准；其余层没有对应基线，保持各自的绝对门槛。
-1. **依赖解析**: `pnpm list --depth 0 | grep @deepseek-ai` 版本一致；扫描完整 lockfile，确认无旧 cohort、已删除 `dsh-client-runtime` 或偶然保留的旧 peer provider。
-2. **静态**: typecheck + build。注意静态全绿证明不了 wire 契约正确——描述符层的参数漂移在这一层是静默的（[DSH-0.1.2-A1-01](v0.1.2-alpha.1.md)）。
-3. **卡片级单测**: 每个命中触点至少一条断言。Remote 调用点覆盖 `ok: false` 的已知业务码、未知码兜底，以及 gateway 层 catch 分支；测试替身编码同一套描述符表，多/缺 key 就 fail，让漂移变成测试失败事件。另防「静默吞错」：调用点把错误 catch 掉会让 UI 永远空白而所有冒烟照绿（实例见 [DSH-0.1.2-A1-30](v0.1.2-alpha.1.md) 实战批注）——契约形状必须由单测钉死，空 UI 在验证里视同失败。
-4. **真实冷启动**: 完整一轮对话（发消息 → 工具调用 → 回复）。观察日志无 `missed the module table`、无 `service-unavailable` 循环、无入口 `pending`。Web Client 插件另按 [DSH-0.1.2-A1-19](v0.1.2-alpha.1.md) 用打印 token URL 换 Cookie，读取 boot entry、请求宿主公告资源，并验证 bundle 注册、真实挂载、remove 与 page error；注册 id 与包名对齐核对 [DSH-0.1.2-A1-26](v0.1.2-alpha.1.md)。无 API key 也能确定性执行这层的替代形态——**挂载冒烟**：`pnpm build && pnpm pack` 出 tarball → 钉版 CLI `dsh plugin --profile web add file:<tarball>` 装进全新 scratch profile → 启动 keyless `dsh web --port 0` → Playwright 无头渲染逐 tab 扫描（断言挂载标记、无 pageerror/console 错误、懒加载 chunk 正常下发）。参考实现：[dsh-better-sidebar e2e-mount.sh](https://github.com/omdsh-dev/DSH-better-sidebar/blob/main/scripts/e2e-mount.sh)。
-5. **跨 cohort**（若做了 R-02）: 旧宿主与新宿主各跑一次第 4 步。
-6. **headless**（若命中 #7）: 比对退出码及 stdout/stderr 内容分类（[DSH-0.1.2-A1-05](v0.1.2-alpha.1.md)）。
+Run in order (layer 0 only collects the baseline and sets no pass threshold); from then on, do not proceed to the next layer until the previous one passes:
 
-## 回退
+0. **Baseline (before touching the migration)**: run the mechanical suite in the repository's own dependency state and record failure fingerprints and the exemption
+   list (see R-06). Layers 2 and 3 (static and card-level unit tests) judge failure as "new relative to baseline"; the other layers have no corresponding baseline and keep their own absolute thresholds.
+1. **Dependency resolution**: `pnpm list --depth 0 | grep @deepseek-ai` versions consistent; scan the full lockfile and confirm there is no old cohort, no removed `dsh-client-runtime`, and no accidentally retained old peer provider.
+2. **Static**: typecheck + build. Note that all-green static checks cannot prove the wire contract — parameter drift at the descriptor layer is silent at this layer ([DSH-0.1.2-A1-01](v0.1.2-alpha.1.md)).
+3. **Card-level unit tests**: at least one assertion per hit touchpoint. Remote call sites cover the known business codes on `ok: false`, the unknown-code fallback, and the gateway-layer catch branch; test doubles encode the same descriptor table and fail when keys are extra or missing, turning drift into a test-failure event. Also guard against "silent error swallowing": a call site that catches the error leaves the UI blank forever while every smoke stays green (a real instance is in the field note of [DSH-0.1.2-A1-30](v0.1.2-alpha.1.md)) — the contract shape must be pinned down by unit tests, and an empty UI counts as a failure in validation.
+4. **Real cold boot**: one full conversation round (send message → tool call → reply). Observe the logs for no `missed the module table`, no `service-unavailable` loop, and no entry `pending`. Web Client plugins additionally follow [DSH-0.1.2-A1-19](v0.1.2-alpha.1.md): exchange the printed token URL for the cookie, read the boot entry, request the host's advertised resources, and verify bundle registration, real mount, remove, and page errors; check the registration id against the package name per [DSH-0.1.2-A1-26](v0.1.2-alpha.1.md). The alternative form of this layer that runs deterministically without an API key is the **mount smoke**: `pnpm build && pnpm pack` produces a tarball → a pinned CLI installs it into a fresh scratch profile with `dsh plugin --profile web add file:<tarball>` → start keyless `dsh web --port 0` → Playwright headless rendering scans tab by tab (asserting mount markers, no pageerror/console errors, and lazy chunks delivered correctly). Reference implementation: [dsh-better-sidebar e2e-mount.sh](https://github.com/omdsh-dev/DSH-better-sidebar/blob/main/scripts/e2e-mount.sh).
+5. **Cross-cohort** (if R-02 was applied): run step 4 once on the old host and once on the new host.
+6. **Headless** (if #7 is hit): compare exit codes and stdout/stderr content classification ([DSH-0.1.2-A1-05](v0.1.2-alpha.1.md)).
 
-1. 升级前记录 branch/HEAD、resolved 版本、lockfile 与将改配置的 hash；有陌生修改就停止；
-2. 在独立 branch/worktree 迁移，不自动 stash/reset/clean/checkout 用户文件；
-3. tarball overrides 回退只恢复本次明确拥有的配置与 lockfile 路径，并在执行前展示 diff、取得确认；
-4. 第三方 lifecycle script 的任意副作用不能承诺由 Git 回滚；如实列出残留风险；
-5. 若问题源于宿主升级，优先切回记录的宿主版本，而不是盲目扩大插件双版本分支。
+## Rollback
 
-## 待确认
+1. Before upgrading, record branch/HEAD, resolved versions, the lockfile, and hashes of the configuration that will change; stop if there are unfamiliar modifications;
+2. migrate in a dedicated branch/worktree; never auto-stash, reset, clean, or checkout user files;
+3. tarball-overrides rollback restores only the configuration and lockfile paths explicitly owned by this task, and shows the diff and obtains confirmation before executing;
+4. arbitrary side effects of third-party lifecycle scripts cannot be promised rollback via Git; list residual risks truthfully;
+5. if the problem originates from a host upgrade, prefer switching back to the recorded host version rather than blindly widening the plugin's dual-version branching.
 
-- 0.1.2 正式版的 dist-tag、final tag 名与 alpha.2 的差异，需在发版后复核本文件全部条目；
-- R-01/R-02 的 pnpm 版本敏感性与 R-07 的重试参数（约 5 次 / 2 秒退避）均来自单一实战报告，未在其他仓库复现验证；
-- R-06 的 baseline 阶段实现尚未公开推送，公开后复核其来源说明。R-06 属待验证实践（单一管线来源、无多仓库复现）：模式 C 第 0 步是强烈建议的默认动作，可按目标仓库实际情况裁量。
+## Pending confirmation
+
+- The 0.1.2 final release's dist-tag, final tag name, and differences from alpha.2 — all entries in this file must be re-reviewed after the release;
+- R-01/R-02's pnpm version sensitivity and R-07's retry parameters (~5 attempts / 2-second backoff) both come from a single field report and have not been reproduced in other repositories;
+- R-06's baseline-stage implementation has not been pushed publicly yet; re-check its source description once it is public. R-06 is an unverified practice (single-pipeline source, no multi-repository reproduction): step 0 of Mode C is the strongly recommended default action, adjustable to the target repository's actual situation.

--- a/skills/plugin-upgrade/references/troubleshooting.md
+++ b/skills/plugin-upgrade/references/troubleshooting.md
@@ -1,15 +1,13 @@
-# Troubleshooting · 迁移后症状反查
+# Troubleshooting · post-migration symptom lookup
 
-> 按症状反查根因与对应卡片的速查表，供模式 C 迁移后排障使用。它不是决策流程，也
-> 不是完整故障典：根因确认仍以卡片配方与目标 tag 源码为准；未列出的症状回到
-> pre-flight 触点与分层验证清单逐层排查。
+> Quick-reference table for tracing symptoms back to root causes and their cards, for debugging after Mode C migrations. It is not a decision flow, nor a complete fault catalog: root-cause confirmation still rests on the card recipes and the target tag's source; symptoms not listed here return to the pre-flight touchpoints and the layered validation checklist for layer-by-layer triage.
 
-| 症状 | 最可能根因 | 先看哪张卡 |
+| Symptom | Most likely root cause | Card to check first |
 |---|---|---|
-| 面板/悬浮球静默消失，boot 图无此插件，且常无任何报错 | `dsh.client.inject` 残留已拆除的包（幻影依赖）导致行不进图；或注册 id / 装配行名与包名不一致；或插件在 patch 层被 `disabled: true` | [DSH-0.1.2-A1-25](v0.1.2-alpha.1.md)、[DSH-0.1.2-A1-26](v0.1.2-alpha.1.md) |
-| 启动断言 `loaded without registering "<id>"` | client bundle 注册 id（`__ModuleLoader__.load` 的 id / tsdown banner `PLUGIN_ID`）≠ package.json `name`，或装配行 `name` 不是裸包名 | [DSH-0.1.2-A1-26](v0.1.2-alpha.1.md) |
-| `web boot: N entries did not activate`，`waiting for service: apiProxy` | 0.1.2 移除 ApiProxy 传输层，`require: ['apiProxy']` 的行永久 pending；或 inject 残留已拆除的包 | [DSH-0.1.2-A1-01](v0.1.2-alpha.1.md)、[DSH-0.1.2-A1-25](v0.1.2-alpha.1.md) |
-| 插件加载但功能半失效，console 报 factory 错误 | 会话内容读取路径失效（per-session `.nodes` 快照已移除）或 composer DOM 漂移 | [DSH-0.1.2-A1-27](v0.1.2-alpha.1.md)、[DSH-0.1.2-A1-28](v0.1.2-alpha.1.md) |
-| 旧宿主上报 `missed the module table` | client bundle 求值期硬 require 目标 cohort 独有的模块（跨 cohort 共存问题） | rollup [R-02](rollup-0.1.2.md) |
+| Panel/floating ball silently disappears, the plugin is absent from the boot graph, usually with no error at all | `dsh.client.inject` still references a removed package (phantom dependency), so the row never enters the graph; or the registration id / assembly row name does not match the package name; or the plugin is `disabled: true` at the patch layer | [DSH-0.1.2-A1-25](v0.1.2-alpha.1.md), [DSH-0.1.2-A1-26](v0.1.2-alpha.1.md) |
+| Startup assertion `loaded without registering "<id>"` | the client bundle's registration id (`__ModuleLoader__.load` id / tsdown banner `PLUGIN_ID`) ≠ package.json `name`, or the assembly row's `name` is not the bare package name | [DSH-0.1.2-A1-26](v0.1.2-alpha.1.md) |
+| `web boot: N entries did not activate`, `waiting for service: apiProxy` | 0.1.2 removed the ApiProxy transport layer, so a row with `require: ['apiProxy']` stays pending forever; or inject still references a removed package | [DSH-0.1.2-A1-01](v0.1.2-alpha.1.md), [DSH-0.1.2-A1-25](v0.1.2-alpha.1.md) |
+| Plugin loads but features half fail, console reports a factory error | the session-content read path is broken (per-session `.nodes` snapshot removed) or the composer DOM has drifted | [DSH-0.1.2-A1-27](v0.1.2-alpha.1.md), [DSH-0.1.2-A1-28](v0.1.2-alpha.1.md) |
+| Old host reports `missed the module table` | the client bundle hard-requires a module unique to the target cohort during evaluation (cross-cohort coexistence problem) | rollup [R-02](rollup-0.1.2.md) |
 
-- **来源**: dsh-input-history 0.1.1 → 0.2.0 实测迁移（2026-08）；末行来自 [discussion #5120](https://github.com/deepseek-ai/deepseek-harness/discussions/5120)。
+- **Source**: real migration of dsh-input-history 0.1.1 → 0.2.0 (2026-08); the last row comes from [discussion #5120](https://github.com/deepseek-ai/deepseek-harness/discussions/5120).

--- a/skills/plugin-upgrade/references/v0.1.1-rc.2.md
+++ b/skills/plugin-upgrade/references/v0.1.1-rc.2.md
@@ -12,37 +12,37 @@ verifiedAt: 2026-08-31
 
 # DSH v0.1.1-rc.1 → v0.1.1-rc.2
 
-> 本卡片集只收录已核对的插件可观察变化，不是完整 API diff。rc.2 的 release notes 将本次版本描述为图像上传与预处理改进；卡片同时核对了对应的 rc.1/rc.2 源码。
+> This card set contains only verified plugin-observable changes, not a complete API diff. The rc.2 release notes describe this version as image upload and preprocessing improvements; the cards also cross-checked the corresponding rc.1/rc.2 sources.
 
-### DSH-0.1.1-R2-01 · 图片附件引用增加原始尺寸信息
+### DSH-0.1.1-R2-01 · Image attachment refs gain original dimensions
 
-- **类型**: behavior
-- **适用对象**: 使用 `ImageAttachmentRef`、`read_image` 输出或自行持久化图片元数据的插件
-- **影响触点**: #5
-- **操作级别**: conditional
-- **症状**: rc.2 的图片附件引用新增可选 `originalDimensions`。当宿主在入库时对图片做了归一化缩放，插件收到的引用可能同时包含原始宽高；只接受固定字段集合的 schema、快照或序列化逻辑可能拒绝这个新增字段。
-- **迁移配方**: 对图片引用和 `read_image` 结果采用“已知字段读取、未知可选字段保留”的方式；若插件自有 schema 使用 `additionalProperties: false`，为 `originalDimensions.width` 与 `originalDimensions.height` 增加可选字段。不要把该字段当作每张图片都存在的必填字段。
-- **验证**: 在 rc.2 的目标 Profile 中读取一张触发归一化的超尺寸图片，确认 `width/height` 是归一化后的尺寸，并在存在时保留 `originalDimensions`；对未缩放图片确认不会凭空生成该字段。检查持久化记录和模型可见结果均能正常解码。
-- **来源**: rc.1 类型基线 [`types.ts`](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.1-rc.1/packages/attachment/attachment/src/types.ts)；rc.2 类型定义 [`types.ts`](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.1-rc.2/packages/attachment/attachment/src/types.ts)；引入变化的固定提交 [`8f83853b601b`](https://github.com/deepseek-ai/deepseek-harness/commit/8f83853b601b)
+- **Type**: behavior
+- **Applies to**: Plugins that use `ImageAttachmentRef`, `read_image` output, or persist image metadata themselves
+- **Touchpoints**: #5
+- **Action level**: conditional
+- **Symptoms**: Image attachment refs in rc.2 gain an optional `originalDimensions`. When the host applies normalized scaling to images on ingest, the refs a plugin receives may also carry the original width/height; schemas, snapshots, or serialization logic that accept only a fixed field set may reject the new field.
+- **Migration recipe**: For image refs and `read_image` results, "read known fields, retain unknown optional fields"; if the plugin's own schema uses `additionalProperties: false`, add optional fields for `originalDimensions.width` and `originalDimensions.height`. Do not treat the field as required on every image.
+- **Verification**: In a target rc.2 profile, read an oversized image that triggers normalization and confirm `width/height` are the normalized dimensions, retaining `originalDimensions` when present; confirm the field is not synthesized for unscaled images. Check that persisted records and model-visible results both decode correctly.
+- **Source**: rc.1 type baseline [`types.ts`](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.1-rc.1/packages/attachment/attachment/src/types.ts); rc.2 type definitions [`types.ts`](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.1-rc.2/packages/attachment/attachment/src/types.ts); the pinned commit introducing the change [`8f83853b601b`](https://github.com/deepseek-ai/deepseek-harness/commit/8f83853b601b)
 
-### DSH-0.1.1-R2-02 · `read_image` 输出暴露缩放事实并改变提示文本
+### DSH-0.1.1-R2-02 · `read_image` output exposes scaling facts and changes prompt text
 
-- **类型**: behavior
-- **适用对象**: 注册、包装、解析或快照测试 `read_image` 的插件与 Web/Host 集成
-- **影响触点**: #5
-- **操作级别**: conditional
-- **症状**: rc.2 的 `read_image` 输出 schema 增加可选 `originalDimensions`；当图片被缩放时，模型可见文本还会说明原始尺寸以及把坐标映射回原图的乘数。严格匹配完整 XML 文本、工具输出 schema 或快照的插件会发生差异。
-- **迁移配方**: 不要按完整 `<content>` 字符串做脆弱匹配；读取结构化的 `path`、`image` 和尺寸字段。若必须保留快照，分别覆盖“未缩放”和“已缩放”两种结果，并把坐标说明当作 rc.2 的条件输出。宿主平面和客户端平面仍按各自的工具/Remote 合约验证，不要仅凭文本变化替换服务注入。
-- **验证**: 在精确 `dsh-v0.1.1-rc.2` 上运行 `read_image` 的已缩放与未缩放用例；断言结构化输出可解码、图片 block 的尺寸与引用一致，并检查快照只在缩放场景出现坐标说明。未运行真实浏览器或 provider 的部分必须单独标记未验证。
-- **来源**: rc.1 实现 [`read-image.ts`](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.1-rc.1/packages/fs/tool-fs/src/read-image.ts)；rc.2 实现 [`read-image.ts`](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.1-rc.2/packages/fs/tool-fs/src/read-image.ts)；对应固定提交 [`6e17c20804cd`](https://github.com/deepseek-ai/deepseek-harness/commit/6e17c20804cd)
+- **Type**: behavior
+- **Applies to**: Plugins and Web/Host integrations that register, wrap, parse, or snapshot-test `read_image`
+- **Touchpoints**: #5
+- **Action level**: conditional
+- **Symptoms**: The rc.2 `read_image` output schema adds an optional `originalDimensions`; when an image is scaled, the model-visible text also states the original dimensions and the multiplier that maps coordinates back to the source image. Plugins that strictly match the full XML text, tool output schemas, or snapshots will see diffs.
+- **Migration recipe**: Do not do fragile matching on the full `<content>` string; read the structured `path`, `image`, and dimension fields. If snapshots must be kept, cover the "unscaled" and "scaled" outcomes separately, and treat the coordinate note as a conditional rc.2 output. The host plane and the client plane are still verified against their own tool/Remote contracts — do not replace service injection based solely on a text change.
+- **Verification**: Run scaled and unscaled `read_image` cases on the exact `dsh-v0.1.1-rc.2`; assert that the structured output decodes and the image block dimensions match the ref, and that the snapshot shows the coordinate note only in scaled scenarios. Parts not run against a real browser or provider must be explicitly marked unverified.
+- **Source**: rc.1 implementation [`read-image.ts`](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.1-rc.1/packages/fs/tool-fs/src/read-image.ts); rc.2 implementation [`read-image.ts`](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.1-rc.2/packages/fs/tool-fs/src/read-image.ts); the corresponding pinned commit [`6e17c20804cd`](https://github.com/deepseek-ai/deepseek-harness/commit/6e17c20804cd)
 
-### DSH-0.1.1-R2-03 · DeepSeek 图片请求优先使用 Files API 并保留回退路径
+### DSH-0.1.1-R2-03 · DeepSeek image requests prefer the Files API and keep a fallback path
 
-- **类型**: behavior
-- **适用对象**: 自定义 DeepSeek LLM adapter、图片请求拦截器、附件/上传缓存插件
-- **影响触点**: #5
-- **操作级别**: conditional
-- **症状**: rc.2 的 DeepSeek adapter 在支持时会把规范化图片解析为 Files API 引用，并对失效的 provider file id 或不兼容的文件图片响应执行一次受限处理/回退。只按 rc.1 的 base64 request body 统计字节、重复上传同一附件，或把 provider 文件 ID 当作永久值的插件可能观察到请求形态、上传次数和错误处理发生变化。
-- **迁移配方**: 把图片身份与 provider 文件 ID 分开；以 `attachmentId`/请求版本作为本地缓存键，并把 Files API 上传结果视为有过期和失效可能的临时映射。请求观测同时支持文件引用和 base64 fallback，不要假设所有图片都会出现在 JSON 的 `data` 字段中。遇到文件解析失败时只接受宿主定义的受限 fallback，不要自行无限重试。
-- **验证**: 在精确 rc.2 上使用带图片的脚本化请求，分别验证首次上传、同一请求版本复用、Files API 失败后的受限回退和取消；确认没有无限重试、上传结果未泄露到 session 日志，并记录 provider credential 未覆盖时的边界。真实 DeepSeek API 未配置时只能验证静态/脚本化路径，不能声称 provider e2e 已通过。
-- **来源**: rc.2 adapter [`adapter.ts`](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.1-rc.2/packages/llm/llm-deepseek/src/adapter.ts)；Files API contract [`files-api.ts`](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.1-rc.2/packages/llm/llm-deepseek/src/files-api.ts)；rc.2 发布说明 [`v0.1.1-rc.2`](https://github.com/deepseek-ai/deepseek-harness/releases/tag/dsh-v0.1.1-rc.2)；对应固定提交 [`1b389798dcab`](https://github.com/deepseek-ai/deepseek-harness/commit/1b389798dcab)
+- **Type**: behavior
+- **Applies to**: Custom DeepSeek LLM adapters, image request interceptors, and attachment/upload cache plugins
+- **Touchpoints**: #5
+- **Action level**: conditional
+- **Symptoms**: The rc.2 DeepSeek adapter resolves normalized images to Files API refs when supported, and performs one bounded handling/fallback for stale provider file IDs or incompatible file-image responses. Plugins that count bytes against the rc.1 base64 request body, re-upload the same attachment repeatedly, or treat provider file IDs as permanent may observe changes in request shape, upload counts, and error handling.
+- **Migration recipe**: Separate image identity from the provider file ID; use `attachmentId`/request version as the local cache key and treat Files API upload results as temporary mappings that can expire or go stale. Request observation should support both file refs and base64 fallback — do not assume every image appears in the JSON `data` field. On file resolution failure, accept only the host-defined bounded fallback; do not retry unboundedly on your own.
+- **Verification**: On the exact rc.2, run scripted requests with images covering first upload, reuse of the same request version, the bounded fallback after a Files API failure, and cancellation; confirm no unbounded retries and no upload results leaking into session logs, and record the boundary when provider credentials are not configured. Without a real DeepSeek API configured, only the static/scripted paths can be verified — do not claim provider e2e passed.
+- **Source**: rc.2 adapter [`adapter.ts`](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.1-rc.2/packages/llm/llm-deepseek/src/adapter.ts); Files API contract [`files-api.ts`](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.1-rc.2/packages/llm/llm-deepseek/src/files-api.ts); rc.2 release notes [`v0.1.1-rc.2`](https://github.com/deepseek-ai/deepseek-harness/releases/tag/dsh-v0.1.1-rc.2); the corresponding pinned commit [`1b389798dcab`](https://github.com/deepseek-ai/deepseek-harness/commit/1b389798dcab)

--- a/skills/plugin-upgrade/references/v0.1.2-alpha.1.md
+++ b/skills/plugin-upgrade/references/v0.1.2-alpha.1.md
@@ -10,327 +10,318 @@ idPrefix: DSH-0.1.2-A1
 verifiedAt: 2026-08-31
 ---
 
-# 变更卡片 · 0.1.2-alpha.1
+# Change Cards · 0.1.2-alpha.1
 
-> 本文件是插件相关变更的精选清单，不是完整 API diff。迁移前仍须检查目标插件的
-> 依赖、导入、配置和实际运行路径。
+> This file is a curated list of plugin-related changes, not a complete API diff. Before
+> migrating, you must still check the target plugin's dependencies, imports, configuration, and
+> actual runtime paths.
 >
-> 上游比较: [dsh-v0.1.1-rc.2...dsh-v0.1.2-alpha.1](https://github.com/deepseek-ai/deepseek-harness/compare/dsh-v0.1.1-rc.2...dsh-v0.1.2-alpha.1)
+> Upstream compare: [dsh-v0.1.1-rc.2...dsh-v0.1.2-alpha.1](https://github.com/deepseek-ai/deepseek-harness/compare/dsh-v0.1.1-rc.2...dsh-v0.1.2-alpha.1)
 > · Release Notes: [dsh-v0.1.2-alpha.1](https://github.com/deepseek-ai/deepseek-harness/releases/tag/dsh-v0.1.2-alpha.1)
-> · 卡片格式见 [references/README.md](README.md)
-> · 触点编号见 [pre-flight.md](pre-flight.md)
+> · Card format: see [references/README.md](README.md)
+> · Touchpoint numbering: see [pre-flight.md](pre-flight.md)
 
-## 目录
+## Table of Contents
 
-- DSH-0.1.2-A1-01 · APIProxy 移除，Host/Web Client 调用迁到 `@Remote`
-- DSH-0.1.2-A1-02 · `SessionEvent.ignorable` 暂时移除
-- DSH-0.1.2-A1-03 · 会话视图工程大幅拆分
-- DSH-0.1.2-A1-04 · ACP/SDK 示例并入 `dsh` Profile，独立 demo bin 与包删除
-- DSH-0.1.2-A1-05 · Headless：stderr 新增 `dsh: reasoning:` 段，stdout 仍是最终文本
-- DSH-0.1.2-A1-06 · Code Mode 精确更名为 PTC mode
-- DSH-0.1.2-A1-07 · 公网 WebFetch 默认开启且不再逐次审批
-- DSH-0.1.2-A1-08 · Web/API 通道使用 process-scoped bootstrap token 与签名 Cookie
-- DSH-0.1.2-A1-09 · 新能力：模型设置页可接入提供方登录配置
-- DSH-0.1.2-A1-10 · 新能力：支持注册第三方语言
-- DSH-0.1.2-A1-11 · 新能力：子代理可选择 provider/model/推理力度/输出上限
-- DSH-0.1.2-A1-12 · 官方 DeepSeek 适配器默认附带插件包名与版本
-- DSH-0.1.2-A1-13 · 平台 shell 与目录选择器修复可能淘汰旧 workaround
-- DSH-0.1.2-A1-14 · 可选的 DeepSeek Session 日志增量上传
-- DSH-0.1.2-A1-19 · Web 插件验收改读宿主启动图与认证 URL
-- DSH-0.1.2-A1-20 · `userQuestions.registerProvider` 移除，answerer 迁到 `'user-questions/request'` waterfall
-- DSH-0.1.2-A1-21 · `dsh-agent-presets` 删除 `resolveSessionPreset`，shipped preset 改由包内 `presets/` 提供
-- DSH-0.1.2-A1-22 · `isTokenDelta` 不再从 `@deepseek-ai/dsh-llm/message` 导出
-- DSH-0.1.2-A1-23 · base 组合两个默认值变化：session telemetry 默认 `FEEDBACK_ONLY`，新增插件包名上报行
-- DSH-0.1.2-A1-24 · `dsh-llm-pi-ai` 的 `@earendil-works/pi-ai` 从 0.82 升到 0.84，直接依赖它的插件会拿到第二份实例
+- DSH-0.1.2-A1-01 · APIProxy removed, Host/Web Client calls moved to `@Remote`
+- DSH-0.1.2-A1-02 · `SessionEvent.ignorable` temporarily removed
+- DSH-0.1.2-A1-03 · Session view internals split up extensively
+- DSH-0.1.2-A1-04 · ACP/SDK examples merged into the `dsh` profile, standalone demo bins and packages removed
+- DSH-0.1.2-A1-05 · Headless: stderr gains a `dsh: reasoning:` segment; stdout remains the final text
+- DSH-0.1.2-A1-06 · Code Mode renamed precisely to PTC mode
+- DSH-0.1.2-A1-07 · Public WebFetch enabled by default, per-request approval removed
+- DSH-0.1.2-A1-08 · Web/API channels use process-scoped bootstrap tokens and signed cookies
+- DSH-0.1.2-A1-09 · New capability: model settings page can integrate provider login configuration
+- DSH-0.1.2-A1-10 · New capability: support for registering third-party languages
+- DSH-0.1.2-A1-11 · New capability: subagents can select provider/model/reasoning effort/output cap
+- DSH-0.1.2-A1-12 · Official DeepSeek adapter attaches plugin package name and version by default
+- DSH-0.1.2-A1-13 · Platform shell and directory picker fixes may obsolete old workarounds
+- DSH-0.1.2-A1-14 · Optional incremental upload of DeepSeek session logs
+- DSH-0.1.2-A1-19 · Web plugin acceptance now reads the host boot manifest and the auth URL
+- DSH-0.1.2-A1-20 · `userQuestions.registerProvider` removed, answerers moved to the `'user-questions/request'` waterfall
+- DSH-0.1.2-A1-21 · `dsh-agent-presets` drops `resolveSessionPreset`; shipped presets now come from the package's `presets/`
+- DSH-0.1.2-A1-22 · `isTokenDelta` no longer exported from `@deepseek-ai/dsh-llm/message`
+- DSH-0.1.2-A1-23 · base composition: two default changes — session telemetry defaults to `FEEDBACK_ONLY`, plus a new plugin package-name reporting row
+- DSH-0.1.2-A1-24 · `dsh-llm-pi-ai` bumps `@earendil-works/pi-ai` from 0.82 to 0.84; plugins that depend on it directly get a second instance
 
 ---
 
-### DSH-0.1.2-A1-01 · APIProxy 移除，Host/Web Client 调用迁到 `@Remote`
+### DSH-0.1.2-A1-01 · APIProxy removed, Host/Web Client calls moved to `@Remote`
 
-- **类型**: breaking
-- **适用对象**: 直接使用 Host APIProxy 的 Web Client、宿主集成插件；普通 Cordis 服务端插件只有命中旧 APIProxy 时才适用
-- **影响触点**: #3；间接 #1
-- **操作级别**: required-if-hit
-- **症状**: 旧 APIProxy 接口消失；会话、设置、凭据、模型目录等调用无法工作。
-- **迁移配方**: 先确认调用点确属旧 Host APIProxy，不要因为看到本卡就让普通插件导入宿主内部 client 包。命中时按下表迁移；Remote unary 调用返回 `RemoteResult<T>`，错误控制流见 [DSH-0.1.2-A2-02](v0.1.2-alpha.2.md)。
+- **Type**: breaking
+- **Applies to**: Web Clients and host integration plugins that use the Host APIProxy directly; ordinary Cordis server-side plugins only when they hit the old APIProxy
+- **Touchpoints**: #3; indirectly #1
+- **Action level**: required-if-hit
+- **Symptoms**: The old APIProxy surface disappears; calls for sessions, settings, credentials, model catalogs, etc. stop working.
+- **Migration recipe**: First confirm the call site really targets the old Host APIProxy; do not have ordinary plugins import host-internal client packages just because this card exists. When hit, migrate per the table below; Remote unary calls return `RemoteResult<T>`; error control flow: see [DSH-0.1.2-A2-02](v0.1.2-alpha.2.md).
 
-| 旧 APIProxy 操作 | 新 Remote 方法 | 备注 |
+| Old APIProxy operation | New Remote method | Notes |
 |---|---|---|
-| `session.rename` | `session/rename` | 生成声明在 `session` 命名空间（`ctx.remote.session.rename`）。上游 08-10 架构笔记写的 `sessionTitle/rename` 是设计稿；`sessionTitle` 是普通服务，不是 Remote 命名空间 |
-| `session.list/search/create/selectModel/fork/prompt/attachment/updateQueue/cancel/history` | `session/list`、`search`、`create`、`selectModel`、`fork`、`prompt`、`attachment`、`updateQueue`、`cancel`、`page`；流 `session/follow`、`session/control` | `history` 没有同名 Remote，分页读用 `page`，实时用 `follow` 流；以生成声明为准 |
-| `command.list` / `command.execute` | `commands/list` / `commands/execute` | rc.2 就已是 Remote（`commandsRemote` 在 rc.2 已挂载），不是本次迁移；保留 Agent 查找与调用方取消 |
-| `llm.providers` | `llm/listProviders` + `llm/listConfigurableProviders` | 一个拆为两个结果 |
+| `session.rename` | `session/rename` | Generated declaration in the `session` namespace (`ctx.remote.session.rename`). The `sessionTitle/rename` in the upstream 08-10 architecture note is a design draft; `sessionTitle` is an ordinary service, not a Remote namespace |
+| `session.list/search/create/selectModel/fork/prompt/attachment/updateQueue/cancel/history` | `session/list`, `search`, `create`, `selectModel`, `fork`, `prompt`, `attachment`, `updateQueue`, `cancel`, `page`; streams `session/follow`, `session/control` | `history` has no Remote of the same name; use `page` for paged reads and the `follow` stream for real-time reads; the generated declarations are authoritative |
+| `command.list` / `command.execute` | `commands/list` / `commands/execute` | Already Remote in rc.2 (`commandsRemote` was mounted in rc.2); not part of this migration; Agent lookup and caller-side cancellation are preserved |
+| `llm.providers` | `llm/listProviders` + `llm/listConfigurableProviders` | One call split into two results |
 | `llm.discoverModels` | `llm/discoverModels` | |
-| `llm.models` | `session/modelCatalog` | 从 LLM 域移到 Session 域 |
+| `llm.models` | `session/modelCatalog` | Moved from the LLM domain to the Session domain |
 | `credentials.describe/set/unset` | `credentials/describe/set/unset` | |
-| `settings.describe/update/replace/mutate` | `settings/*` 同名方法 | 保留脱敏与 revision 检查 |
+| `settings.describe/update/replace/mutate` | Same-named methods under `settings/*` | Redaction and revision checks preserved |
 | `settings.openDocument` | `settings/openSettingsDocument` | |
-| `agentPreset.read/copy/remove` | `agentPresets/read` / `agentPresets/copy` / `agentPresets/deletePreset` | `remove` 在生成声明里叫 `deletePreset` |
+| `agentPreset.read/copy/remove` | `agentPresets/read` / `agentPresets/copy` / `agentPresets/deletePreset` | `remove` is called `deletePreset` in the generated declarations |
 | `agentPreset.list/select` | `agentPresets/list` / `agentPresets/select` | |
-| `agentPreset.openDocument` | `settings/openAgentPresetDirectory` | 移到 Settings 域 |
-| `subagent.interrupt` | `subagents/interruptByParent` | 保留父 Agent 权威 |
-| `subagent.list/prompt/history` | `subagents/list` / `subagents/prompt` | `history` 没有同名方法，以生成声明为准 |
-| `workspace.list/insertSessionBefore/archiveSession` | `workspace/follow`（stream）/ `workspace/insertSessionBefore` / `workspace/archiveSession` | 没有 `workspace/list`：列表改为 `follow` 流，先发一帧完整 baseline，再发 upsert/remove/order/archived 增量 |
+| `agentPreset.openDocument` | `settings/openAgentPresetDirectory` | Moved to the Settings domain |
+| `subagent.interrupt` | `subagents/interruptByParent` | Parent-agent authority preserved |
+| `subagent.list/prompt/history` | `subagents/list` / `subagents/prompt` | `history` has no same-named method; the generated declarations are authoritative |
+| `workspace.list/insertSessionBefore/archiveSession` | `workspace/follow` (stream) / `workspace/insertSessionBefore` / `workspace/archiveSession` | No `workspace/list`: the list becomes a `follow` stream that first sends a full baseline frame, then upsert/remove/order/archived deltas |
 | `workspace.create/rename/delete/insertBefore` | `workspace/create` / `rename` / `delete` / `insertBefore` | |
 | `host.pickDirectory/listDirectory/createDirectory` | `directoryPicker/pick` / `directoryPicker/list` / `directoryPicker/createDirectory` | |
-| `skill.list` | `skills/list` | 列举不激活冷 Agent |
-| `fileReferences/list` | `fileReferences/list` | wire 名不变，rc.2 就已是 Remote；owner 从 `dsh-file-reference/remote` 移到 `dsh-api-session-controller`，`dsh-file-reference` 不再导出 `./remote` |
-| `host.openPath` | `session/openWorkspacePath` | Client 先解析工作区相对路径 |
-| `host.describe` | `$events` ready 帧 + 按域查询 | alpha.1 通过 generation-ready 帧携带 Host home，尚无 `ctx.remote.$host`；alpha.2 见 A2-06 |
-| `session.export` | `GET/HEAD /api/session.export` | 路径 rc.2 已如此，变的是 route owner（apiproxy fetch handler → Connection exact Fetch route）；Fetch 流式 ZIP，不走 JSON Remote 信封；认证见 A1-08 |
+| `skill.list` | `skills/list` | Listing does not activate cold Agents |
+| `fileReferences/list` | `fileReferences/list` | Wire name unchanged; already Remote in rc.2; owner moved from `dsh-file-reference/remote` to `dsh-api-session-controller`, and `dsh-file-reference` no longer exports `./remote` |
+| `host.openPath` | `session/openWorkspacePath` | The client resolves the workspace-relative path first |
+| `host.describe` | `$events` ready frame + per-domain queries | alpha.1 carries the Host home in the generation-ready frame; `ctx.remote.$host` does not exist yet; see A2-06 for alpha.2 |
+| `session.export` | `GET/HEAD /api/session.export` | The path was already this in rc.2; what changed is the route owner (apiproxy fetch handler → Connection exact Fetch route); Fetch streams the ZIP and does not use the JSON Remote envelope; auth: see A1-08 |
 
-  标识符：rc.2 的服务键是 `apiProxy`（类型 `ApiProxy`，包 `@deepseek-ai/dsh-host-apiproxy`），alpha.1 删除该包；不存在 `APIProxy` 标识符。rc.2 已是混合状态，`goals/*`、`dynamicCordisRunner/*`、`pluginInventory/list`、`messageFeedback/*`、`sessionReferenceResolver/candidates` 在 rc.2 就是 Remote，不在本表。表中命名以目标 tag 的生成声明（`lib/typert.remote-client.d.ts`）为准，笔记和 release notes 只给方向。
+  Identifiers: rc.2's service key is `apiProxy` (type `ApiProxy`, package `@deepseek-ai/dsh-host-apiproxy`); alpha.1 deletes that package; there is no `APIProxy` identifier. rc.2 was already a mixed state: `goals/*`, `dynamicCordisRunner/*`, `pluginInventory/list`, `messageFeedback/*`, `sessionReferenceResolver/candidates` were already Remote in rc.2 and are not in this table. The naming in the table follows the generated declarations of the target tag (`lib/typert.remote-client.d.ts`); notes and release notes only indicate direction.
 
-  调用插件在 `inject` 声明所需 Remote contribution，经
-  `@deepseek-ai/dsh-api-remotes/client` 获得生成的类型挂载，再调用
-  `ctx.remote.<namespace>.<method>(...)`。不要手写 wire 中转对象或方法签名。
-- **验证**: 每个命中调用至少覆盖成功分支、一个业务失败码及取消；对
-  `session.export` 验证无会话认证被拒、合法浏览器会话能下载。
-- **实战批注**（2026-08-30，容器全链路验证）: 迁移前先判定插件运行在哪个平面——
-  旧 `apiProxy` 是宿主平面（服务器侧）门面，`ctx.remote` 是客户端平面
-  （浏览器侧）门面，两者不在同一运行时，注入名不能直接对号替换。
-  宿主平面的 apiProxy 消费者正确迁法是跳过网关、直接注入背后的领域服务
-  （如 `inject: ["llm"]` 后 `ctx.llm.listProviders()`）；若误改成
-  `inject: ["remote"]`，宿主平面会报
-  `pending (waiting for service: remote)`——与 discussion #5120 痛点 #4
-  同款症状。客户端平面（浏览器插件）才走本表 `ctx.remote.*`，且需在
-  package.json 声明 `dsh.client` 才会进入浏览器插件名册。
-  完整过程见仓库 [benchmark/validation-report-2026-08-30.md](https://github.com/oh-my-dsh/dsh-plugin-upgrade-skill/blob/main/benchmark/validation-report-2026-08-30.md)。
-- **实战批注**（2026-08-30，dsh-better-sidebar e2e，npm 0.1.2-alpha.2 真机）: 直连 `/api` 的测试 harness / 探活脚本还要迁 **wire 契约**：点分端点已 404，一律斜杠 `POST /api/<ns>/<method>`；envelope `{type:'client-request', rpcId, method, payload}` 的 `method` 必须与路径端点一致；payload 恰为 `{args: {...}}` 且 **args 按控制器 TS 参数名包装**——`workspace/create`、`session/create` 用 `{request:{...}}`，`session/list` 的参数名就是 `_request` 且不可省略（传 `{}` 也被拒 `args fields do not match the descriptor`）。实现参考 [tests/e2e/host-protocol.ts](https://github.com/omdsh-dev/DSH-better-sidebar/blob/main/tests/e2e/host-protocol.ts)。
-- **来源**: [APIProxy→Remote 架构笔记（alpha.1）](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/.agents/notes/implemented/architecture/2026-08-10-unary-apiproxy-remote-migration.md) · [alpha.1 session-controller `@Remote` 声明](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/packages/api/session-controller/src/index.ts) · [alpha.1 agent-presets `@Remote('deletePreset')`](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/packages/preset/agent-presets/src/index.ts) · [alpha.1 workspace-controller `follow` 流](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/packages/api/workspace-controller/src/index.ts) · [rc.2 apiproxy rpc-map（旧键全表）](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.1-rc.2/packages/host/apiproxy/src/api/rpc-map.ts)
-
----
-
-### DSH-0.1.2-A1-02 · `SessionEvent.ignorable` 暂时移除
-
-- **类型**: breaking
-- **适用对象**: 生产第三方持久 SessionEvent 的插件，以及负责持久化/reload/transport 的集成层
-- **影响触点**: #2
-- **操作级别**: required-if-target-is-alpha.1
-- **症状**: alpha.1 无法保留第三方 informational event 的 `ignorable: true` 标记；第一方 reader 遇到未知持久事件时会按 required 事件拒绝 reload。
-- **迁移配方**: 若目标恰好是 alpha.1，不要把未知持久事件改成消费者白名单——那会错误放过 required 事件。应暂时停止写入该未知持久事件，或改用目标版本已知的公开事件词汇。若最终目标是 alpha.2 或更高，先读 [DSH-0.1.2-A2-01](v0.1.2-alpha.2.md) 计算走廊净状态，不要先删再恢复 producer marker。
-- **验证**: 未知 required 事件必须 fail closed；目标 alpha.1 不应写出无法被该版本安全 reload 的未知事件。
-- **来源**: [alpha.2 恢复决策对 alpha.1 移除的说明](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/.agents/notes/implemented/architecture/2026-08-30-retain-ignorable-external-session-events.md)
+  Calling plugins declare the needed Remote contributions in `inject`, obtain the
+  generated type mounts via `@deepseek-ai/dsh-api-remotes/client`, and then call
+  `ctx.remote.<namespace>.<method>(...)`. Do not hand-write wire relay objects or method signatures.
+- **Verification**: For each hit call, cover at least the success branch, one business failure code, and cancellation; for `session.export`, verify that a request without a session is rejected by auth and that a legitimate browser session can download.
+- **Field note** (2026-08-30, container end-to-end validation): Before migrating, determine which plane the plugin runs in —
+  the old `apiProxy` is the host-plane (server-side) facade, `ctx.remote` is the client-plane
+  (browser-side) facade; they are not in the same runtime, so injection names cannot be swapped one-to-one.
+  The correct migration for host-plane apiProxy consumers is to skip the gateway and inject the domain service behind it directly
+  (e.g. `inject: ["llm"]` and then `ctx.llm.listProviders()`); if you mistakenly change it to
+  `inject: ["remote"]`, the host plane reports
+  `pending (waiting for service: remote)` — the same symptom as discussion #5120 pain point #4.
+  Only the client plane (browser plugins) follows this table's `ctx.remote.*`, and the plugin must declare
+  `dsh.client` in package.json to enter the browser plugin roster.
+  The full process is in the repo's [benchmark/validation-report-2026-08-30.md](https://github.com/oh-my-dsh/dsh-plugin-upgrade-skill/blob/main/benchmark/validation-report-2026-08-30.md).
+- **Field note** (2026-08-30, dsh-better-sidebar e2e, npm 0.1.2-alpha.2 on a real machine): Test harnesses / liveness scripts that hit `/api` directly must also migrate the **wire contract**: dotted endpoints now 404 — always use the slash form `POST /api/<ns>/<method>`; the `method` of the envelope `{type:'client-request', rpcId, method, payload}` must match the path endpoint; the payload is exactly `{args: {...}}`, and **args are wrapped by the controller's TS parameter names** — `workspace/create` and `session/create` use `{request:{...}}`; `session/list`'s parameter name is literally `_request` and cannot be omitted (passing `{}` is also rejected with `args fields do not match the descriptor`). Reference implementation: [tests/e2e/host-protocol.ts](https://github.com/omdsh-dev/DSH-better-sidebar/blob/main/tests/e2e/host-protocol.ts).
+- **Source**: [APIProxy→Remote architecture note (alpha.1)](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/.agents/notes/implemented/architecture/2026-08-10-unary-apiproxy-remote-migration.md) · [alpha.1 session-controller `@Remote` declarations](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/packages/api/session-controller/src/index.ts) · [alpha.1 agent-presets `@Remote('deletePreset')`](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/packages/preset/agent-presets/src/index.ts) · [alpha.1 workspace-controller `follow` stream](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/packages/api/workspace-controller/src/index.ts) · [rc.2 apiproxy rpc-map (full old-key table)](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.1-rc.2/packages/host/apiproxy/src/api/rpc-map.ts)
 
 ---
 
-### DSH-0.1.2-A1-03 · 会话视图工程大幅拆分
+### DSH-0.1.2-A1-02 · `SessionEvent.ignorable` temporarily removed
 
-- **类型**: breaking
-- **适用对象**: patch 宿主源码或从会话视图内部路径导入的 Host/Web Client 集成
-- **影响触点**: #1、#5
-- **操作级别**: required-if-hit
-- **症状**: patch 目标路径、内部 import 或 UI 注册点失效。
-- **迁移配方**: 对照精确 tag compare 逐一核对宿主路径；按 owning 模块重建导入。没有稳定公开 seam 的能力标记「待确认」，不要猜新路径。普通插件优先迁到公开 facet/service，避免继续增加内部导入。
-- **验证**: 用目标 tag 源码做 patch-surface 合成；每个旧目标都必须映射到目标版本文件或明确删除原因。
-- **来源**: [alpha.1 release notes「其他变更」](https://github.com/deepseek-ai/deepseek-harness/releases/tag/dsh-v0.1.2-alpha.1)
-- **实战批注**: dsh-tui 使用 `DSH_HARNESS_SOURCE_ROOT` 指向目标 tag，并对 patch-surface 路径逐项合成验证。
-- **实战批注**（2026-08-28，[dsh-ui-whale v0.3.5](https://github.com/lhh010/dsh-ui-whale) / dsh-ui-progress v0.9.4 / dsh-input-history v0.1.4，Windows，npm link 安装）: 公开快照消费面同样受影响——`ConversationSnapshot` 旧平铺字段（nodes/partial/runningCalls/turnEnds）经 `views.get('chat')?.legacy` 投影全部可读，三插件按「先全量迁 legacy、稳定后再逐字段迁 views/timeline」两步走一次迁移成功；生命周期字段（running 等）不在投影内，需改走 `useSession` 座。
-- **实战批注**（2026-08-31，`omdsh-dev/omdsh-plugin-lab` 0.6.4 → 0.7.0-alpha.0）:
-  该样本起点是 DSH `0.1.0-rc.6`，早于本走廊最早卡片，故只验证 alpha.2 最终目标，不能
-  反向声称缺失边已被卡片覆盖。真实源码迁移删除 `dsh-client-runtime`，把 Context/SessionId/
-  ConversationNode/CommandRowProps 分配回 owning 包，`useSession` transcript 改为 `useChat`，
-  用 `order + nodes.get(id)` 读取 keyed store；38 条 client、11 条 server 测试及 pack/install/
-  Web boot/client load/remove e2e 通过。详细证据见
-  [real Web Client alpha.2 migration](../examples/08-real-web-client-alpha2-migration.md) 与
-  [API-10](api-migration-0.1.2-alpha.2.md#api-10--web-client-runtime-拆包keyed-chat-snapshot-与命令附件参数)。
+- **Type**: breaking
+- **Applies to**: Plugins that produce third-party persisted SessionEvents, and integration layers responsible for persistence/reload/transport
+- **Touchpoints**: #2
+- **Action level**: required-if-target-is-alpha.1
+- **Symptoms**: alpha.1 cannot preserve the `ignorable: true` marker on third-party informational events; when first-party readers encounter unknown persisted events, they reject the reload treating them as required events.
+- **Migration recipe**: If the target is exactly alpha.1, do not turn unknown persisted events into a consumer whitelist — that would wrongly let required events through. Temporarily stop writing that unknown persisted event, or switch to public event vocabulary that the target version already knows. If the final target is alpha.2 or later, first read [DSH-0.1.2-A2-01](v0.1.2-alpha.2.md) to compute the corridor net state; do not delete the producer marker and then restore it.
+- **Verification**: Unknown required events must fail closed; targeting alpha.1 must not write unknown events that this version cannot safely reload.
+- **Source**: [alpha.2 restore decision explaining the alpha.1 removal](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/.agents/notes/implemented/architecture/2026-08-30-retain-ignorable-external-session-events.md)
 
 ---
 
-### DSH-0.1.2-A1-04 · ACP/SDK 示例并入 `dsh` Profile，独立 demo bin 与包删除
+### DSH-0.1.2-A1-03 · Session view internals split up extensively
 
-- **类型**: behavior
-- **适用对象**: 启动包装器、Python SDK/ACP 集成、直接读取 profile 文件的插件
-- **影响触点**: #4、#7
-- **操作级别**: required-if-hit
-- **症状**: `dsh --profile <name>` 在 rc.2 就有，不是 alpha.1 新增。alpha.1 变的是：新增 `acp`、`sdk`、`sdk-minimal` 三个 profile，删除独立 bin `dsh-acp-demo`、`dsh-jsonrpc-agent` 及包 `@deepseek-ai/dsh-acp-demo`、`dsh-sdk-jsonrpc-demo`、`dsh-acp-snapshot`。硬编码这些 bin、旧进程树或固定 profile 路径的包装器失配。
-- **迁移配方**: 以运行时 `DSH_HOME`、目标 profile 和官方启动器为事实源；区分 profile composition（如 `cordis.patch.yml` / `agent.cordis.yml`）、包清单和 resolved config，不硬编码用户目录。
-- **验证**: 新 profile 冷启动与旧 profile 升级启动各一次；核对 cwd、环境变量、插件挂载与 resolved config。
-- **实战批注**（2026-08-30，alpha.2 容器实测）: `dsh --help` 确认 profile 位于 `$DSH_HOME/profiles` 下；未配置 API key 时 headless 冷启动报 `dsh: MISSING_CREDENTIAL: ... store DEEPSEEK_API_KEY through the credentials service`——属 profile 配置问题，归类时勿误判为插件/运行时故障。
-- **来源**: [alpha.1 release notes「其他变更」](https://github.com/deepseek-ai/deepseek-harness/releases/tag/dsh-v0.1.2-alpha.1)
-
----
-
-### DSH-0.1.2-A1-05 · Headless：stderr 新增 `dsh: reasoning:` 段，stdout 仍是最终文本
-
-- **类型**: behavior
-- **适用对象**: headless 包装器、进程监督器、stdout/stderr 解析器
-- **影响触点**: #7
-- **操作级别**: required-if-hit
-- **症状**: rc.2 的 stdout 就已是最终 assistant 文本、退出码 0/1（`packages/bundle/headless/src/index.ts:129`），从来不是 JSONL；alpha.1 唯一变化是 stderr 多了 `dsh: reasoning:` 段（rc.2 成功时 stderr 为空）。忽略 stderr 会丢 reasoning；把「stderr 有输出」当失败会误判。
-- **迁移配方**: 将 stdout 作为最终 assistant 文本通道（除非具体入口另有结构化契约）；stderr 接收 `dsh: reasoning:` 段或 `dsh: <code>: <message>`；以退出码判定成功（完成为 0，失败/中止/无完成回合为 1）。不要对 stdout 默认 `JSON.parse`。
-- **验证**: 覆盖纯文本成功、带 reasoning、空最终文本、直接启动失败与非零退出；确认敏感 reasoning 被送到受控 stderr sink。
-- **实战批注**（2026-08-30，alpha.2 容器实测）: 与上述契约一致——stdout 无结果时仅一个换行，报错（如 `dsh: AUTH: ...`）全走 stderr。
-- **来源**: [alpha.1 headless README](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/packages/bundle/headless/README.md) · [rc.2 headless src（stdout 已是最终文本）](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.1-rc.2/packages/bundle/headless/src/index.ts)
+- **Type**: breaking
+- **Applies to**: Host/Web Client integrations that patch host source or import from internal session-view paths
+- **Touchpoints**: #1, #5
+- **Action level**: required-if-hit
+- **Symptoms**: Patch target paths, internal imports, or UI registration points no longer work.
+- **Migration recipe**: Check the host paths one by one against an exact-tag compare; rebuild imports by owning module. Mark capabilities that have no stable public seam as "pending confirmation"; do not guess new paths. Ordinary plugins should preferably migrate to public facets/services and avoid adding more internal imports.
+- **Verification**: Run a patch-surface composition against the target tag source; every old target must map to a target-version file or state an explicit removal reason.
+- **Source**: [alpha.1 release notes, "Other changes"](https://github.com/deepseek-ai/deepseek-harness/releases/tag/dsh-v0.1.2-alpha.1)
+- **Field note**: dsh-tui points `DSH_HARNESS_SOURCE_ROOT` at the target tag and validates each patch-surface path by composition.
+- **Field note** (2026-08-28, [dsh-ui-whale v0.3.5](https://github.com/lhh010/dsh-ui-whale) / dsh-ui-progress v0.9.4 / dsh-input-history v0.1.4, Windows, npm link install): The public snapshot consumption surface is affected too — the old flat `ConversationSnapshot` fields (nodes/partial/runningCalls/turnEnds) are all still readable through the `views.get('chat')?.legacy` projection; the three plugins migrated in one pass with a two-step approach ("migrate everything to legacy first, then migrate field-by-field to views/timeline once stable"); lifecycle fields (e.g. running) are not in the projection and must go through the `useSession` seat instead.
+- **Field note** (2026-08-31, `omdsh-dev/omdsh-plugin-lab` 0.6.4 → 0.7.0-alpha.0):
+  The sample started from DSH `0.1.0-rc.6`, earlier than the earliest card in this corridor, so it only validates the final alpha.2 target and cannot
+  retroactively claim that missing edges are covered by cards. The real source migration removed `dsh-client-runtime`, reassigned Context/SessionId/
+  ConversationNode/CommandRowProps to their owning packages, switched the `useSession` transcript to `useChat`,
+  and read the keyed store via `order + nodes.get(id)`; 38 client and 11 server tests plus pack/install/
+  Web boot/client load/remove e2e passed. Detailed evidence: see
+  [real Web Client alpha.2 migration](../examples/08-real-web-client-alpha2-migration.md) and
+  [API-10](api-migration-0.1.2-alpha.2.md#api-10--web-client-runtime-unbundling-keyed-chat-snapshots-and-command-attachment-parameters).
 
 ---
 
-### DSH-0.1.2-A1-06 · Code Mode 精确更名为 PTC mode
+### DSH-0.1.2-A1-04 · ACP/SDK examples merged into the `dsh` profile, standalone demo bins and packages removed
 
-- **类型**: breaking
-- **适用对象**: 使用工具呈现模式、PTC preset、dispatch waterfall 或相关类型的插件
-- **影响触点**: #2、#3、#5、#7
-- **操作级别**: required-if-hit
-- **症状**: `tools.mode: code`、preset id `code`、旧 dispatch 名称与 prompt rule 不再受支持。
-- **迁移配方**: 只按 ledger 逐项改，全局替换 `code` 会误伤下面保留的标识：
+- **Type**: behavior
+- **Applies to**: Launcher wrappers, Python SDK/ACP integrations, and plugins that read profile files directly
+- **Touchpoints**: #4, #7
+- **Action level**: required-if-hit
+- **Symptoms**: `dsh --profile <name>` already existed in rc.2; it is not new in alpha.1. What changed in alpha.1: three profiles `acp`, `sdk`, `sdk-minimal` were added, and the standalone bins `dsh-acp-demo`, `dsh-jsonrpc-agent` plus the packages `@deepseek-ai/dsh-acp-demo`, `dsh-sdk-jsonrpc-demo`, `dsh-acp-snapshot` were removed. Wrappers that hardcode these bins, old process trees, or fixed profile paths no longer match.
+- **Migration recipe**: Use the runtime `DSH_HOME`, the target profile, and the official launcher as the source of truth; distinguish profile composition (e.g. `cordis.patch.yml` / `agent.cordis.yml`), package manifests, and resolved config, and do not hardcode user directories.
+- **Verification**: Cold-boot the new profile and upgrade-boot the old profile once each; check cwd, environment variables, plugin mounts, and resolved config.
+- **Field note** (2026-08-30, alpha.2 container test): `dsh --help` confirms profiles live under `$DSH_HOME/profiles`; when no API key is configured, a headless cold boot reports `dsh: MISSING_CREDENTIAL: ... store DEEPSEEK_API_KEY through the credentials service` — this is a profile configuration issue; do not misclassify it as a plugin/runtime failure when triaging.
+- **Source**: [alpha.1 release notes, "Other changes"](https://github.com/deepseek-ai/deepseek-harness/releases/tag/dsh-v0.1.2-alpha.1)
+
+---
+
+### DSH-0.1.2-A1-05 · Headless: stderr gains a `dsh: reasoning:` segment; stdout remains the final text
+
+- **Type**: behavior
+- **Applies to**: Headless wrappers, process supervisors, stdout/stderr parsers
+- **Touchpoints**: #7
+- **Action level**: required-if-hit
+- **Symptoms**: rc.2's stdout was already the final assistant text with exit code 0/1 (`packages/bundle/headless/src/index.ts:129`); it was never JSONL. The only alpha.1 change is that stderr gains a `dsh: reasoning:` segment (rc.2's stderr was empty on success). Ignoring stderr loses reasoning; treating "stderr has output" as failure misjudges runs.
+- **Migration recipe**: Treat stdout as the final assistant-text channel (unless a specific entrypoint has its own structured contract); receive the `dsh: reasoning:` segment or `dsh: <code>: <message>` on stderr; judge success by exit code (0 for completion, 1 for failure/abort/no completed turn). Do not `JSON.parse` stdout by default.
+- **Verification**: Cover plain-text success, reasoning present, empty final text, direct launch failure, and non-zero exit; confirm sensitive reasoning goes to a controlled stderr sink.
+- **Field note** (2026-08-30, alpha.2 container test): Consistent with the contract above — stdout is a single newline when there is no result, and errors (e.g. `dsh: AUTH: ...`) all go to stderr.
+- **Source**: [alpha.1 headless README](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/packages/bundle/headless/README.md) · [rc.2 headless src (stdout already the final text)](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.1-rc.2/packages/bundle/headless/src/index.ts)
+
+---
+
+### DSH-0.1.2-A1-06 · Code Mode renamed precisely to PTC mode
+
+- **Type**: breaking
+- **Applies to**: Plugins using the tool presentation mode, PTC presets, the dispatch waterfall, or related types
+- **Touchpoints**: #2, #3, #5, #7
+- **Action level**: required-if-hit
+- **Symptoms**: `tools.mode: code`, preset id `code`, the old dispatch names, and prompt rules are no longer supported.
+- **Migration recipe**: Change items one by one per the ledger only; a global replace of `code` would wrongly hit the identifiers preserved below:
   - `tools.mode: 'code'` → `'ptc'`
-  - preset id/目录 `code` → `ptc`
+  - preset id/directory `code` → `ptc`
   - `tools/code-dispatch-log` → `tools/ptc-dispatch-log`
   - `CodeDispatch*` → `PtcDispatch*`
   - `tools:code-only` → `tools:ptc-only`
-  - 用户文案 `Code Mode` → `PTC mode` / `PTC 模式`
+  - user-facing copy `Code Mode` → `PTC mode` / `PTC 模式`
 
-  保持不变：`run_code`、它的 `code` 参数、`CodeSdkLanguage`、`CodeRunFailedError`、
-  `dsh-code-runtime*` 包族，以及持久事件 `tool/code-dispatch*`、插件名
-  `tools-code-mode`、sub-call id 中的 `:code:`。
-- **验证**: 新配置/preset 可启动；旧 Session 日志仍能加载；保留标识未被误改。
-- **来源**: [PTC rename ledger](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/.agents/notes/implemented/architecture/2026-08-25-rename-code-mode-to-ptc.md)
-
----
-
-### DSH-0.1.2-A1-07 · 公网 WebFetch 默认开启且不再逐次审批
-
-- **类型**: security
-- **适用对象**: 使用 shipped Cordis/PTC/Standard preset 的权限、审批、WebFetch 策略与审计插件
-- **影响触点**: #2、#3
-- **操作级别**: conditional
-- **症状**: 这些 shipped preset 在所有 sandbox/审批模式下暴露 `web_fetch`，公网抓取不逐次确认；该默认不代表所有自定义 composition。
-- **迁移配方**: 需要确认步骤的部署应添加 `tools/pre-execute` policy 或禁用 `web_fetch`，并在目标版本实测公网/私网事件；文件 sandbox 不治理 Web 网络访问。
-- **验证**: 对使用中的具体 preset 测试公网、loopback、私网与 policy 拒绝；自定义 composition 单独核对，不从 shipped preset 推断。
-- **来源**: [alpha.1 Web subsystem「Fetch network policy」](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/docs/subsystems/web.md) · [alpha.1 release notes](https://github.com/deepseek-ai/deepseek-harness/releases/tag/dsh-v0.1.2-alpha.1)
+  Unchanged: `run_code`, its `code` argument, `CodeSdkLanguage`, `CodeRunFailedError`,
+  the `dsh-code-runtime*` package family, the persisted events `tool/code-dispatch*`, the plugin name
+  `tools-code-mode`, and the `:code:` inside sub-call ids.
+- **Verification**: New configs/presets boot; old session logs still load; preserved identifiers were not wrongly changed.
+- **Source**: [PTC rename ledger](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/.agents/notes/implemented/architecture/2026-08-25-rename-code-mode-to-ptc.md)
 
 ---
 
-### DSH-0.1.2-A1-08 · Web/API 通道使用 process-scoped bootstrap token 与签名 Cookie
+### DSH-0.1.2-A1-07 · Public WebFetch enabled by default, per-request approval removed
 
-- **类型**: security
-- **适用对象**: 自建 loopback HTTP/WS/RPC、浏览器页面或自定义 `/api` 路由的插件
-- **影响触点**: #6
-- **操作级别**: required-if-hit
-- **症状**: 网络访问 Web UI 或直接调用 `/api` 的旧通道可能收到 401/403；绕过认证的私有路由形成安全缺口。bootstrap token 并非 strict single-use：同一进程内可重复兑换，进程重启才轮换。
-- **迁移配方**: token 只用于 `GET /?token=...`，成功后 303 到 `/` 并签发绑定 authority 的 HttpOnly/SameSite Cookie；不要把 token 放进 `/api`、WS URL 或 Authorization header。官方 `/api` Remote/RPC/exact Fetch route 与 `/api/remote.mux` 会调用 Connection auth gate。直接用 `ctx.webServer.register()` / `registerUpgrade()` 的自建 route 不会自动继承认证、Host/Origin fence、CORS 或 TLS；handler 应先调用 `ctx.connection.requestRejection(req)`，或改用 Connection 所有的 carrier/seam。raw/Node client 需先兑换并保存 Cookie。
-- **验证**: 错误 Host/Origin 返回 403，无/坏 Cookie 返回 401；正确 bootstrap token 在同一进程可重复兑换 Cookie；合法 Cookie 可调用官方 `/api`/WS；自建 route 在未显式接入 gate 前不能被视为已保护。
-- **实战批注**（2026-08-30，dsh-better-sidebar e2e 与本机 pm2 迁移）: 从就绪行解析启动 URL 必须延伸到空白（`[^ ]*`）——在 `/` 处截断会丢掉 `?token=`，整条 lane 挂在首屏 401；token 兑换的 303 会**丢弃同 URL 的其它 query 参数**，带参导航要先经 token URL 兑换 cookie、`addCookies` 后再直达目标 URL（验收侧另见 `DSH-0.1.2-A1-19`）。参见 [e2e-mount.sh 就绪行解析](https://github.com/omdsh-dev/DSH-better-sidebar/blob/main/scripts/e2e-mount.sh)。
-- **来源**: [alpha.1 browser auth](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/packages/client/connection/src/browser-auth.ts) · [alpha.1 Connection routes](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/packages/client/connection/src/index.ts) · [alpha.1 raw WebServer](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/packages/host/webserver/src/index.ts)
-
----
-
-### DSH-0.1.2-A1-09 · 新能力：模型设置页可接入提供方登录配置
-
-- **类型**: capability
-- **适用对象**: 模型提供方插件
-- **影响触点**: #5
-- **操作级别**: optional
-- **症状**: 无；这是可选能力。
-- **迁移配方**: 采用前先从目标 tag 的公开类型/示例确认注册入口；若只找到内部 UI 接口，标「待确认」，不要 patch 设置页。
-- **验证**: 登录入口可见、凭据写入走宿主凭据服务、卸载插件后入口消失。
-- **来源**: [alpha.1 release notes「新增功能」](https://github.com/deepseek-ai/deepseek-harness/releases/tag/dsh-v0.1.2-alpha.1)
+- **Type**: security
+- **Applies to**: Permission, approval, WebFetch policy, and audit plugins using the shipped Cordis/PTC/Standard presets
+- **Touchpoints**: #2, #3
+- **Action level**: conditional
+- **Symptoms**: These shipped presets expose `web_fetch` in all sandbox/approval modes, and public fetches are no longer confirmed one at a time; this default does not extend to all custom compositions.
+- **Migration recipe**: Deployments that need a confirmation step should add a `tools/pre-execute` policy or disable `web_fetch`, and test public/private network events against the target version; the file sandbox does not govern web network access.
+- **Verification**: Test public, loopback, private network, and policy rejections against the specific preset in use; check custom compositions separately, and do not infer from shipped presets.
+- **Source**: [alpha.1 Web subsystem, "Fetch network policy"](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/docs/subsystems/web.md) · [alpha.1 release notes](https://github.com/deepseek-ai/deepseek-harness/releases/tag/dsh-v0.1.2-alpha.1)
 
 ---
 
-### DSH-0.1.2-A1-10 · 新能力：支持注册第三方语言
+### DSH-0.1.2-A1-08 · Web/API channels use process-scoped bootstrap tokens and signed cookies
 
-- **类型**: capability
-- **适用对象**: 提供本地化资源的 UI 插件
-- **影响触点**: #5
-- **操作级别**: optional
-- **症状**: 无；这是可选能力。
-- **迁移配方**: 用目标 tag 的公开语言注册 API 替代自建 i18n patch；未找到公开入口时不要猜测接口。
-- **验证**: 语言可选、切换后生效、缺失键按宿主规则回退。
-- **来源**: [alpha.1 release notes「新增功能」](https://github.com/deepseek-ai/deepseek-harness/releases/tag/dsh-v0.1.2-alpha.1)
-
----
-
-### DSH-0.1.2-A1-11 · 新能力：子代理可选择 provider/model/推理力度/输出上限
-
-- **类型**: capability
-- **适用对象**: 子代理编排或选择器插件
-- **影响触点**: #3、#5
-- **操作级别**: optional
-- **症状**: 无；这是可选能力。
-- **迁移配方**: 从目标 tag 类型定义确认确切参数名与授权约束后再透传；不要根据 release notes 自造对象结构。
-- **验证**: 带参启动子代理，核对授权范围、实际 provider/model、推理力度与最大输出长度。
-- **来源**: [alpha.1 release notes「新增功能」](https://github.com/deepseek-ai/deepseek-harness/releases/tag/dsh-v0.1.2-alpha.1)
+- **Type**: security
+- **Applies to**: Plugins with custom loopback HTTP/WS/RPC, browser pages, or custom `/api` routes
+- **Touchpoints**: #6
+- **Action level**: required-if-hit
+- **Symptoms**: Old channels that reach the Web UI over the network or call `/api` directly may receive 401/403; private routes that bypass auth become security holes. The bootstrap token is not strictly single-use: it can be redeemed repeatedly within the same process and only rotates on process restart.
+- **Migration recipe**: Use the token only for `GET /?token=...`; on success, 303 to `/` and issue an HttpOnly/SameSite Cookie bound to the authority; do not put the token into `/api`, WS URLs, or the Authorization header. The official `/api` Remote/RPC/exact Fetch routes and `/api/remote.mux` go through the Connection auth gate. Custom routes registered directly with `ctx.webServer.register()` / `registerUpgrade()` do not automatically inherit auth, the Host/Origin fence, CORS, or TLS; handlers should call `ctx.connection.requestRejection(req)` first, or switch to a Connection-owned carrier/seam. Raw/Node clients must redeem and store the Cookie first.
+- **Verification**: Wrong Host/Origin returns 403; missing/bad Cookie returns 401; a correct bootstrap token can redeem a Cookie repeatedly within the same process; a valid Cookie can call the official `/api`/WS; custom routes must not be considered protected before they are explicitly wired into the gate.
+- **Field note** (2026-08-30, dsh-better-sidebar e2e and local pm2 migration): Parsing the startup URL from the readiness line must extend to whitespace (`[^ ]*`) — truncating at `/` drops `?token=`, and the whole lane hangs on a first-screen 401; the token-redeeming 303 **discards other query parameters on the same URL**, so navigation with parameters must first redeem the cookie via the token URL, `addCookies`, and then go straight to the target URL (see also `DSH-0.1.2-A1-19` on the acceptance side). See [e2e-mount.sh readiness-line parsing](https://github.com/omdsh-dev/DSH-better-sidebar/blob/main/scripts/e2e-mount.sh).
+- **Source**: [alpha.1 browser auth](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/packages/client/connection/src/browser-auth.ts) · [alpha.1 Connection routes](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/packages/client/connection/src/index.ts) · [alpha.1 raw WebServer](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/packages/host/webserver/src/index.ts)
 
 ---
 
-### DSH-0.1.2-A1-12 · 官方 DeepSeek 适配器默认附带插件包名与版本
+### DSH-0.1.2-A1-09 · New capability: model settings page can integrate provider login configuration
 
-- **类型**: privacy
-- **适用对象**: 使用官方 DeepSeek 适配器的部署与面向用户的插件
-- **影响触点**: 无（部署/隐私面）
-- **操作级别**: informational
-- **症状**: 启用插件的包名与版本默认随请求提供；部署可通过配置关闭。
-- **迁移配方**: 插件代码通常无需修改；部署维护者应审阅目标 tag 的配置项，按自身隐私政策决定是否关闭，并向用户准确说明宿主行为。
-- **验证**: 在不打印凭据或请求正文的前提下，仅验证配置开关是否改变元数据附带状态。
-- **来源**: [alpha.1 release notes「新增功能」](https://github.com/deepseek-ai/deepseek-harness/releases/tag/dsh-v0.1.2-alpha.1)
-
----
-
-### DSH-0.1.2-A1-13 · 平台 shell 与目录选择器修复可能淘汰旧 workaround
-
-- **类型**: fix
-- **适用对象**: 为持久 PowerShell/Bash 或 Windows 目录选择器维护兼容 workaround 的插件
-- **影响触点**: #4、#7
-- **操作级别**: conditional
-- **症状**: 旧 workaround 可能产生重复等待、错误截断或平台分支漂移。
-- **迁移配方**: 只在对应平台复现确认修复后，逐条删除有证据已不需要的 workaround；不要一次性清理所有兼容分支。
-- **验证**: macOS/Linux 持久 shell、macOS 多子进程、Windows 特定编码路径分别做目标平台测试。
-- **来源**: [alpha.1 release notes「问题修复」](https://github.com/deepseek-ai/deepseek-harness/releases/tag/dsh-v0.1.2-alpha.1)
+- **Type**: capability
+- **Applies to**: Model provider plugins
+- **Touchpoints**: #5
+- **Action level**: optional
+- **Symptoms**: None; this is an optional capability.
+- **Migration recipe**: Before adopting, confirm the registration entry from the target tag's public types/examples; if only an internal UI interface exists, mark it "pending confirmation" and do not patch the settings page.
+- **Verification**: The login entry is visible, credential writes go through the host credentials service, and the entry disappears after the plugin is uninstalled.
+- **Source**: [alpha.1 release notes, "New features"](https://github.com/deepseek-ai/deepseek-harness/releases/tag/dsh-v0.1.2-alpha.1)
 
 ---
 
-### DSH-0.1.2-A1-14 · 可选的 DeepSeek Session 日志增量上传
+### DSH-0.1.2-A1-10 · New capability: support for registering third-party languages
 
-- **类型**: privacy
-- **适用对象**: 使用官方 DeepSeek LLM API 且考虑启用 `session-log-deepseek` 的部署/插件
-- **影响触点**: #2、#3；数据出境面
-- **操作级别**: conditional
-- **症状**: 功能默认 `enabled: false`；启用后，官方请求会携带 live Session 的 canonical log 连续后缀，而不是普通本地-only 行为。
-- **迁移配方**: 仅在部署明确同意日志出境后启用。每次从该 Session 的已接受 watermark 后发送连续 suffix；HTTP 2xx 后追加 `session-log-deepseek/delivery-accepted` watermark。非 2xx/传输失败不推进水位，后续会重发不确定区间；崩溃窗口是 at-least-once，可能重复、不应漏序列。该插件没有独立请求大小上限，provider 拒绝时保持水位不变。
-- **验证**: 关闭时无 `dsh_session_log` 字段且无 acceptance event；开启时只对 live、非空 Session 发 suffix；2xx 推进 watermark，非 2xx 不推进。诊断不得打印日志正文。
-- **来源**: [alpha.1 session-log-deepseek README](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/packages/session/session-log-deepseek/README.md) · [alpha.1 release notes](https://github.com/deepseek-ai/deepseek-harness/releases/tag/dsh-v0.1.2-alpha.1)
+- **Type**: capability
+- **Applies to**: UI plugins that provide localization resources
+- **Touchpoints**: #5
+- **Action level**: optional
+- **Symptoms**: None; this is an optional capability.
+- **Migration recipe**: Replace custom i18n patches with the target tag's public language-registration API; when no public entry exists, do not guess the interface.
+- **Verification**: The language is selectable, takes effect after switching, and missing keys fall back per host rules.
+- **Source**: [alpha.1 release notes, "New features"](https://github.com/deepseek-ai/deepseek-harness/releases/tag/dsh-v0.1.2-alpha.1)
 
 ---
 
-### DSH-0.1.2-A1-19 · Web 插件验收改读宿主启动图与认证 URL
+### DSH-0.1.2-A1-11 · New capability: subagents can select provider/model/reasoning effort/output cap
 
-- **类型**: behavior
-- **适用对象**: 硬编码 Web 根地址、插件 bundle 路径或启动日志格式的浏览器验收脚本与包装器
-- **影响触点**: #6、#7
-- **操作级别**: required-if-hit
-- **症状**: alpha.1 的 `dsh web` 根 URL 带进程级 token，客户端 bundle 又由宿主通过
-  `window.__DSH_BOOT__` 公告带 revision 的单资源或组合 URL。继续拼接无 revision 的
-  `/plugins/<id>/client.js`，或只检查 HTTP 200，会把 401/404、未注册 bundle 和未挂载 UI
-  误判为插件兼容。
-- **迁移配方**: 在隔离 profile 上以精确目标 tag 启动 `dsh web --no-open`，保留并访问
-  `dsh web:` 打印的完整 URL，让根路径 token 交换得到 Cookie。随后从真实页面读取
-  `window.__DSH_BOOT__.entries`，按插件 `package.json#name` 找 entry，并请求宿主公告的
-  `url` 或所属 batch URL；不要自行推导资源路径。若同一产物声明兼容 rc 与 alpha，脚本应
-  同时接受旧宿主的裸根 URL 和 alpha 的 token URL，但每条 lane 都只按该宿主实际公告的
-  资源地址验收。
-- **验证**: 公告资源返回 200；bundle 以目标包名完成 `__ModuleLoader__.load` 注册；等待一个
-  插件拥有的 DOM 标记或等价核心行为；收集并拒绝 page error。资源 200、启动日志出现 URL、
-  或 `entries` 中出现 id，任一单项都不能独立证明插件可用。
-- **来源**: [alpha.1 Web App 启动 URL](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/packages/bundle/web-app/README.md) · [alpha.1 client modules 启动图与 bundle URL](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/packages/client/modules/README.md) · [alpha.1 boot manifest 解析](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/packages/client/modules/src/client/manifest.ts)
-- **实战批注**（2026-08，GenUI 0.9.6 与 Annotation 1.4.5）: 两个插件用同一份发布产物分别在
-  `dsh-v0.1.1-rc.2` 与 `dsh-v0.1.2-alpha.1` 通过真实 Web smoke；脚本兼容裸 URL 与 token
-  URL，并验证 boot entry、资源 200、插件 DOM 挂载和 page error。见
-  [GenUI PR #86](https://github.com/omdsh-dev/dsh-genui/pull/86) 与
-  [Annotation PR #40](https://github.com/omdsh-dev/dsh-annotation/pull/40)。
-- **实战批注**（2026-08-31，Node `fetch` e2e）: 默认跟随 token URL 的 303 并不会替测试脚本
-  保存 `Set-Cookie`，后续 boot manifest 请求会得到 401。无 cookie jar 的脚本应先用
-  `redirect: 'manual'` 断言 303 并提取 Cookie，再用该 Cookie 请求干净根 URL、boot manifest
-  和宿主公告资源；浏览器自动化则保留同一 context 完成 token 交换。
+- **Type**: capability
+- **Applies to**: Subagent orchestration or selector plugins
+- **Touchpoints**: #3, #5
+- **Action level**: optional
+- **Symptoms**: None; this is an optional capability.
+- **Migration recipe**: Confirm the exact parameter names and authorization constraints from the target tag's type definitions before passing them through; do not invent object shapes from release notes.
+- **Verification**: Launch a subagent with parameters and check the authorization scope, actual provider/model, reasoning effort, and maximum output length.
+- **Source**: [alpha.1 release notes, "New features"](https://github.com/deepseek-ai/deepseek-harness/releases/tag/dsh-v0.1.2-alpha.1)
 
-### DSH-0.1.2-A1-20 · `userQuestions.registerProvider` 移除，answerer 迁到 `'user-questions/request'` waterfall
+---
 
-- **类型**: breaking
-- **适用对象**: 注册结构化提问 answerer 的宿主 UI 插件（宿主内 TUI 类 answerer；官方 web client 经 Remote 桥接不受影响）
-- **影响触点**: #3
-- **操作级别**: required-if-hit
-- **症状**: alpha.1 起 `packages/interaction/user-questions/src/index.ts` 无 `registerProvider`，`:136` 改为 `ctx.waterfall('user-questions/request', …)` 派发。attach 期抛 `TypeError: userQuestions.registerProvider is not a function`；提问无人 answer，调用方挂起或收到 `NO_PROVIDER`。
-- **迁移配方**: answerer 改为注册 Cordis waterfall 事件 `'user-questions/request'`（事件与词汇类型经 `@deepseek-ai/dsh-user-questions` 的 module augmentation 合并）：
+### DSH-0.1.2-A1-12 · Official DeepSeek adapter attaches plugin package name and version by default
+
+- **Type**: privacy
+- **Applies to**: Deployments using the official DeepSeek adapter, and user-facing plugins
+- **Touchpoints**: None (deployment/privacy surface)
+- **Action level**: informational
+- **Symptoms**: The package name and version of enabled plugins are sent with requests by default; deployments can turn this off via configuration.
+- **Migration recipe**: Plugin code usually needs no changes; deployment maintainers should review the target tag's configuration options, decide whether to disable this per their own privacy policy, and explain the host behavior to users accurately.
+- **Verification**: Without printing credentials or request bodies, verify only whether the configuration switch changes the metadata attachment state.
+- **Source**: [alpha.1 release notes, "New features"](https://github.com/deepseek-ai/deepseek-harness/releases/tag/dsh-v0.1.2-alpha.1)
+
+---
+
+### DSH-0.1.2-A1-13 · Platform shell and directory picker fixes may obsolete old workarounds
+
+- **Type**: fix
+- **Applies to**: Plugins maintaining compatibility workarounds for persistent PowerShell/Bash or the Windows directory picker
+- **Touchpoints**: #4, #7
+- **Action level**: conditional
+- **Symptoms**: Old workarounds may cause duplicate waits, incorrect truncation, or platform-branch drift.
+- **Migration recipe**: Only after reproducing and confirming the fix on the corresponding platform, delete workarounds one by one that evidence shows are no longer needed; do not clean up all compatibility branches at once.
+- **Verification**: Run target-platform tests separately for the macOS/Linux persistent shell, macOS multi-subprocess, and Windows specific-encoding paths.
+- **Source**: [alpha.1 release notes, "Bug fixes"](https://github.com/deepseek-ai/deepseek-harness/releases/tag/dsh-v0.1.2-alpha.1)
+
+---
+
+### DSH-0.1.2-A1-14 · Optional incremental upload of DeepSeek session logs
+
+- **Type**: privacy
+- **Applies to**: Deployments/plugins using the official DeepSeek LLM API that consider enabling `session-log-deepseek`
+- **Touchpoints**: #2, #3; data-egress surface
+- **Action level**: conditional
+- **Symptoms**: The feature defaults to `enabled: false`; once enabled, official requests carry the continuous suffix of the live session's canonical log, instead of the normal local-only behavior.
+- **Migration recipe**: Enable only after the deployment explicitly agrees to log egress. Each time, send the continuous suffix starting after this session's accepted watermark; after an HTTP 2xx, append the `session-log-deepseek/delivery-accepted` watermark. Non-2xx/transport failures do not advance the watermark, and the uncertain interval is re-sent later; the crash window is at-least-once, so delivery may duplicate but must not skip sequence. This plugin has no separate request-size cap; when the provider rejects, the watermark stays put.
+- **Verification**: When disabled, no `dsh_session_log` field and no acceptance event; when enabled, suffixes are sent only for live, non-empty sessions; 2xx advances the watermark, non-2xx does not. Diagnostics must not print log bodies.
+- **Source**: [alpha.1 session-log-deepseek README](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/packages/session/session-log-deepseek/README.md) · [alpha.1 release notes](https://github.com/deepseek-ai/deepseek-harness/releases/tag/dsh-v0.1.2-alpha.1)
+
+---
+
+### DSH-0.1.2-A1-19 · Web plugin acceptance now reads the host boot manifest and the auth URL
+
+- **Type**: behavior
+- **Applies to**: Browser acceptance scripts and wrappers that hardcode the web root URL, plugin bundle paths, or startup-log format
+- **Touchpoints**: #6, #7
+- **Action level**: required-if-hit
+- **Symptoms**: alpha.1's `dsh web` root URL carries a process-level token, and the host advertises the client bundle through `window.__DSH_BOOT__` as revision-bearing single-resource or combo URLs. Continuing to concatenate a revision-less
+  `/plugins/<id>/client.js`, or checking only HTTP 200, misjudges 401/404, unregistered bundles, and unmounted UIs as plugin compatibility.
+- **Migration recipe**: On an isolated profile, start `dsh web --no-open` at the exact target tag, keep and visit the full URL printed by `dsh web:`, and let the root-path token exchange yield the Cookie. Then read `window.__DSH_BOOT__.entries` from the real page, find the entry by the plugin's `package.json#name`, and request the host-advertised `url` or its batch URL; do not derive resource paths yourself. If the same artifact declares compatibility with both rc and alpha, the script should accept both the old host's bare root URL and alpha's token URL, but each lane must be accepted only against the resource addresses that host actually advertises.
+- **Verification**: The advertised resource returns 200; the bundle completes `__ModuleLoader__.load` registration under the target package name; wait for a DOM marker owned by the plugin or equivalent core behavior; collect and fail on page errors. Any single item — resource 200, the URL appearing in the startup log, or the id appearing in `entries` — cannot by itself prove the plugin works.
+- **Source**: [alpha.1 Web App startup URL](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/packages/bundle/web-app/README.md) · [alpha.1 client modules boot manifest and bundle URLs](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/packages/client/modules/README.md) · [alpha.1 boot manifest parsing](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/packages/client/modules/src/client/manifest.ts)
+- **Field note** (2026-08, GenUI 0.9.6 and Annotation 1.4.5): Both plugins passed a real web smoke on
+  `dsh-v0.1.1-rc.2` and `dsh-v0.1.2-alpha.1` using the same published artifact; the scripts accept both bare and token
+  URLs and verify the boot entry, resource 200, plugin DOM mount, and page errors. See
+  [GenUI PR #86](https://github.com/omdsh-dev/dsh-genui/pull/86) and
+  [Annotation PR #40](https://github.com/omdsh-dev/dsh-annotation/pull/40).
+- **Field note** (2026-08-31, Node `fetch` e2e): Following the token URL's 303 by default does not
+  store `Set-Cookie` for the test script, so the subsequent boot-manifest request gets a 401. Scripts without a cookie jar should first use
+  `redirect: 'manual'` to assert the 303 and extract the Cookie, then use that Cookie for the clean root URL, boot manifest,
+  and host-advertised resources; browser automation should keep the same context to complete the token exchange.
+
+### DSH-0.1.2-A1-20 · `userQuestions.registerProvider` removed, answerers moved to the `'user-questions/request'` waterfall
+
+- **Type**: breaking
+- **Applies to**: Host UI plugins that register structured-question answerers (in-host TUI-style answerers; the official web client bridges over Remote and is unaffected)
+- **Touchpoints**: #3
+- **Action level**: required-if-hit
+- **Symptoms**: Starting with alpha.1, `packages/interaction/user-questions/src/index.ts` has no `registerProvider`; `:136` dispatches via `ctx.waterfall('user-questions/request', …)`. During attach, `TypeError: userQuestions.registerProvider is not a function` is thrown; questions get no answer and the caller hangs or receives `NO_PROVIDER`.
+- **Migration recipe**: Answerers should instead register the Cordis waterfall event `'user-questions/request'` (event and vocabulary types are merged via `@deepseek-ai/dsh-user-questions`'s module augmentation):
 
   ```typescript
   // 旧（rc.2）：服务级 provider
@@ -343,127 +334,127 @@ verifiedAt: 2026-08-31
   this.disposer = ctx.on('user-questions/request', (request, next) => this.handle(request))
   ```
 
-  claim/委托语义：返回 `AskUserQuestionAnswer` 即接管该请求；取消语义不变——挂起被取消时 reject `UserQuestionError('...', 'ASK_CANCELLED')`，不要 resolve 空 answer。
+  Claim/delegation semantics: returning an `AskUserQuestionAnswer` claims the request; cancellation semantics are unchanged — when a pending question is cancelled, reject with `UserQuestionError('...', 'ASK_CANCELLED')`; do not resolve an empty answer.
 
-  **scope 过滤的坑**：`ctx.userQuestions.ask()` 不带 `agent` 时在 userQuestions 服务自身 ctx 上派发，同一 fiber 树其他 entry（如 TUI runner）注册的监听者收不到；带 live `agent` 时经 `scopeTarget(agent, agent)` scope-filtered 派发，无 scope 标签的监听者必然被投递。迁移前先确认调用方按 wire 语义携带 agent——不要在未查证前把监听器注册到 `ctx.root` 来「修」收不到的问题。
-- **验证**: 真实 spine 下 `ask` 挂起 → 面板渲染 → 数字键结算 resolve；Esc 取消 reject `ASK_CANCELLED`；切会话/dispose 后挂起提问 fail-closed 且监听 disposer 已释放（重复 attach 不叠加）；不带 agent 的 ask 在同一 fiber 树其他 entry 的监听者处不可达（记录为已知语义而非回归）。
-- **来源**: [rc.2 registerProvider 定义](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.1-rc.2/packages/interaction/user-questions/src/index.ts) · [alpha.1 user-questions 服务（无 registerProvider，waterfall 派发）](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/packages/interaction/user-questions/src/index.ts) · [alpha.1 answerer waterfall 类型契约](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/packages/interaction/user-questions/src/types.ts) · [官方 tripwire answerer fixture](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/test-support/session-snapshot/tests/fixtures/child-question-tripwire.ts)
-- **实战批注**（2026-08-30，dsh-tui@0.1.2-rc.28 → alpha.2）: 注册改为 waterfall 后，unscoped `ask()`（不带 agent）确实无法送达同 fiber 树其他 entry 的监听者——loader-composition 测试先按 rc.2 语义不带 agent 调用，面板不渲染；改按 wire 语义携带 live agent 后立即可达。
+  **The scope-filtering pitfall**: `ctx.userQuestions.ask()` without `agent` dispatches on the userQuestions service's own ctx, so listeners registered by other entries in the same fiber tree (e.g. the TUI runner) do not receive it; with a live `agent`, dispatch is scope-filtered via `scopeTarget(agent, agent)`, and listeners without a scope tag always receive the delivery. Before migrating, confirm that the caller carries the agent per the wire semantics — do not register the listener on `ctx.root` to "fix" non-delivery until that is verified.
+- **Verification**: On a real spine: `ask` hangs → the panel renders → a number-key selection resolves it; Esc cancels and rejects with `ASK_CANCELLED`; after session switch/dispose, pending questions fail closed and the listener disposer is released (repeat attaches do not stack); an ask without `agent` is unreachable from listeners of other entries in the same fiber tree (record as known semantics, not a regression).
+- **Source**: [rc.2 registerProvider definition](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.1-rc.2/packages/interaction/user-questions/src/index.ts) · [alpha.1 user-questions service (no registerProvider, waterfall dispatch)](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/packages/interaction/user-questions/src/index.ts) · [alpha.1 answerer waterfall type contract](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/packages/interaction/user-questions/src/types.ts) · [official tripwire answerer fixture](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/test-support/session-snapshot/tests/fixtures/child-question-tripwire.ts)
+- **Field note** (2026-08-30, dsh-tui@0.1.2-rc.28 → alpha.2): After switching registration to the waterfall, unscoped `ask()` (without agent) indeed cannot reach listeners of other entries in the same fiber tree — the loader-composition test first called without agent per rc.2 semantics and the panel did not render; after switching to carry a live agent per the wire semantics, it became reachable immediately.
 
-- **实战批注**（2026-08-28，[dsh-TUI #622](https://github.com/ccch1mneyyy/dsh-TUI/pull/622)）: `typeof service.registerProvider === 'function'` 探测选路径；waterfall 监听器按 `request.agent.id` 过滤，不带 agent 的请求主动接管（dsh-auth `/auth` 向导无 agent）；在 channel 建好后再绑，`/new`、`/resume`、rewind 会换 agentId。rc.2 的 `DUPLICATE_PROVIDER` 独占席位在 waterfall 里没有对应物。
-
----
-
-### DSH-0.1.2-A1-21 · `dsh-agent-presets` 删除 `resolveSessionPreset`，shipped preset 改由包内 `presets/` 提供
-
-- **类型**: breaking
-- **适用对象**: 需要从持久会话推断当前 agent preset 的宿主 UI / 会话管理插件；自行给 agent-presets 配 `roots` 的 profile
-- **影响触点**: #3、#4
-- **操作级别**: required-if-hit
-- **症状**: rc.2 `@deepseek-ai/dsh-agent-presets` 导出 `resolveSessionPreset(session)`（`src/session.ts:48`），alpha.1 整个删除（源码 0 命中），typecheck TS2305。同时 shipped preset 从 dsh CLI 的 `config/agent-presets/` 目录移到 `dsh-agent-presets` 包内 `presets/`（`cordis`、`minimal`、`ptc`、`standard`），服务默认 `includeShippedRoot: true`；仍把 rc.2 的 CLI 目录写进 `roots` 的配置在 alpha.1 指向不存在的路径。
-- **迁移配方**: 按同一语义本地折叠：取会话里最后一条 `agent-preset/selected` 事件的 `data.agentPreset`，没有则回退 `header.agentPreset`；不要从 preset 显示名反推。`roots` 改为探测：`require.resolve('@deepseek-ai/dsh-agent-presets/package.json')` 所在目录有 `presets/` 就省略 `roots`（走 `includeShippedRoot`），否则保留 rc.2 的 CLI 目录回退。要用自定义 root 遮蔽 shipped 同名 preset，见 [rollup R-10](rollup-0.1.2.md)。
-- **验证**: 带 `agent-preset/selected` 事件的会话恢复后得到最后一次选择；无事件会话得到 header 值；rc.2 与 alpha.1 两个宿主上 roster 都能列出 `standard`。
-- **来源**: [rc.2 `resolveSessionPreset`](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.1-rc.2/packages/preset/agent-presets/src/session.ts) · [alpha.1 agent-presets 服务（`includeShippedRoot`）](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/packages/preset/agent-presets/src/index.ts) · [alpha.1 包内 presets/](https://github.com/deepseek-ai/deepseek-harness/tree/dsh-v0.1.2-alpha.1/packages/preset/agent-presets/presets)
-- **实战批注**（2026-08-28，[dsh-TUI #622](https://github.com/ccch1mneyyy/dsh-TUI/pull/622)）: `preset-resolution.ts` 的 `resolveRecordedPreset` 做折叠；`cordis.patch.yml` 用 `!!js` 探测包目录有无 `presets/`。直接删 `roots` 在 rc.2 上得到空 roster，必须探测。
-- **实战批注**（2026-08-28，dsh-ui-whale / dsh-ui-progress 迁移期，Windows）: 本卡症状可能以 tsbuildinfo 假阳性形态出现——插件代码对 `resolveSessionPreset` 零引用仍报 `MISSING_EXPORT`，`pnpm run clean` 后消失。诊断顺序应先 clean 排除增量缓存，再 grep 真实引用判定是否命中本卡。
+- **Field note** (2026-08-28, [dsh-TUI #622](https://github.com/ccch1mneyyy/dsh-TUI/pull/622)): Probe with `typeof service.registerProvider === 'function'` to pick the path; waterfall listeners filter by `request.agent.id`, and requests without an agent are taken over proactively (the dsh-auth `/auth` wizard has no agent); bind only after the channel is set up, because `/new`, `/resume`, and rewind change the agentId. rc.2's exclusive `DUPLICATE_PROVIDER` seat has no counterpart in the waterfall.
 
 ---
 
-### DSH-0.1.2-A1-22 · `isTokenDelta` 不再从 `@deepseek-ai/dsh-llm/message` 导出
+### DSH-0.1.2-A1-21 · `dsh-agent-presets` drops `resolveSessionPreset`; shipped presets now come from the package's `presets/`
 
-- **类型**: breaking
-- **适用对象**: 用 `isTokenDelta` 判首 token、算 TPS 的宿主 UI 插件
-- **影响触点**: #3
-- **操作级别**: required-if-hit
-- **症状**: rc.2 `@deepseek-ai/dsh-llm/message` 导出 `isTokenDelta`（`dsh-client-runtime` 再导出）；alpha.1 该函数只在 `packages/client/ui-chat/src/client/conversation-nodes/event-projection.ts`（Web Client 内部），`dsh-llm` 不再导出，typecheck TS2305。
-- **迁移配方**: 本地按 `StreamChunk` 判别式收窄：`text-delta` / `reasoning-delta` 非空即 token；`tool-call-delta` 带 `argumentsDelta` 或 `name` 即 token。不要为此去 import `dsh-client-ui-chat`——那是浏览器平面包。
-- **验证**: 同一条回放日志上首 token 时刻与 rc.2 一致；工具调用 delta 计入。
-- **来源**: [rc.2 从 `dsh-llm/message` 再导出](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.1-rc.2/packages/client/runtime/src/client/sessions/assistant-timing.ts) · [alpha.1 只剩 ui-chat 内部实现](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/packages/client/ui-chat/src/client/conversation-nodes/event-projection.ts)
-- **实战批注**（2026-08-28，[dsh-TUI #622](https://github.com/ccch1mneyyy/dsh-TUI/pull/622)）: `src/dsh-adapter/channel.ts` 本地 `isTokenDelta(chunk: StreamChunk)`，`scripts/verify-tps.mjs` 回归。
-
----
-
-### DSH-0.1.2-A1-23 · base 组合两个默认值变化：session telemetry 默认 `FEEDBACK_ONLY`，新增插件包名上报行
-
-- **类型**: privacy
-- **适用对象**: 复用 `dsh-base` 组合、对遥测有明确隐私立场的 profile / bundle 维护者
-- **影响触点**: 无（组合/隐私面）
-- **操作级别**: conditional
-- **症状**: rc.2 `packages/bundle/base/cordis.patch.yml:151` 的 `session-telemetry-otel` 默认 `mode: DSH_TELEMETRY_MODE || 'DISABLED'`，alpha.1 `:193` 改成 `'FEEDBACK_ONLY'`。alpha.1 base 还新增 `plugin-package-inventory-deepseek` 行（`:70`，包 `@deepseek-ai/dsh-plugin-package-inventory-deepseek`），默认把启用插件的包名和版本随官方 DeepSeek 请求上报——这就是 [DSH-0.1.2-A1-12](v0.1.2-alpha.1.md) 说的行为，这里给出它的 loader 行 id。
-- **迁移配方**: 要保持 rc.2 的关闭立场，在自己的 `cordis.patch.yml` 覆盖：`session-telemetry-otel` 必须重述整个 `config` 对象（include patch 是替换不是合并），`mode` 写 `process.env.DSH_TELEMETRY_MODE || 'DISABLED'`；`plugin-package-inventory-deepseek` 行 `config: { enabled: false }`。开不开由部署方按隐私政策定，本卡只保证默认值变化被看见。
-- **验证**: `dsh --profile <p> --dump-config` 里两行 resolved config 是期望值；发一次真实请求确认没有插件包清单字段（不打印凭据和正文）。
-- **来源**: [rc.2 base 组合（`DISABLED`）](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.1-rc.2/packages/bundle/base/cordis.patch.yml) · [alpha.1 base 组合（`FEEDBACK_ONLY` + inventory 行）](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/packages/bundle/base/cordis.patch.yml)
-- **实战批注**（2026-08-28，[dsh-TUI #622](https://github.com/ccch1mneyyy/dsh-TUI/pull/622)）: `cordis.patch.yml` 两处覆盖；telemetry 那行必须整个 config 重述。
+- **Type**: breaking
+- **Applies to**: Host UI / session-management plugins that need to infer the current agent preset from a persisted session; profiles that set `roots` for agent-presets themselves
+- **Touchpoints**: #3, #4
+- **Action level**: required-if-hit
+- **Symptoms**: rc.2's `@deepseek-ai/dsh-agent-presets` exports `resolveSessionPreset(session)` (`src/session.ts:48`); alpha.1 deletes it entirely (zero hits in source), typecheck TS2305. At the same time, shipped presets moved from the dsh CLI's `config/agent-presets/` directory into `presets/` inside the `dsh-agent-presets` package (`cordis`, `minimal`, `ptc`, `standard`), and the service defaults to `includeShippedRoot: true`; configs that still write rc.2's CLI directory into `roots` now point at a nonexistent path in alpha.1.
+- **Migration recipe**: Fold it locally with the same semantics: take `data.agentPreset` from the last `agent-preset/selected` event in the session, falling back to `header.agentPreset` when there is none; do not reverse-engineer it from the preset display name. Switch `roots` to probing: if the directory of `require.resolve('@deepseek-ai/dsh-agent-presets/package.json')` contains `presets/`, omit `roots` (going through `includeShippedRoot`); otherwise keep the rc.2 CLI directory as the fallback. To shadow a shipped preset of the same name with a custom root, see [rollup R-10](rollup-0.1.2.md).
+- **Verification**: A session with `agent-preset/selected` events resumes with the last selection; a session without events gets the header value; the roster lists `standard` on both the rc.2 and alpha.1 hosts.
+- **Source**: [rc.2 `resolveSessionPreset`](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.1-rc.2/packages/preset/agent-presets/src/session.ts) · [alpha.1 agent-presets service (`includeShippedRoot`)](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/packages/preset/agent-presets/src/index.ts) · [alpha.1 in-package presets/](https://github.com/deepseek-ai/deepseek-harness/tree/dsh-v0.1.2-alpha.1/packages/preset/agent-presets/presets)
+- **Field note** (2026-08-28, [dsh-TUI #622](https://github.com/ccch1mneyyy/dsh-TUI/pull/622)): `resolveRecordedPreset` in `preset-resolution.ts` does the folding; `cordis.patch.yml` probes whether the package directory has `presets/` via `!!js`. Deleting `roots` outright yields an empty roster on rc.2, so probing is required.
+- **Field note** (2026-08-28, dsh-ui-whale / dsh-ui-progress migration period, Windows): This card's symptom can appear as a tsbuildinfo false positive — plugin code with zero references to `resolveSessionPreset` still reports `MISSING_EXPORT`, which disappears after `pnpm run clean`. Diagnostic order: clean first to rule out incremental caches, then grep for real references to decide whether this card is hit.
 
 ---
 
-### DSH-0.1.2-A1-24 · `dsh-llm-pi-ai` 的 `@earendil-works/pi-ai` 从 0.82 升到 0.84，直接依赖它的插件会拿到第二份实例
+### DSH-0.1.2-A1-22 · `isTokenDelta` no longer exported from `@deepseek-ai/dsh-llm/message`
 
-- **类型**: behavior
-- **适用对象**: 直接 import `@earendil-works/pi-ai`（provider 目录、`Credential`/`AuthContext` 类型）的 provider / 认证插件
-- **影响触点**: 无（打包/依赖面）
-- **操作级别**: required-if-hit
-- **症状**: `@deepseek-ai/dsh-llm-pi-ai` 对 `@earendil-works/pi-ai` 的范围 rc.2 `^0.82.1` → alpha.1 `^0.84.2`。插件自己声明 `^0.82.x` 会在 alpha 宿主上装出第二份 pi-ai，类型和运行时对象跨实例不相等；一个范围也无法同时满足 rc.2 和 alpha.1 两个 cohort。
-- **迁移配方**: 不直接依赖 pi-ai。从宿主适配器解析：`createRequire(import.meta.resolve('@deepseek-ai/dsh-llm-pi-ai/package.json'))`，再 `require.resolve('@earendil-works/pi-ai', { paths })` 拿目录；类型从 `PiAiAdapterOptions['auth']`、`ResolvedPiAiProviderProfile['piProvider']` 派生。
-- **验证**: rc.2 与 alpha.1 宿主各装一次，`pnpm why @earendil-works/pi-ai` 只有一份，且来自 `dsh-llm-pi-ai`。
-- **来源**: [rc.2 `dsh-llm-pi-ai` package.json（`^0.82.1`）](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.1-rc.2/packages/llm/llm-pi-ai/package.json) · [alpha.1 `dsh-llm-pi-ai` package.json（`^0.84.2`）](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/packages/llm/llm-pi-ai/package.json)
-- **实战批注**（2026-08-28，[dsh-TUI #622](https://github.com/ccch1mneyyy/dsh-TUI/pull/622)）: dsh-auth 硬 bump 到 `^0.84.2` 加 override 在 rc.2 上装出两份；改为从 `dsh-llm-pi-ai` 解析后各 cohort 只有一份。
+- **Type**: breaking
+- **Applies to**: Host UI plugins that use `isTokenDelta` to detect the first token and compute TPS
+- **Touchpoints**: #3
+- **Action level**: required-if-hit
+- **Symptoms**: rc.2's `@deepseek-ai/dsh-llm/message` exports `isTokenDelta` (re-exported by `dsh-client-runtime`); in alpha.1 the function lives only in `packages/client/ui-chat/src/client/conversation-nodes/event-projection.ts` (Web Client internals), `dsh-llm` no longer exports it, typecheck TS2305.
+- **Migration recipe**: Narrow locally on the `StreamChunk` discriminator: `text-delta` / `reasoning-delta` non-empty counts as a token; `tool-call-delta` with `argumentsDelta` or `name` counts as a token. Do not import `dsh-client-ui-chat` for this — it is a browser-plane package.
+- **Verification**: On the same replay log, the first-token timestamp matches rc.2; tool-call deltas count as tokens.
+- **Source**: [rc.2 re-export from `dsh-llm/message`](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.1-rc.2/packages/client/runtime/src/client/sessions/assistant-timing.ts) · [alpha.1 only ui-chat's internal implementation remains](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/packages/client/ui-chat/src/client/conversation-nodes/event-projection.ts)
+- **Field note** (2026-08-28, [dsh-TUI #622](https://github.com/ccch1mneyyy/dsh-TUI/pull/622)): local `isTokenDelta(chunk: StreamChunk)` in `src/dsh-adapter/channel.ts`, regression-checked by `scripts/verify-tps.mjs`.
 
 ---
 
-### DSH-0.1.2-A1-25 · `@deepseek-ai/dsh-client-runtime` 包拆除，client 符号按域迁移
+### DSH-0.1.2-A1-23 · base composition: two default changes — session telemetry defaults to `FEEDBACK_ONLY`, plus a new plugin package-name reporting row
 
-- **类型**: breaking
-- **适用对象**: 从 `@deepseek-ai/dsh-client-runtime`（含 `/client` 入口）导入符号、或在 `dsh.client.inject` 里声明该包的 Web Client 插件
-- **影响触点**: #3、#5
-- **操作级别**: required-if-hit
-- **症状**: build/typecheck 报 missing-export 或模块不存在；运行期插件不进 boot 图或装配行永久 pending，且常无显式报错。
-- **迁移配方**: 该包在 alpha.1 已从 `packages/client` 删除，符号按域拆走。实测对照如下（仍以目标 tag 各包实际导出为准）：
+- **Type**: privacy
+- **Applies to**: Profile / bundle maintainers that reuse the `dsh-base` composition and have an explicit privacy stance on telemetry
+- **Touchpoints**: None (composition/privacy surface)
+- **Action level**: conditional
+- **Symptoms**: rc.2's `session-telemetry-otel` at `packages/bundle/base/cordis.patch.yml:151` defaults to `mode: DSH_TELEMETRY_MODE || 'DISABLED'`; alpha.1 `:193` changes it to `'FEEDBACK_ONLY'`. alpha.1's base also adds a `plugin-package-inventory-deepseek` row (`:70`, package `@deepseek-ai/dsh-plugin-package-inventory-deepseek`) that by default reports the package names and versions of enabled plugins with official DeepSeek requests — this is the behavior described in [DSH-0.1.2-A1-12](v0.1.2-alpha.1.md); this card gives its loader row id.
+- **Migration recipe**: To keep rc.2's opt-out stance, override in your own `cordis.patch.yml`: `session-telemetry-otel` must restate the whole `config` object (an include patch replaces, it does not merge), with `mode` written as `process.env.DSH_TELEMETRY_MODE || 'DISABLED'`; give the `plugin-package-inventory-deepseek` row `config: { enabled: false }`. Whether to enable is the deployment's decision per its privacy policy; this card only ensures the default change is noticed.
+- **Verification**: In `dsh --profile <p> --dump-config`, the two rows' resolved config matches the expected values; send one real request to confirm no plugin package-manifest field is present (without printing credentials or bodies).
+- **Source**: [rc.2 base composition (`DISABLED`)](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.1-rc.2/packages/bundle/base/cordis.patch.yml) · [alpha.1 base composition (`FEEDBACK_ONLY` + inventory row)](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/packages/bundle/base/cordis.patch.yml)
+- **Field note** (2026-08-28, [dsh-TUI #622](https://github.com/ccch1mneyyy/dsh-TUI/pull/622)): two overrides in `cordis.patch.yml`; the telemetry row must restate the entire config.
 
-| 0.1.1（dsh-client-runtime/client） | 0.1.2 去处 |
+---
+
+### DSH-0.1.2-A1-24 · `dsh-llm-pi-ai` bumps `@earendil-works/pi-ai` from 0.82 to 0.84; plugins that depend on it directly get a second instance
+
+- **Type**: behavior
+- **Applies to**: Provider / auth plugins that import `@earendil-works/pi-ai` directly (provider directory, `Credential`/`AuthContext` types)
+- **Touchpoints**: None (packaging/dependency surface)
+- **Action level**: required-if-hit
+- **Symptoms**: `@deepseek-ai/dsh-llm-pi-ai`'s range on `@earendil-works/pi-ai` moves from rc.2 `^0.82.1` to alpha.1 `^0.84.2`. A plugin that declares `^0.82.x` itself gets a second pi-ai installed on an alpha host; types and runtime objects are not equal across instances. No single range can satisfy both the rc.2 and alpha.1 cohorts at once.
+- **Migration recipe**: Do not depend on pi-ai directly. Resolve from the host adapter: `createRequire(import.meta.resolve('@deepseek-ai/dsh-llm-pi-ai/package.json'))`, then `require.resolve('@earendil-works/pi-ai', { paths })` to get the directory; derive types from `PiAiAdapterOptions['auth']` and `ResolvedPiAiProviderProfile['piProvider']`.
+- **Verification**: Install once on each of the rc.2 and alpha.1 hosts; `pnpm why @earendil-works/pi-ai` shows exactly one copy, coming from `dsh-llm-pi-ai`.
+- **Source**: [rc.2 `dsh-llm-pi-ai` package.json (`^0.82.1`)](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.1-rc.2/packages/llm/llm-pi-ai/package.json) · [alpha.1 `dsh-llm-pi-ai` package.json (`^0.84.2`)](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/packages/llm/llm-pi-ai/package.json)
+- **Field note** (2026-08-28, [dsh-TUI #622](https://github.com/ccch1mneyyy/dsh-TUI/pull/622)): dsh-auth's hard bump to `^0.84.2` plus an override installed two copies on rc.2; after switching to resolving from `dsh-llm-pi-ai`, each cohort has exactly one copy.
+
+---
+
+### DSH-0.1.2-A1-25 · `@deepseek-ai/dsh-client-runtime` package removed, client symbols migrated by domain
+
+- **Type**: breaking
+- **Applies to**: Web Client plugins that import symbols from `@deepseek-ai/dsh-client-runtime` (including the `/client` entry) or declare that package in `dsh.client.inject`
+- **Touchpoints**: #3, #5
+- **Action level**: required-if-hit
+- **Symptoms**: build/typecheck report missing exports or a nonexistent module; at runtime the plugin does not enter the boot graph or its assembly row stays pending forever, often without an explicit error.
+- **Migration recipe**: The package was deleted from `packages/client` in alpha.1, with symbols split out by domain. The verified mapping is as follows (still defer to each package's actual exports at the target tag):
+
+| 0.1.1 (`dsh-client-runtime`/client) | Where it went in 0.1.2 |
 |---|---|
-| `Context`（client ctx，别名 ClientContext） | `import type { Context as ClientContext } from '@deepseek-ai/cordis'` |
+| `Context` (client ctx, alias ClientContext) | `import type { Context as ClientContext } from '@deepseek-ai/cordis'` |
 | `ISessions` / `SessionFace` / `SessionBinding` | `@deepseek-ai/dsh-api-session-controller/client` |
 | `ConversationNode` / `ConversationNodeDefinition` / `IConversation` | `@deepseek-ai/dsh-client-ui-conversation/client` |
-| `createSnapshotStore` / `defineStore` | `@deepseek-ai/dsh-client-store`（签名不变） |
-| 宿主侧裸 `cordis` 导入 | 不变（仅访问 0.1.2 新增 invariant 服务的文件改 `@deepseek-ai/cordis`） |
+| `createSnapshotStore` / `defineStore` | `@deepseek-ai/dsh-client-store` (signatures unchanged) |
+| Bare `cordis` imports on the host side | Unchanged (only files that access the invariant service new in 0.1.2 switch to `@deepseek-ai/cordis`) |
 
-  同步清理 `package.json`：
+  Clean up `package.json` at the same time:
 
-  - `dsh.client.inject` 删除 `@deepseek-ai/dsh-client-runtime`——拆除后它是运行时幻影依赖，保留会让装配行 pending / 不进 boot 图；只保留真正提供服务的包；
-  - 类型依赖在 cohort 未发布期间用 `link:` 指向官方源码 checkout，或按 [R-01](rollup-0.1.2.md) 用 tarball `overrides`。
-- **验证**: typecheck 无 `dsh-client-runtime` 残留导入；`dsh.client.inject` 只声明真实服务包；冷启动后 boot 图含本插件、无 pending 行。
-- **来源**: [alpha.1 release notes](https://github.com/deepseek-ai/deepseek-harness/releases/tag/dsh-v0.1.2-alpha.1) · [alpha.1 的 packages/client（已无 runtime 包）](https://github.com/deepseek-ai/deepseek-harness/tree/dsh-v0.1.2-alpha.1/packages/client) · [dsh-client-store 导出](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/packages/client/store/src/index.ts) · [session-controller client 导出](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/packages/api/session-controller/src/client/index.ts)
-- **实战批注**（2026-08，dsh-input-history 0.1.1 → 0.2.0，Windows + alpha.2 staging 实测）: 上表逐项命中；`inject` 残留 runtime 包时行不进图，删除后恢复。
-
----
-
-### DSH-0.1.2-A1-26 · client-modules 扫描契约：注册 id 必须等于 package.json name
-
-- **类型**: breaking
-- **适用对象**: 有 Web Client 半部的插件（打 client bundle 并经装配行挂载者）
-- **影响触点**: #5
-- **操作级别**: required-if-hit
-- **症状**: 启动断言 `loaded without registering "<id>"`；或更隐蔽地——面板静默消失、boot 图无此插件、日志无该插件相关错误。
-- **迁移配方**: 0.1.2 的 boot manifest 以包名为 entry / module / 插件注册的唯一键（`Entry name == package name`）。三处 id 必须一致，以 package.json `name` 为基准：
-
-  1. client bundle 的注册 id（`__ModuleLoader__.load` 的 id，通常由 tsdown banner `PLUGIN_ID` 注入）== package.json `name`；
-  2. 装配行（插件自带 cordis.patch.yml 或 home patch 的 insert 行）`name` 用裸包名（含 scope，如 `'@dsh-external/dsh-input-history'`）——0.1.1 的 `file:///` 直写路径 + 短名 id 形态在新扫描下 client 半部静默不进图，必须替换；
-  3. `dsh --profile <name> --dump-config` 核对行名与无 pending。
-- **验证**: 首页 HTML 的 `window.__DSH_BOOT__.entries` 出现 `"id":"<包名>"`；combo 路由 `/plugins/??<包名>/client.js&rev=...`（URL 含 `??`，curl 加 `-g`）取回的脚本含 `__ModuleLoader__.load({ id: "<包名>"`；启动日志无 `loaded without registering` / `entries did not activate`。
-- **来源**: [modules/src/client/system.ts 的注册断言](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/packages/client/modules/src/client/system.ts) · [modules/src/client/manifest.ts（Entry name == package name）](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/packages/client/modules/src/client/manifest.ts) · [`__DSH_BOOT__` 全局注入](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/packages/client/modules/src/index.ts)
-- **实战批注**（2026-08，dsh-input-history 实测）: 三处 id 任一不一致即可复现上述两种症状之一；全部对齐裸包名后消失。
+  - Remove `@deepseek-ai/dsh-client-runtime` from `dsh.client.inject` — after the dismantling it is a runtime phantom dependency, and keeping it leaves the assembly row pending / out of the boot graph; keep only packages that actually provide services;
+  - While the cohort is unpublished, point type dependencies at the official source checkout with `link:`, or use tarball `overrides` per [R-01](rollup-0.1.2.md).
+- **Verification**: typecheck shows no leftover `dsh-client-runtime` imports; `dsh.client.inject` declares only real service packages; after a cold boot the boot graph contains this plugin with no pending rows.
+- **Source**: [alpha.1 release notes](https://github.com/deepseek-ai/deepseek-harness/releases/tag/dsh-v0.1.2-alpha.1) · [alpha.1's packages/client (no runtime package)](https://github.com/deepseek-ai/deepseek-harness/tree/dsh-v0.1.2-alpha.1/packages/client) · [dsh-client-store exports](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/packages/client/store/src/index.ts) · [session-controller client exports](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/packages/api/session-controller/src/client/index.ts)
+- **Field note** (2026-08, dsh-input-history 0.1.1 → 0.2.0, Windows + alpha.2 staging test): every row of the table above hit; with the runtime package left in `inject` the row did not enter the graph, and removing it restored it.
 
 ---
 
-### DSH-0.1.2-A1-27 · 会话内容读取改走 SessionBinding durable 事件窗
+### DSH-0.1.2-A1-26 · client-modules scan contract: registration id must equal the package.json name
 
-- **类型**: breaking
-- **适用对象**: 读取会话时间线 / 用户消息内容的 Web Client 插件
-- **影响触点**: #3
-- **操作级别**: required-if-hit
-- **症状**: 插件加载但功能半失效：`session.getSnapshot().nodes` 为 undefined / 空，console 报 factory 错误。
-- **迁移配方**: 0.1.2 不再暴露 per-session 会话节点快照（时间线成为各视图包的内部投影，见 [DSH-0.1.2-A1-03](v0.1.2-alpha.1.md)）。第三方读会话内容的缝隙是 session binding 的 durable 事件窗：
+- **Type**: breaking
+- **Applies to**: Plugins with a Web Client half (those that build a client bundle and mount it through an assembly row)
+- **Touchpoints**: #5
+- **Action level**: required-if-hit
+- **Symptoms**: Startup assertion `loaded without registering "<id>"`; or, more subtly — the panel silently disappears, the boot graph lacks this plugin, and logs show no plugin-related errors.
+- **Migration recipe**: 0.1.2's boot manifest keys entries / modules / plugin registrations by package name (`Entry name == package name`). The three ids must agree, with package.json `name` as the baseline:
+
+  1. The client bundle's registration id (the id of `__ModuleLoader__.load`, usually injected by the tsdown banner `PLUGIN_ID`) == package.json `name`;
+  2. The assembly row's (the insert row in the plugin's own cordis.patch.yml or the home patch) `name` uses the bare package name (with the scope, e.g. `'@dsh-external/dsh-input-history'`) — under the new scan, 0.1.1's `file:///` literal-path plus short-name id form silently keeps the client half out of the graph and must be replaced;
+  3. `dsh --profile <name> --dump-config` to check row names and no pending.
+- **Verification**: The index page's HTML `window.__DSH_BOOT__.entries` contains `"id":"<package name>"`; the script fetched from the combo route `/plugins/??<package name>/client.js&rev=...` (the URL contains `??`; add `-g` for curl) contains `__ModuleLoader__.load({ id: "<package name>"`; the startup log has no `loaded without registering` / `entries did not activate`.
+- **Source**: [modules/src/client/system.ts registration assertion](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/packages/client/modules/src/client/system.ts) · [modules/src/client/manifest.ts (`Entry name == package name`)](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/packages/client/modules/src/client/manifest.ts) · [`__DSH_BOOT__` global injection](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/packages/client/modules/src/index.ts)
+- **Field note** (2026-08, dsh-input-history test): any one of the three ids being inconsistent reproduces one of the two symptoms above; aligning all of them to the bare package name makes them disappear.
+
+---
+
+### DSH-0.1.2-A1-27 · Session content reads now go through the SessionBinding durable event window
+
+- **Type**: breaking
+- **Applies to**: Web Client plugins that read session timelines / user message content
+- **Touchpoints**: #3
+- **Action level**: required-if-hit
+- **Symptoms**: The plugin loads but half its functionality is broken: `session.getSnapshot().nodes` is undefined / empty, and the console reports factory errors.
+- **Migration recipe**: 0.1.2 no longer exposes per-session conversation-node snapshots (the timeline becomes an internal projection of each view package; see [DSH-0.1.2-A1-03](v0.1.2-alpha.1.md)). The gap through which third parties read session content is the session binding's durable event window:
 
   ```ts
   // 旧：sessions.scope(id) → sessionOf(actx) → session.getSnapshot().nodes
@@ -476,73 +467,73 @@ verifiedAt: 2026-08-31
   //          文本在 entry.event.data.content 的 { type: 'text', text } 块里
   ```
 
-  `SessionEventLikeEntry` 与 `SessionBinding` 从 `@deepseek-ai/dsh-api-session-controller/client` 导入；作用域寻址服务照旧经 `binding.ctx.get(...)`；输入机 face（`conversation.input.for(actx)` / `setDraft` / `state.getSnapshot().draft`）签名不变，`actx` 用 `binding.ctx`。
-- **验证**: 真实会话发一条用户消息，插件读到与 UI 一致的文本；空会话 / 未知 id 返回 null 而非抛错。
-- **来源**: [SessionBinding 定义](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/packages/api/session-controller/src/client/sessions/service.ts) · [SessionEventLikeEntry 契约](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/packages/api/session-controller/src/client/contract/events.ts) · [alpha.1 release notes](https://github.com/deepseek-ai/deepseek-harness/releases/tag/dsh-v0.1.2-alpha.1)
-- **实战批注**（2026-08，dsh-input-history 实测，alpha.2 staging）: 事件窗路径稳定召回历史消息，Ctrl+Up 浏览器 e2e 通过。
+  Import `SessionEventLikeEntry` and `SessionBinding` from `@deepseek-ai/dsh-api-session-controller/client`; scoped-addressing services still go through `binding.ctx.get(...)`; the input-machine face (`conversation.input.for(actx)` / `setDraft` / `state.getSnapshot().draft`) keeps its signatures, with `binding.ctx` as `actx`.
+- **Verification**: Send one user message in a real session and the plugin reads text consistent with the UI; empty sessions / unknown ids return null instead of throwing.
+- **Source**: [SessionBinding definition](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/packages/api/session-controller/src/client/sessions/service.ts) · [SessionEventLikeEntry contract](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/packages/api/session-controller/src/client/contract/events.ts) · [alpha.1 release notes](https://github.com/deepseek-ai/deepseek-harness/releases/tag/dsh-v0.1.2-alpha.1)
+- **Field note** (2026-08, dsh-input-history test, alpha.2 staging): the event-window path reliably recalls historical messages, and the Ctrl+Up browser e2e passes.
 
 ---
 
-### DSH-0.1.2-A1-28 · composer 编辑面从 `<textarea>` 变为 contenteditable DIV
+### DSH-0.1.2-A1-28 · composer edit surface changed from `<textarea>` to a contenteditable DIV
 
-- **类型**: breaking
-- **适用对象**: 直接操作 composer DOM 的 Web Client 插件（草稿注入、历史召回、快捷键、选区操作）
-- **影响触点**: #6（DOM）、#5
-- **操作级别**: required-if-hit
-- **症状**: 插件加载但功能半失效：`instanceof HTMLTextAreaElement` 判定失败、`el.value` 为 undefined、`setSelectionRange` 抛错。
-- **迁移配方**: composer 编辑面在 alpha.1 重构为 contenteditable 实现（`ComposerContentEditable`，仍在 `[data-input-scroll]` 容器内）。判定与读写改双轨兼容：
+- **Type**: breaking
+- **Applies to**: Web Client plugins that manipulate the composer DOM directly (draft injection, history recall, shortcuts, selection operations)
+- **Touchpoints**: #6 (DOM), #5
+- **Action level**: required-if-hit
+- **Symptoms**: The plugin loads but half its functionality is broken: `instanceof HTMLTextAreaElement` checks fail, `el.value` is undefined, `setSelectionRange` throws.
+- **Migration recipe**: In alpha.1, the composer edit surface was refactored to a contenteditable implementation (`ComposerContentEditable`, still inside the `[data-input-scroll]` container). Switch detection and read/write to the dual-track compatible form:
 
-  - 判定：`el.isContentEditable` 分支替代 `instanceof HTMLTextAreaElement`；
-  - 读值：`textContent` 替代 `el.value`；
-  - 选区/光标：Range API（`getSelection()`、`Range.collapse()`、`range.insertNode`）替代 `setSelectionRange`；
-  - 其余选择器类漂移（面板 id、slot 名）以官方 `packages/client/ui-*` 源码为准，用浏览器 devtools 核对 0.1.2 页面实际形状，不凭 0.1.1 记忆（同 [DSH-0.1.2-A1-03](v0.1.2-alpha.1.md) 的核对要求）。
-- **验证**: 在 0.1.2 staging 页面真实执行一次草稿写入 + 召回（含光标位置恢复），console 无 DOM 异常；textarea 路径仅在做跨 cohort 共存（[R-02](rollup-0.1.2.md)）时保留。
-- **来源**: [ComposerContentEditable.tsx（alpha.1 新增）](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/packages/client/ui-conversation/src/client/input/editor/ComposerContentEditable.tsx) · [alpha.1 release notes](https://github.com/deepseek-ai/deepseek-harness/releases/tag/dsh-v0.1.2-alpha.1)
-- **实战批注**（2026-08，dsh-input-history 实测）: Ctrl+Up / Ctrl+Down 历史召回按双轨改写后通过浏览器 e2e。
-
----
-
-### DSH-0.1.2-A1-29 · `MarkdownText` labels 改为必填嵌套形状（ui-primitives）
-
-- **类型**: breaking
-- **适用对象**: 渲染 `@deepseek-ai/dsh-client-ui-primitives` 的 `MarkdownText` / fence CodeBlock 的 Web Client 插件
-- **影响触点**: #5
-- **操作级别**: required-if-hit
-- **症状**: labels prop 从扁平可选 `codeLabels`（`{ copyLabel, copiedLabel }`）改为**必填嵌套** `labels: { code: { copyLabel, copiedLabel }, footnotes }`。只传旧 prop 时 fence 渲染抛 `Cannot read properties of undefined (reading 'code')`，markdown/mermaid 预览直接崩溃；完全省略 labels 则回退宿主硬编码中文，locale 跟随失效（该包 cordis-free，文案只能经 props 注入）。**typecheck 对此静默**——devDependencies 未同步升级时旧声明照常编译，只有真实宿主渲染才炸。
-- **迁移配方**: 所有渲染点统一经单一 helper 构造嵌套对象（copy 按钮文案走插件自己的 locale 词典；`footnotes` 是 sr-only 标题，无对应词典键时传空串）。只需支持 alpha cohort 时传单一 `labels`；确要跨 cohort 共存（rollup R-02）再把同一对象同时挂两个 prop 名。注意流式渲染按 labels 对象**引用**缓存——每次 render 新建对象会中途丢弃流式缓存，helper 返回值应按 locale 修订保持引用稳定。
-- **验证**: 真实宿主渲染含 fenced code block 的 markdown；切换 locale 后 copy 按钮文案跟随；console 无报错；流式消息不整段重渲。
-- **来源**: [alpha.1 MarkdownText.tsx（labels 必填）](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/packages/client/ui-primitives/src/markdown/MarkdownText.tsx) · [alpha.1 render.tsx（MarkdownLabels 形状）](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/packages/client/ui-primitives/src/markdown/render.tsx)
-- **实战批注**（2026-08-30，dsh-better-sidebar，macOS，真机 0.1.2-alpha.1/alpha.2）: 该崩溃由挂载冒烟在真实 alpha.1 宿主上捕获（devDeps 钉在 0.1.1-rc.1，typecheck 全绿）；修复为四个渲染点统一走 `markdownTextProps()` helper，v0.18.0-alpha.0 起收敛为仅嵌套单形状并移除 cast。见 [PR #472](https://github.com/omdsh-dev/DSH-better-sidebar/pull/472)。
+  - Detection: branch on `el.isContentEditable` instead of `instanceof HTMLTextAreaElement`;
+  - Reading values: `textContent` instead of `el.value`;
+  - Selection/caret: the Range API (`getSelection()`, `Range.collapse()`, `range.insertNode`) instead of `setSelectionRange`;
+  - Other selector-class drift (panel ids, slot names): the official `packages/client/ui-*` source is authoritative; verify the actual 0.1.2 page shape with browser devtools, not from 0.1.1 memory (same verification requirement as [DSH-0.1.2-A1-03](v0.1.2-alpha.1.md)).
+- **Verification**: On a 0.1.2 staging page, really perform one draft write + recall (including caret-position restore) with no DOM errors in the console; keep the textarea path only for cross-cohort coexistence ([R-02](rollup-0.1.2.md)).
+- **Source**: [ComposerContentEditable.tsx (new in alpha.1)](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/packages/client/ui-conversation/src/client/input/editor/ComposerContentEditable.tsx) · [alpha.1 release notes](https://github.com/deepseek-ai/deepseek-harness/releases/tag/dsh-v0.1.2-alpha.1)
+- **Field note** (2026-08, dsh-input-history test): after rewriting Ctrl+Up / Ctrl+Down history recall in dual-track form, the browser e2e passes.
 
 ---
 
-### DSH-0.1.2-A1-30 · 客户端 `ctx.connection.api` face 整体移除，历史/转录读取改道
+### DSH-0.1.2-A1-29 · `MarkdownText` labels changed to a required nested shape (ui-primitives)
 
-- **类型**: breaking
-- **适用对象**: 消费 `ctx.connection.api.*`（如 `sessions.history`、`agentPresets`）的 Web Client 插件
-- **影响触点**: #3
-- **操作级别**: required-if-hit
-- **症状**: alpha.1 移除了 `ctx.connection` 上的旧 apiProxy 镜像 face，客户端调用抛错。**若调用点把错误 catch 静默吞掉，UI 呈现「永远空白」而非报错**——只断言不崩溃的冒烟抓不到。继任 Remote（`session/page` / `session/follow`）对 `origin:'subagent'` 会话强制 subagent 地址：普通 `{ kind: 'session' }` 请求被 `session/agent-busy` 拒；分页 `throughSeq` 不得超当前游标，纯 page 翻页拿不到尾页。
-- **迁移配方**: 先按会话 origin 分流。普通会话的历史读取迁 `session/page|follow`。subagent-origin 会话（side chat、委派线程）的转录读取**没有可用的宿主 RPC**——改由插件自有 host 路由供给：live 线程读 `agent.session.events`（AgentRegistry `create/get`），冷线程读 `sessionPersistence.inspect`，服务端做种子切割（如 `session/end-seed` 边界）+ `afterSeq` 增量，客户端经插件公开路由 fetch。客户端不再消费后，同步从 `inject` 清单与类型镜像中删除 `connection`，不留死 face。
-- **验证**: live 与冷（宿主重启后）两条路径的转录一致；`afterSeq` 增量不复活种子；`session/list` 能看到 subagent 子会话；故意断路由时 UI 显示错误态而非空白。
-- **来源**: [alpha.1 connection/client/api.ts（旧 face 只剩协议类型再导出）](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/packages/client/connection/src/client/api.ts) · [alpha.1 APIProxy→Remote 架构笔记](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/.agents/notes/implemented/architecture/2026-08-10-unary-apiproxy-remote-migration.md)
-- **实战批注**（2026-08-30，dsh-better-sidebar，macOS，npm 0.1.2-alpha.2 真机）: side chat 转录轮询漏改且错误被 catch 吞掉，alpha.1+ 宿主上 tab 永远渲染空转录而冒烟全绿；v0.18.0-alpha.0 以自有 `sidechat.events` 路由修复。设计见 [sidechat-tab-design §10](https://github.com/omdsh-dev/DSH-better-sidebar/blob/main/docs/plans/2026-08-20-sidechat-tab-design.md)。
-
----
-
-### DSH-0.1.2-A1-31 · `dsh-subagent` 描述符格式版本 2 → 3（宿主包常量盖章）
-
-- **类型**: behavior
-- **适用对象**: 构造 subagent 种子/持久描述符，或断言 `subagent/descriptor` 事件形状的插件（`snapshotSubagentDescriptor` 消费方）
-- **影响触点**: #3
-- **操作级别**: conditional
-- **症状**: `SUBAGENT_DESCRIPTOR_VERSION` 由 2 升到 3；描述符的 `version` 字段由宿主包的快照函数盖章，插件侧钉 `version: 2` 字面量的测试断言失败（插件运行时本身不受影响——它不写 version）。
-- **迁移配方**: 断言跟随包导出常量 `import { SUBAGENT_DESCRIPTOR_VERSION } from '@deepseek-ai/dsh-subagent'`，不硬编码字面量；种子构造统一经 `snapshotSubagentDescriptor`，插件不自行拼 version。
-- **验证**: 升级 devDependencies 后相关单测通过；种子事件 `subagent/descriptor` 的 `version === SUBAGENT_DESCRIPTOR_VERSION`。
-- **来源**: [alpha.1 descriptor.ts（= 3）](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/packages/subagent/subagent/src/descriptor.ts) · [rc.2 descriptor.ts（= 2）](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.1-rc.2/packages/subagent/subagent/src/descriptor.ts)
-- **实战批注**（2026-08-30，dsh-better-sidebar）: devDeps 0.1.1-rc.1 → 0.1.2-alpha.2 后唯一失败的种子断言即此；改为跟随常量后全绿。
+- **Type**: breaking
+- **Applies to**: Web Client plugins that render `MarkdownText` / fenced CodeBlocks from `@deepseek-ai/dsh-client-ui-primitives`
+- **Touchpoints**: #5
+- **Action level**: required-if-hit
+- **Symptoms**: The labels prop changed from the flat optional `codeLabels` (`{ copyLabel, copiedLabel }`) to the **required nested** `labels: { code: { copyLabel, copiedLabel }, footnotes }`. Passing only the old prop makes fenced rendering throw `Cannot read properties of undefined (reading 'code')` and markdown/mermaid previews crash outright; omitting labels entirely falls back to the host's hardcoded Chinese and locale following breaks (this package is cordis-free, so copy can only be injected via props). **typecheck is silent about this** — without upgrading devDependencies in sync, the old declarations still compile and only real host rendering blows up.
+- **Migration recipe**: Build the nested object through a single shared helper at every render point (copy-button copy comes from the plugin's own locale dictionary; `footnotes` is an sr-only heading — pass an empty string when there is no dictionary key). When only the alpha cohort needs support, pass a single `labels`; if cross-cohort coexistence is really needed (rollup R-02), attach the same object to both prop names. Note that streaming rendering caches by the labels object's **reference** — creating a new object per render drops the streaming cache midway, so the helper's return value must keep a stable reference per locale revision.
+- **Verification**: Render markdown containing a fenced code block on a real host; after switching locale the copy-button copy follows; no console errors; streaming messages are not re-rendered wholesale.
+- **Source**: [alpha.1 MarkdownText.tsx (labels required)](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/packages/client/ui-primitives/src/markdown/MarkdownText.tsx) · [alpha.1 render.tsx (MarkdownLabels shape)](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/packages/client/ui-primitives/src/markdown/render.tsx)
+- **Field note** (2026-08-30, dsh-better-sidebar, macOS, real machine 0.1.2-alpha.1/alpha.2): The crash was caught by a mount smoke on a real alpha.1 host (devDeps pinned to 0.1.1-rc.1, typecheck all green); the fix routes all four render points through the `markdownTextProps()` helper, and starting with v0.18.0-alpha.0 it converged to only the single nested shape with the cast removed. See [PR #472](https://github.com/omdsh-dev/DSH-better-sidebar/pull/472).
 
 ---
 
-*未建卡的宿主 UI/性能变化不代表“确定无 API 影响”；这里只表示官方材料未声明
-插件迁移动作。发现真实插件受影响时，应补带一手证据的卡片。*
+### DSH-0.1.2-A1-30 · Client `ctx.connection.api` face removed entirely; history/transcript reads rerouted
+
+- **Type**: breaking
+- **Applies to**: Web Client plugins consuming `ctx.connection.api.*` (e.g. `sessions.history`, `agentPresets`)
+- **Touchpoints**: #3
+- **Action level**: required-if-hit
+- **Symptoms**: alpha.1 removed the old apiProxy mirror face on `ctx.connection`; client calls throw. **If the call site silently swallows the error in a catch, the UI renders "forever blank" instead of an error** — a smoke that only asserts no-crash cannot catch it. The successor Remotes (`session/page` / `session/follow`) enforce the subagent address for `origin:'subagent'` sessions: ordinary `{ kind: 'session' }` requests are rejected with `session/agent-busy`; the paging `throughSeq` must not exceed the current cursor, and plain `page` paging cannot reach the last page.
+- **Migration recipe**: Branch by session origin first. For ordinary sessions, move history reads to `session/page|follow`. For subagent-origin sessions (side chat, delegated threads), transcript reads have **no usable host RPC** — supply them through the plugin's own host routes instead: live threads read `agent.session.events` (AgentRegistry `create/get`), cold threads read `sessionPersistence.inspect`, with server-side seed cutting (e.g. at the `session/end-seed` boundary) plus `afterSeq` deltas, and the client fetches through the plugin's public routes. Once the client no longer consumes it, also remove `connection` from the `inject` list and the type mirror — leave no dead face.
+- **Verification**: The live and cold (after host restart) paths return consistent transcripts; `afterSeq` deltas do not resurrect the seed; `session/list` shows subagent child sessions; with the route deliberately broken, the UI shows an error state rather than blank.
+- **Source**: [alpha.1 connection/client/api.ts (old face now only re-exports protocol types)](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/packages/client/connection/src/client/api.ts) · [alpha.1 APIProxy→Remote architecture note](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/.agents/notes/implemented/architecture/2026-08-10-unary-apiproxy-remote-migration.md)
+- **Field note** (2026-08-30, dsh-better-sidebar, macOS, npm 0.1.2-alpha.2 real machine): the side-chat transcript polling was missed in the migration and the errors were swallowed by catch, so on alpha.1+ hosts the tab rendered an empty transcript forever while smokes stayed all green; v0.18.0-alpha.0 fixed it with its own `sidechat.events` route. Design: see [sidechat-tab-design §10](https://github.com/omdsh-dev/DSH-better-sidebar/blob/main/docs/plans/2026-08-20-sidechat-tab-design.md).
+
+---
+
+### DSH-0.1.2-A1-31 · `dsh-subagent` descriptor format version 2 → 3 (stamped by the host package constant)
+
+- **Type**: behavior
+- **Applies to**: Plugins that construct subagent seed/persisted descriptors or assert the shape of the `subagent/descriptor` event (`snapshotSubagentDescriptor` consumers)
+- **Touchpoints**: #3
+- **Action level**: conditional
+- **Symptoms**: `SUBAGENT_DESCRIPTOR_VERSION` goes from 2 to 3; the descriptor's `version` field is stamped by the host package's snapshot function, so test assertions on the plugin side that hardcode the literal `version: 2` fail (the plugin runtime itself is unaffected — it does not write version).
+- **Migration recipe**: Follow the package-exported constant in assertions — `import { SUBAGENT_DESCRIPTOR_VERSION } from '@deepseek-ai/dsh-subagent'` — instead of hardcoding a literal; build seeds uniformly through `snapshotSubagentDescriptor`, and plugins do not assemble version themselves.
+- **Verification**: After upgrading devDependencies, the relevant unit tests pass; the seed event `subagent/descriptor` has `version === SUBAGENT_DESCRIPTOR_VERSION`.
+- **Source**: [alpha.1 descriptor.ts (= 3)](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/packages/subagent/subagent/src/descriptor.ts) · [rc.2 descriptor.ts (= 2)](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.1-rc.2/packages/subagent/subagent/src/descriptor.ts)
+- **Field note** (2026-08-30, dsh-better-sidebar): after devDeps 0.1.1-rc.1 → 0.1.2-alpha.2, the only failing seed assertion was this one; switching to follow the constant made everything green.
+
+---
+
+*Host UI/performance changes without cards do not mean "definitely no API impact"; they only mean the official material declares no
+plugin migration action. When a real plugin is found to be affected, add a card backed by primary-source evidence.*

--- a/skills/plugin-upgrade/references/v0.1.2-alpha.2.md
+++ b/skills/plugin-upgrade/references/v0.1.2-alpha.2.md
@@ -10,53 +10,53 @@ idPrefix: DSH-0.1.2-A2
 verifiedAt: 2026-08-31
 ---
 
-# 变更卡片 · 0.1.2-alpha.2
+# Change cards · 0.1.2-alpha.2
 
-> 本文件是插件相关变更的精选清单，不是完整 API diff。
+> This file is a curated list of plugin-relevant changes, not a complete API diff.
 >
-> 上游比较: [dsh-v0.1.2-alpha.1...dsh-v0.1.2-alpha.2](https://github.com/deepseek-ai/deepseek-harness/compare/dsh-v0.1.2-alpha.1...dsh-v0.1.2-alpha.2)
+> Upstream comparison: [dsh-v0.1.2-alpha.1...dsh-v0.1.2-alpha.2](https://github.com/deepseek-ai/deepseek-harness/compare/dsh-v0.1.2-alpha.1...dsh-v0.1.2-alpha.2)
 > · Release Notes: [dsh-v0.1.2-alpha.2](https://github.com/deepseek-ai/deepseek-harness/releases/tag/dsh-v0.1.2-alpha.2)
-> · 卡片格式见 [references/README.md](README.md)
-> · 触点编号见 [pre-flight.md](pre-flight.md)
+> · Card format: see [references/README.md](README.md)
+> · Touchpoint numbering: see [pre-flight.md](pre-flight.md)
 
-## 目录
+## Contents
 
-- DSH-0.1.2-A2-01 · 恢复第三方持久事件的 `SessionEvent.ignorable`
-- DSH-0.1.2-A2-02 · Remote failure 改为 `RemoteError` 实例，错误码加命名空间
-- DSH-0.1.2-A2-03 · NPM 包裁剪不必要的 peer dependency
-- DSH-0.1.2-A2-04 · Node.js 24.0–24.11.1 下 `dsh web` 空 client graph 修复
-- DSH-0.1.2-A2-05 · Plugin inventory 返回可选的 Agent Preset 分组
-- DSH-0.1.2-A2-06 · Client Remote 增加固定 Host facts `$host.home/isLoopback`
-- DSH-0.1.2-A2-08 · `sessionProjections` 成为多个工具包的必需 inject 与 peer
-
----
-
-### DSH-0.1.2-A2-01 · 恢复第三方持久事件的 `SessionEvent.ignorable`
-
-- **类型**: fix
-- **适用对象**: 生产第三方持久 SessionEvent 的插件，以及 persistence/reload/transport 集成
-- **影响触点**: #2
-- **操作级别**: required-if-hit
-- **症状**: alpha.1 无法保留外部 informational event 的 marker；alpha.2 恢复后，旧适配若继续删除 marker，会让第一方 reader 拒绝包含未知事件的 Session。
-- **迁移配方**: producer 只对“旧 reader 即使省略其语义也不影响重建”的 informational event 写 `ignorable: true`；该 marker 不是消费端过滤指令，reload 后事件仍保留在 loaded events。alpha.2 恢复的是 envelope/persistence/reload/transport 的保留语义，公开 live `Session.append(...)` 仍没有 `ignorable` 参数；普通插件若只有该 API，应把 producer seam 标为能力缺口，不能靠 cast 假装已有公开入口。JSONL、SQLite、API transport 和 generated catalog 必须原样保留字段；未知事件没有 marker 时仍是 required-on-read。SQLite provider 只接受 schema 20，不自动迁移 schema 19，并拒绝其他 schema；升级前先备份/导出或按 provider 文档重建。
-- **验证**: 手工 envelope/seed 或拥有 persistence seam 的测试中，未知且 `ignorable: true` 的事件 reload 后仍存在于 loaded events，旧 reader 可省略其语义；未知 required 事件被拒；常规 `Session.append` 不应被文档成支持该字段；schema 19 被拒绝，重建后的 schema 20 可启动。
-- **来源**: [alpha.2 release notes](https://github.com/deepseek-ai/deepseek-harness/releases/tag/dsh-v0.1.2-alpha.2) · [retain ignorable external session events 决策](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/.agents/notes/implemented/architecture/2026-08-30-retain-ignorable-external-session-events.md) · 回滚 [DSH-0.1.2-A1-02](v0.1.2-alpha.1.md)
+- DSH-0.1.2-A2-01 · Restore `SessionEvent.ignorable` for third-party persisted events
+- DSH-0.1.2-A2-02 · Remote failures become `RemoteError` instances; error codes gain namespaces
+- DSH-0.1.2-A2-03 · NPM packages trim unneeded peer dependencies
+- DSH-0.1.2-A2-04 · Fix empty client graph for `dsh web` on Node.js 24.0–24.11.1
+- DSH-0.1.2-A2-05 · Plugin inventory returns optional Agent Preset grouping
+- DSH-0.1.2-A2-06 · Client Remote adds fixed Host facts `$host.home/isLoopback`
+- DSH-0.1.2-A2-08 · `sessionProjections` becomes a required inject and peer for multiple tool packages
 
 ---
 
-### DSH-0.1.2-A2-02 · Remote failure 改为 `RemoteError` 实例，错误码加命名空间
+### DSH-0.1.2-A2-01 · Restore `SessionEvent.ignorable` for third-party persisted events
 
-- **类型**: breaking
-- **适用对象**: 使用 `ctx.remote` 或承接 Remote failure 的 Host/Web Client 集成
-- **影响触点**: #3
-- **操作级别**: required-if-hit
-- **症状**: `RemoteResult<T>` 的 `{ ok, value } | { ok: false, error }` 形状 rc.2 和 alpha.1 就是这样（gateway `src/client/index.ts` rc.2:334、alpha.1:404），alpha.2 没改调用形状。变的是：
-  - `error` 从普通对象 `{ code, message, details }` 变成 `RemoteError` 实例（`packages/typert/protocol/src/remote-error.ts:12`），`throw result.error` 保留 throw 语义；
-  - 错误码加命名空间：`session-not-found` → `session/not-found`、`agent-busy` → `session/agent-busy`、`internal` → `gateway/internal`、`cancelled` → `gateway/cancelled`、`bad-request` → `gateway/bad-request`、`agent-preset-not-found` → `agent-preset/not-found`、`agent-preset-locked` → `agent-preset/locked`；
-  - 新增 `isRemoteFailure`；删除 `RemoteStreamError`（gateway client）、`TypertRemoteFailure`、`TypertLookupFailure`（typert-protocol），stream 终止失败改抛 `RemoteError`；`dsh-client-connection` 的 `RpcErrorDetailsMap`/`RpcErrorCode`/`RpcError` 删除。
+- **Type**: fix
+- **Applies to**: Plugins that produce third-party persisted SessionEvents, and persistence/reload/transport integrations
+- **Touchpoints**: #2
+- **Action level**: required-if-hit
+- **Symptoms**: alpha.1 could not retain the marker on external informational events; now that alpha.2 restores it, old adapters that keep dropping the marker will make first-party readers reject Sessions containing unknown events.
+- **Migration recipe**: Producers should write `ignorable: true` only for informational events whose semantics an old reader can omit without affecting reconstruction; the marker is not a consumer-side filtering directive, and events remain in loaded events after reload. What alpha.2 restores is the retention semantics of envelope/persistence/reload/transport; the public live `Session.append(...)` still has no `ignorable` parameter, so ordinary plugins with only this API should mark the producer seam as a capability gap rather than faking a public entry via cast. JSONL, SQLite, API transports, and the generated catalog must preserve the field as-is; unknown events without the marker remain required-on-read. The SQLite provider accepts only schema 20, does not auto-migrate schema 19, and rejects other schemas; back up/export, or rebuild per the provider documentation, before upgrading.
+- **Verification**: In manual envelope/seed setups, or in tests that own a persistence seam, unknown events with `ignorable: true` still exist in loaded events after reload and old readers can omit their semantics; unknown required events are rejected; a plain `Session.append` should not be documented as supporting the field; schema 19 is rejected, and a rebuilt schema 20 boots.
+- **Source**: [alpha.2 release notes](https://github.com/deepseek-ai/deepseek-harness/releases/tag/dsh-v0.1.2-alpha.2) · [retain ignorable external session events decision](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/.agents/notes/implemented/architecture/2026-08-30-retain-ignorable-external-session-events.md) · revert of [DSH-0.1.2-A1-02](v0.1.2-alpha.1.md)
 
-  按旧码字符串分支、解析 `Error.message`、给每次调用套防御性 catch、或跨 realm 用 `instanceof RemoteError`，都会误分业务失败与本地装配缺陷。
-- **迁移配方**: Unary Remote 调用解析为 `RemoteResult<T>`，业务/载体失败在结果分支中处理：
+---
+
+### DSH-0.1.2-A2-02 · Remote failures become `RemoteError` instances; error codes gain namespaces
+
+- **Type**: breaking
+- **Applies to**: Host/Web Client integrations that use `ctx.remote` or handle Remote failures
+- **Touchpoints**: #3
+- **Action level**: required-if-hit
+- **Symptoms**: The `{ ok, value } | { ok: false, error }` shape of `RemoteResult<T>` was already like this in rc.2 and alpha.1 (gateway `src/client/index.ts` rc.2:334, alpha.1:404); alpha.2 does not change the call shape. What changed:
+  - `error` changes from a plain object `{ code, message, details }` to a `RemoteError` instance (`packages/typert/protocol/src/remote-error.ts:12`); `throw result.error` keeps its throw semantics;
+  - error codes gain namespaces: `session-not-found` → `session/not-found`, `agent-busy` → `session/agent-busy`, `internal` → `gateway/internal`, `cancelled` → `gateway/cancelled`, `bad-request` → `gateway/bad-request`, `agent-preset-not-found` → `agent-preset/not-found`, `agent-preset-locked` → `agent-preset/locked`;
+  - `isRemoteFailure` is added; `RemoteStreamError` (gateway client), `TypertRemoteFailure`, and `TypertLookupFailure` (typert-protocol) are removed, and stream termination failures now throw `RemoteError`; `RpcErrorDetailsMap`/`RpcErrorCode`/`RpcError` are removed from `dsh-client-connection`.
+
+  Branching on old code strings, parsing `Error.message`, wrapping every call in a defensive catch, or using `instanceof RemoteError` across realms all misclassify business failures and local assembly defects.
+- **Migration recipe**: Resolve unary Remote calls to `RemoteResult<T>` and handle business/carrier failures in the result branch:
 
   ```ts
   const result = await ctx.remote.session.rename(args)
@@ -76,97 +76,90 @@ verifiedAt: 2026-08-31
   }
   ```
 
-  Remote 调用不会因普通业务/载体失败 reject；装配故障应暴露而不是被防御性 catch 吞掉。只有上层接住主动 `throw result.error` 的值时，才用
-  `isRemoteFailure`（`@deepseek-ai/dsh-api-gateway/client`）做结构判别；永远不要用
-  `instanceof`。导入位置：`RemoteError`、`RemoteResult`、`RemoteErrorCode`、`RemoteErrorDetailsMap` 来自 `@deepseek-ai/dsh-typert-protocol`；gateway client 只导出 `isRemoteFailure` 和 `TypertGatewayFaultDetails`。`gateway/cancelled` 应终止/静默取消或沿调用链传播；`gateway/internal` 与未知码默认保留原始 `code/details` 并上报，不重试。只有明确瞬态码、幂等操作且用户策略允许时才重试。
-- **验证**: 覆盖成功、`gateway/cancelled`、`session/not-found`、`session/agent-busy`、`gateway/internal`、未知业务码和本地装配缺陷；取消不得变成通用错误，internal/未知不得自动重试。
-- **来源**: [RemoteError failure vocabulary](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/.agents/notes/implemented/architecture/2026-08-28-ctx-remote-failure-vocabulary.md) · [adding a Remote API](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/docs/cookbook/adding-a-remote-api.md) · [alpha.2 `RemoteError` 类](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/typert/protocol/src/remote-error.ts) · [alpha.2 gateway client（`isRemoteFailure`）](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/api/gateway/src/client/index.ts) · [alpha.1 gateway client（同样返回 `RemoteResult`）](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/packages/api/gateway/src/client/index.ts)
+  Remote calls do not reject on ordinary business/carrier failures; assembly faults should surface rather than be swallowed by a defensive catch. Use `isRemoteFailure` (from `@deepseek-ai/dsh-api-gateway/client`) for structural discrimination only when an upper layer catches a value that explicitly `throw result.error`; never use `instanceof`. Import locations: `RemoteError`, `RemoteResult`, `RemoteErrorCode`, and `RemoteErrorDetailsMap` come from `@deepseek-ai/dsh-typert-protocol`; the gateway client exports only `isRemoteFailure` and `TypertGatewayFaultDetails`. `gateway/cancelled` should terminate/silently cancel or propagate along the call chain; `gateway/internal` and unknown codes should by default preserve the original `code/details` and report them without retrying. Retry only when the code is explicitly transient, the operation is idempotent, and user policy allows.
+- **Verification**: Cover success, `gateway/cancelled`, `session/not-found`, `session/agent-busy`, `gateway/internal`, unknown business codes, and local assembly defects; cancellation must not become a generic error, and internal/unknown must not auto-retry.
+- **Source**: [RemoteError failure vocabulary](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/.agents/notes/implemented/architecture/2026-08-28-ctx-remote-failure-vocabulary.md) · [adding a Remote API](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/docs/cookbook/adding-a-remote-api.md) · [alpha.2 `RemoteError` class](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/typert/protocol/src/remote-error.ts) · [alpha.2 gateway client (`isRemoteFailure`)](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/api/gateway/src/client/index.ts) · [alpha.1 gateway client (also returns `RemoteResult`)](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/packages/api/gateway/src/client/index.ts)
 
 ---
 
-### DSH-0.1.2-A2-03 · NPM 包裁剪不必要的 peer dependency
+### DSH-0.1.2-A2-03 · NPM packages trim unneeded peer dependencies
 
-- **类型**: behavior
-- **适用对象**: 插件打包、安装与依赖图维护
-- **影响触点**: 无（打包/分发面）
-- **操作级别**: conditional
-- **症状**: 上游按 runtime ownership 将部分内部边移到 dependencies/devDependencies，只为 Cordis 或身份敏感导出保留 peer；独立 TypeScript consumer 若直接引用被移出的类型包，可能需要显式声明依赖。
-- **迁移配方**: 同时看反方向：alpha.2 也新增了 peer（`dsh-session-projection` 等），见 [DSH-0.1.2-A2-08](v0.1.2-alpha.2.md)。先按 lockfile 选择仓库现用的唯一包管理器；在隔离目录用 frozen lockfile/等价模式验证。检查插件实际 import 的类型/运行时包，补直接依赖；逐条证明 override 只为已裁剪 peer 服务后再删除，不切换包管理器、不重写另一套 lockfile。
-- **验证**: 安装与 typecheck 成功；没有新增与目标升级相关的 peer/缺包错误；依赖图和打包产物只出现预期变化。
-- **来源**: [alpha.2 release notes「问题修复」](https://github.com/deepseek-ai/deepseek-harness/releases/tag/dsh-v0.1.2-alpha.2)
-- **实战批注**（2026-08-30，dsh-tui 依赖树实测）: 两个会绕过常规「补直接依赖」检查的坑：① `legacy-peer-deps=true` 会让 npm 跳过 alpha.2 官方 CLI 的 peer `@deepseek-ai/cordis-plugin-group`（`dsh-app-boot` 顶层 import），npx 缓存树残缺、CLI 启动即 `ERR_MODULE_NOT_FOUND`——安装/重建 CLI 树必须用干净 npmrc；② `dsh-subagent` 把 `@deepseek-ai/dsh-util-time` 声明在 `optionalDependencies`，但 `lib/index.js` 顶层无条件 import——npm 跳过 optional 后运行时才崩，静态安装与 typecheck 均不报错。验证清单应加「依赖树冷启动」而不只是安装成功。
-- **实战批注**（2026-08-31，Web Client 插件源码迁移）: packed package 的
-  `devDependencies` 不会传递给 consumer；ui-chat 的 `.d.ts` 会引用 `dsh-client-store`、UI
-  primitives、session/commands/conversation 等声明。consumer 开着 `skipLibCheck: true` 时，
-  缺包可能不报在依赖声明处，而是让 `ctx.useChat` selector/callback 变成 implicit `any`。
-  迁移时临时用 `skipLibCheck: false` 找全声明所有者，再将实际消费的包补成 direct dev/peer
-  dependency；详见 [API-10](api-migration-0.1.2-alpha.2.md#api-10--web-client-runtime-拆包keyed-chat-snapshot-与命令附件参数)。
+- **Type**: behavior
+- **Applies to**: Plugin packaging, installation, and dependency graph maintenance
+- **Touchpoints**: None (packaging/distribution surface)
+- **Action level**: conditional
+- **Symptoms**: Upstream moved some internal edges to dependencies/devDependencies based on runtime ownership, keeping peers only for Cordis or identity-sensitive exports; standalone TypeScript consumers that directly reference the moved-out type packages may need to declare those dependencies explicitly.
+- **Migration recipe**: Also look at the opposite direction: alpha.2 adds peers as well (`dsh-session-projection` and others), see [DSH-0.1.2-A2-08](v0.1.2-alpha.2.md). First choose the single package manager the repository currently uses, per its lockfile; verify in an isolated directory with a frozen lockfile or equivalent mode. Check which type/runtime packages the plugin actually imports and add direct dependencies; delete an override only after proving item by item that it exists solely for a pruned peer. Do not switch package managers or rewrite a second lockfile.
+- **Verification**: Installation and typecheck succeed; no new peer/missing-package errors related to the target upgrade; the dependency graph and packed artifacts change only as expected.
+- **Source**: [alpha.2 release notes, "Bug fixes"](https://github.com/deepseek-ai/deepseek-harness/releases/tag/dsh-v0.1.2-alpha.2)
+- **Field note** (2026-08-30, dsh-tui dependency tree measurements): Two pitfalls bypass the normal "add a direct dependency" check: ① `legacy-peer-deps=true` makes npm skip the alpha.2 official CLI's peer `@deepseek-ai/cordis-plugin-group` (top-level import of `dsh-app-boot`), leaving the npx cache tree incomplete and the CLI failing at startup with `ERR_MODULE_NOT_FOUND` — installing/rebuilding the CLI tree requires a clean npmrc; ② `dsh-subagent` declares `@deepseek-ai/dsh-util-time` in `optionalDependencies`, but `lib/index.js` imports it unconditionally at the top level — npm skips the optional, and it only crashes at runtime, while static install and typecheck both pass. The verification checklist should include a dependency-tree cold boot, not just successful installation.
+- **Field note** (2026-08-31, Web Client plugin source migration): A packed package's `devDependencies` are not passed to consumers; ui-chat's `.d.ts` references declarations such as `dsh-client-store`, UI primitives, and session/commands/conversation. With `skipLibCheck: true` enabled, a missing package may not be reported at the dependency declaration but instead turns `ctx.useChat` selectors/callbacks into implicit `any`. During migration, temporarily enable `skipLibCheck: false` to find all declaration owners, then add the packages actually consumed as direct dev/peer dependencies; see [API-10](api-migration-0.1.2-alpha.2.md#api-10--web-client-runtime-unbundling-keyed-chat-snapshots-and-command-attachment-parameters).
 
 ---
 
-### DSH-0.1.2-A2-04 · Node.js 24.0–24.11.1 下 `dsh web` 空 client graph 修复
+### DSH-0.1.2-A2-04 · Fix empty client graph for `dsh web` on Node.js 24.0–24.11.1
 
-- **类型**: fix
-- **适用对象**: 为这段 Node 版本加过强制 Node 22 / 跳过 web 等绕行逻辑的启动包装器与 CI 矩阵
-- **影响触点**: #7
-- **操作级别**: conditional
-- **症状**: Node 24.0–24.11.1 报 major 24 但仍带 v1 内部 loader；alpha.1 的 `vendor/loader` 按 major 判 v2，`resolveSync` 参数反了，`dsh web` 进程能起来但 `__DSH_BOOT__.entries` 为空、HMR 找不到入口。alpha.2 改为按 `getOrCreateModuleJob` / `getModuleJobForImport` 探测 loader 形状。`engines.node` 两个 tag 都是 `^22.19.0 || >=24.0.0`，没有变化，不要在 engines 上找差异。
-- **迁移配方**: 只删除有证据专门绕过该缺陷的分支（强制 Node 22、跳过 `dsh web`、按 major 探测 loader）；保留其他 Node 兼容约束。验证矩阵必须包含故障窗口内版本，不能只测 latest/LTS。
-- **验证**: 至少在官方 CI 使用的 Node 24.9（故障窗口 24.0–24.11.1）、修复后的 Node 24.12 或当前 24.x、以及受支持的 Node 22 LTS 上冷启动；插件涉及 HMR 时三档都验证 HMR。
-- **来源**: [alpha.2 release notes「问题修复」](https://github.com/deepseek-ai/deepseek-harness/releases/tag/dsh-v0.1.2-alpha.2) · [alpha.2 vendor/README 第 19 条](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/vendor/README.md) · [alpha.2 loader 形状探测](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/vendor/loader/src/internal.ts) · [alpha.2 CI 钉 Node 24.9](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/.github/workflows/ci.yml)
-
----
-
-### DSH-0.1.2-A2-05 · Plugin inventory 返回可选的 Agent Preset 分组
-
-- **类型**: behavior
-- **适用对象**: 消费 `pluginInventory/list` 或精确校验 `PluginInventorySnapshot` 的 Host/Web Client 插件
-- **影响触点**: #3、#5
-- **操作级别**: conditional
-- **症状**: `PluginInventorySnapshot` 新增可选 `agentPresets`；并公开 `AgentPresetPluginGroup`、`AgentPresetPluginRow` 与 `PresetPluginEnablement`。封闭 schema 或拒绝未知字段的 consumer 可能失败。
-- **迁移配方**: 将 `agentPresets` 按 optional 字段解析，缺失时维持旧 entries 视图；不要用整对象重建丢弃未来字段。需要展示 preset 时，再按 trust、rows 与 `boolean | 'conditional'` enablement 渲染。
-- **验证**: 无 preset roster 时字段可缺失；存在 roster 时多 preset/conditional row 能解析；旧 entries 行为不变。
-- **来源**: [alpha.2 PluginInventorySnapshot types](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/host/plugin-inventory/src/types.ts) · [alpha.2 release notes](https://github.com/deepseek-ai/deepseek-harness/releases/tag/dsh-v0.1.2-alpha.2)
+- **Type**: fix
+- **Applies to**: Startup wrappers and CI matrices that added workarounds for this Node range, such as forcing Node 22 or skipping `dsh web`
+- **Touchpoints**: #7
+- **Action level**: conditional
+- **Symptoms**: Node 24.0–24.11.1 reports major 24 but still carries the v1 internal loader; alpha.1's `vendor/loader` judged v2 by major version, with the `resolveSync` arguments reversed, so the `dsh web` process starts but `__DSH_BOOT__.entries` is empty and HMR cannot find the entry. alpha.2 instead probes the loader shape via `getOrCreateModuleJob` / `getModuleJobForImport`. `engines.node` is `^22.19.0 || >=24.0.0` on both tags — unchanged, so do not look for differences in engines.
+- **Migration recipe**: Remove only branches with evidence of specifically bypassing this defect (forcing Node 22, skipping `dsh web`, probing the loader by major version); keep other Node compatibility constraints. The verification matrix must include versions inside the failure window, not just latest/LTS.
+- **Verification**: Cold boot at least on Node 24.9, which official CI uses (failure window 24.0–24.11.1), on the fixed Node 24.12 or current 24.x, and on a supported Node 22 LTS; when the plugin involves HMR, verify HMR on all three tiers.
+- **Source**: [alpha.2 release notes, "Bug fixes"](https://github.com/deepseek-ai/deepseek-harness/releases/tag/dsh-v0.1.2-alpha.2) · [alpha.2 vendor/README item 19](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/vendor/README.md) · [alpha.2 loader shape probing](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/vendor/loader/src/internal.ts) · [alpha.2 CI pins Node 24.9](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/.github/workflows/ci.yml)
 
 ---
 
-### DSH-0.1.2-A2-06 · Client Remote 增加固定 Host facts `$host.home/isLoopback`
+### DSH-0.1.2-A2-05 · Plugin inventory returns optional Agent Preset grouping
 
-- **类型**: behavior
-- **适用对象**: 曾调用 `host.describe` 或需要 Host home/loopback 状态的 Web Client 集成
-- **影响触点**: #3
-- **操作级别**: required-if-hit
-- **症状**: alpha.1 只有 generation-ready 帧与按域查询，没有 `ctx.remote.$host`；alpha.2 Client face 新增普通值 `home` 与 `isLoopback`。
-- **迁移配方**: alpha.2 读取 `ctx.remote.$host.home`（首个 ready 帧前可为 `undefined`）和 `ctx.remote.$host.isLoopback`。`$host` 不是 store、没有订阅或 generation counter；需要响应重连时监听 `connection/reset`，不要轮询它。
-- **验证**: ready 前后分别检查 `home`；loopback/非 loopback 连接核对布尔值；重连路径由 `connection/reset` 驱动。
-- **来源**: [alpha.2 API gateway README](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/api/gateway/README.md) · [alpha.2 APIProxy→Remote note](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/.agents/notes/implemented/architecture/2026-08-10-unary-apiproxy-remote-migration.md)
-
-### DSH-0.1.2-A2-08 · `sessionProjections` 成为多个工具包的必需 inject 与 peer
-
-- **类型**: breaking
-- **适用对象**: 不用 shipped bundle 全量、自己组 profile 单独挂 `dsh-tool-todo`、`dsh-tool-subagent`、`dsh-agent`、`dsh-agent-loop`、`dsh-terminal-bash` 等包的宿主；把这些包列为 peer 的插件
-- **影响触点**: #3
-- **操作级别**: required-if-hit
-- **症状**: alpha.2 `dsh-tool-todo` 的 `inject` 从 `['tools']` 变成 `['tools', 'sessionProjections']`（`src/index.ts:23`），`dsh-tool-subagent` 变成 `['tools', 'subagents', 'systemPrompt', 'sessionProjections']`（`src/index.ts:43`）；`@deepseek-ai/dsh-session-projection` 新增为 `dsh-agent`、`dsh-agent-loop`、`dsh-tool-subagent`、`dsh-terminal-bash` 等包的 peer。组合里没有 session-projection 服务时，这些入口停在 `pending (waiting for service: sessionProjections)`。
-- **迁移配方**: 用 shipped bundle 的不受影响：`dsh-base` alpha.2 已挂 `session-projection`（`cordis.patch.yml:138`）和 `session-projection-cache`。自组 profile 在这些包之前补一行 `@deepseek-ai/dsh-session-projection`；插件把上述包列为 peer 时同步补 `dsh-session-projection` peer。这是 [DSH-0.1.2-A2-03](v0.1.2-alpha.2.md) 没提的反方向——新增 peer 比裁剪 peer 危险，缺了不是 typecheck 报错，是运行时 pending。
-- **验证**: `dsh --profile <p> --dump-config` 没有 pending 行；冷启动跑一轮消息 → 工具 → 回复。
-- **来源**: [alpha.2 tool-todo `inject`](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/todo/tool-todo/src/index.ts) · [alpha.2 tool-subagent `inject`](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/subagent/tool-subagent/src/index.ts) · [alpha.2 `dsh-agent` package.json（新增 peer）](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/core/agent/package.json) · [alpha.2 base 组合的 session-projection 行](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/bundle/base/cordis.patch.yml)
+- **Type**: behavior
+- **Applies to**: Host/Web Client plugins that consume `pluginInventory/list` or validate `PluginInventorySnapshot` strictly
+- **Touchpoints**: #3, #5
+- **Action level**: conditional
+- **Symptoms**: `PluginInventorySnapshot` gains an optional `agentPresets`; `AgentPresetPluginGroup`, `AgentPresetPluginRow`, and `PresetPluginEnablement` are also exposed. Consumers with closed schemas or that reject unknown fields may fail.
+- **Migration recipe**: Parse `agentPresets` as an optional field, keeping the old entries view when it is absent; do not rebuild the whole object in a way that drops future fields. When presets need to be displayed, render from trust, rows, and `boolean | 'conditional'` enablement.
+- **Verification**: The field may be absent when no preset roster exists; with a roster present, multiple preset/conditional rows parse; the old entries behavior is unchanged.
+- **Source**: [alpha.2 PluginInventorySnapshot types](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/host/plugin-inventory/src/types.ts) · [alpha.2 release notes](https://github.com/deepseek-ai/deepseek-harness/releases/tag/dsh-v0.1.2-alpha.2)
 
 ---
 
-### DSH-0.1.2-A2-10 · `dsh-settings` 移除运行时 `settingsNamespace` 导出，命名空间改编译期校验
+### DSH-0.1.2-A2-06 · Client Remote adds fixed Host facts `$host.home/isLoopback`
 
-- **类型**: breaking
-- **适用对象**: 注册/读写 settings namespace 的 host 侧插件（`ctx.settings.register/update/get`）与镜像该 seam 的测试替身
-- **影响触点**: #3
-- **操作级别**: required-if-hit
-- **症状**: `import { settingsNamespace } from '@deepseek-ai/dsh-settings'` 在 alpha.2 上编译即报 TS2724（no exported member）——devDependencies 升级后 typecheck 失败。运行时导出只剩 `SettingsConflictError` / `SettingsProvider` / `redactSecrets` / default；alpha.1 及更早该助手仍在。
-- **迁移配方**: 命名空间合法性校验已转为编译期模板字面量 `SettingsNamespaceInput`（小写字母开头 + `[a-z0-9-]` 尾部；`SettingsNamespace` 是 brand 类型）：宿主侧直接把命名空间**字面量常量**传给 `register/update/get`（合规字面量直接过编译），不再调运行时转换助手；测试替身处用 `as SettingsNamespace` 品牌转换构造 `SettingsConflictError`。
-- **验证**: 升级 devDependencies 后 typecheck 通过；namespace 注册/读/写/监听路径单测；真机设置面板读写一次。
-- **来源**: [alpha.2 settings/src/index.ts（SettingsNamespaceInput，无 settingsNamespace 导出）](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/settings/settings/src/index.ts) · [alpha.1 settings/src/index.ts（导出仍在）](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/packages/settings/settings/src/index.ts)
-- **实战批注**（2026-08-30，dsh-better-sidebar，devDeps 0.1.1-rc.1 → 0.1.2-alpha.2）: 升级后全部 typecheck 失败仅此一处语义（宿主侧 + smoke 测试替身两个调用点）；修复为直接传常量 + 品牌转换，见 [PR #472](https://github.com/omdsh-dev/DSH-better-sidebar/pull/472)。
+- **Type**: behavior
+- **Applies to**: Web Client integrations that previously called `host.describe` or need the Host home/loopback state
+- **Touchpoints**: #3
+- **Action level**: required-if-hit
+- **Symptoms**: alpha.1 had only generation-ready frames and per-domain queries, with no `ctx.remote.$host`; the alpha.2 client face adds plain values `home` and `isLoopback`.
+- **Migration recipe**: In alpha.2, read `ctx.remote.$host.home` (may be `undefined` before the first ready frame) and `ctx.remote.$host.isLoopback`. `$host` is not a store — it has no subscriptions or generation counter; to react to reconnects, listen for `connection/reset` instead of polling it.
+- **Verification**: Check `home` before and after ready; verify the boolean against loopback/non-loopback connections; the reconnect path is driven by `connection/reset`.
+- **Source**: [alpha.2 API gateway README](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/api/gateway/README.md) · [alpha.2 APIProxy→Remote note](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/.agents/notes/implemented/architecture/2026-08-10-unary-apiproxy-remote-migration.md)
+
+### DSH-0.1.2-A2-08 · `sessionProjections` becomes a required inject and peer for multiple tool packages
+
+- **Type**: breaking
+- **Applies to**: Hosts that do not use the full shipped bundle and compose their own profiles, mounting `dsh-tool-todo`, `dsh-tool-subagent`, `dsh-agent`, `dsh-agent-loop`, `dsh-terminal-bash`, and similar packages individually; plugins that list these packages as peers
+- **Touchpoints**: #3
+- **Action level**: required-if-hit
+- **Symptoms**: In alpha.2, `dsh-tool-todo`'s `inject` changes from `['tools']` to `['tools', 'sessionProjections']` (`src/index.ts:23`), and `dsh-tool-subagent`'s to `['tools', 'subagents', 'systemPrompt', 'sessionProjections']` (`src/index.ts:43`); `@deepseek-ai/dsh-session-projection` is added as a peer of `dsh-agent`, `dsh-agent-loop`, `dsh-tool-subagent`, `dsh-terminal-bash`, and others. When the composition has no session-projection service, these entries stall at `pending (waiting for service: sessionProjections)`.
+- **Migration recipe**: Users of the shipped bundle are unaffected: `dsh-base` alpha.2 already mounts `session-projection` (`cordis.patch.yml:138`) and `session-projection-cache`. For self-composed profiles, add a `@deepseek-ai/dsh-session-projection` line before these packages; when a plugin lists the above packages as peers, add the `dsh-session-projection` peer as well. This is the opposite direction that [DSH-0.1.2-A2-03](v0.1.2-alpha.2.md) does not mention — adding a peer is more dangerous than pruning one, because a missing peer shows up not as a typecheck error but as a runtime pending.
+- **Verification**: `dsh --profile <p> --dump-config` shows no pending lines; cold boot and run one message → tool → response round.
+- **Source**: [alpha.2 tool-todo `inject`](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/todo/tool-todo/src/index.ts) · [alpha.2 tool-subagent `inject`](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/subagent/tool-subagent/src/index.ts) · [alpha.2 `dsh-agent` package.json (new peer)](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/core/agent/package.json) · [alpha.2 base composition session-projection lines](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/bundle/base/cordis.patch.yml)
 
 ---
 
-*未建卡的宿主 UI/性能变化仅表示官方材料未声明插件迁移动作，不等于已证明没有
-API 或行为影响。发现真实插件受影响时，应补一手来源与可复现验证。*
+### DSH-0.1.2-A2-10 · `dsh-settings` drops the runtime `settingsNamespace` export; namespaces are validated at compile time
+
+- **Type**: breaking
+- **Applies to**: Host-side plugins that register/read/write settings namespaces (`ctx.settings.register/update/get`) and test doubles that mirror this seam
+- **Touchpoints**: #3
+- **Action level**: required-if-hit
+- **Symptoms**: `import { settingsNamespace } from '@deepseek-ai/dsh-settings'` fails to compile on alpha.2 with TS2724 (no exported member) — typecheck fails after upgrading devDependencies. The runtime exports are now only `SettingsConflictError` / `SettingsProvider` / `redactSecrets` / default; the helper was still present in alpha.1 and earlier.
+- **Migration recipe**: Namespace validity checking has moved to compile time via the template literal type `SettingsNamespaceInput` (lowercase letter at the start + `[a-z0-9-]` suffix; `SettingsNamespace` is a brand type): on the host side, pass namespace **literal constants** directly to `register/update/get` (compliant literals compile as-is) and stop calling the runtime conversion helper; in test doubles, construct `SettingsConflictError` with an `as SettingsNamespace` brand conversion.
+- **Verification**: Typecheck passes after upgrading devDependencies; unit-test the namespace register/read/write/listen paths; read and write once on a real host settings panel.
+- **Source**: [alpha.2 settings/src/index.ts (SettingsNamespaceInput, no settingsNamespace export)](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.2/packages/settings/settings/src/index.ts) · [alpha.1 settings/src/index.ts (export still present)](https://github.com/deepseek-ai/deepseek-harness/blob/dsh-v0.1.2-alpha.1/packages/settings/settings/src/index.ts)
+- **Field note** (2026-08-30, dsh-better-sidebar, devDeps 0.1.1-rc.1 → 0.1.2-alpha.2): After the upgrade, all typecheck failures came from this single semantic change (two call sites: the host side and the smoke-test double); the fix passes constants directly plus the brand conversion, see [PR #472](https://github.com/omdsh-dev/DSH-better-sidebar/pull/472).
+
+---
+
+*Host UI/performance changes without cards only mean the official material declares no plugin migration action; they do not prove the absence
+of API or behavior impact. When a real plugin is found to be affected, add a primary source and reproducible verification.*

--- a/skills/plugin-upgrade/scripts/plan-migration.mjs
+++ b/skills/plugin-upgrade/scripts/plan-migration.mjs
@@ -132,12 +132,12 @@ async function loadCardSets() {
       const end = headings[index + 1]?.index ?? body.length
       const card = body.slice(heading.index, end)
       const field = (name) => new RegExp(`^- \\*\\*${name}\\*\\*:\\s*([^\\r\\n]+)`, 'm').exec(card)?.[1]?.trim()
-      const impact = field('影响触点') ?? ''
+      const impact = field('Touchpoints') ?? ''
       return {
         id: heading[1],
         title: heading[2].trim(),
-        type: field('类型'),
-        action: field('操作级别'),
+        type: field('Type'),
+        action: field('Action level'),
         impact,
         touchpoints: [...new Set([...impact.matchAll(/#([1-7])/g)].map((match) => Number(match[1])))].sort(),
         sourceFile: name,


### PR DESCRIPTION
## Summary

English adaptation of the `plugin-upgrade` reference documents — the largest Chinese content block in the repo:

- **Version cards** (38 cards): `v0.1.1-rc.2.md` (3), `v0.1.2-alpha.1.md` (27), `v0.1.2-alpha.2.md` (8) — frontmatter byte-identical, card IDs and the `·` heading separator preserved.
- **Card field names now English** (schema change, see below): `Type / Applies to / Touchpoints / Action level / Symptoms / Migration recipe / Verification / Source`.
- `rollup-0.1.2.md`, `api-migration-0.1.2-alpha.2.md`, `pre-flight.md`, `references/README.md`, `migration-hygiene.md`, `troubleshooting.md`, `host-plane-probes.md` — translated in place.
- `pre-flight-patterns.json` — only the 7 touchpoint class `name` values translated; `id`/`slug`/`patterns` untouched and kept in lockstep with `pre-flight.md`.
- Cross-file anchors into `api-migration-0.1.2-alpha.2.md` (API-08/API-10) and card headings updated to the English GitHub slugs (rollup, pre-flight, cards).

## Machine contracts updated in the same PR

- `scripts/validate.mjs` — `requiredFields`, the Type/Action level/Source extraction regexes, the rollup contract string (`#7 subprocess`) and the retired-rule regex now match the English schema. The `六类触点` retired-schema guard is kept as-is.
- `skills/plugin-upgrade/scripts/plan-migration.mjs` — field lookups (`Touchpoints`/`Type`/`Action level`).
- `skills/plugin-upgrade/SKILL.md` — the "cards are kept in Chinese" note replaced.
- `CONTRIBUTING.md` — the card field list references the English field names.

## Verification

- `node scripts/validate.mjs` — Validation OK (38 cards, 94 Markdown files, face contracts + planner checks green)
- `node scripts/validate-manifests.mjs` — passed
- `verify-runtime.check.mjs` — all assertions passed; `npm test` smoke suite green
- `node --check` on the edited scripts; planner `--help` runs.

## Notes for reviewers

- **Intentional correction**: `api-migration-0.1.2-alpha.2.md` cross-reference `[rollup R-07]` → `[rollup R-11]` — the ledger row is R-11 in the rollup (the Chinese original pointed to R-07 by mistake). The Chinese original should be corrected in a follow-up.
- Field-name translation is a machine-visible schema change: the validator and the migration planner were updated in lockstep, so `node scripts/validate.mjs` is the source of truth.
- Chinese remains only in code-block comments, quoted UI strings (`PTC 模式`) and the `日志` regex example in R-13 — all literal content.
