### PR TITLE
i18n(dsh-upgrade-audit): English playbook, example README and skill evals

### DIFF
--- a/skills/dsh-upgrade-audit/SKILL.md
+++ b/skills/dsh-upgrade-audit/SKILL.md
@@ -11,7 +11,7 @@ Audit every change observable by consumers **outside the repository** between tw
 
 External compatibility = everything observable by consumers outside the repository: the npm package public API (exports, types, signatures, dependency surface), the `dsh` CLI (commands, flags, profiles, config keys), the wire protocol (SDK JSON-RPC, remote gateway/BFF, ACP, hooks), session data on disk (JSONL logs, SQLite stores and their version guards), the model-visible surface (tool names/schemas, system-prompt output), and the Python SDK's expectations. Internal refactors are background, not findings — aggregate and count them.
 
-Note: `references/audit-playbook.md` is kept in Chinese, and the existing sample report under `examples/` is in English by historical convention; report language follows the user's language (see "Output contract" below).
+Note: report language follows the user's language (see "Output contract" below); the existing sample report under `examples/` is in English by historical convention.
 
 ## Phase 0 — Parse input and choose a mode
 

--- a/skills/dsh-upgrade-audit/evals/evals.json
+++ b/skills/dsh-upgrade-audit/evals/evals.json
@@ -3,26 +3,26 @@
   "evals": [
     {
       "id": 1,
-      "prompt": "检查一下 dsh-v0.1.1-rc.1 -> dsh-v0.1.1-rc.2 对于外部兼容来说相对 rc.1 是否有更多的改动或者回滚？如果有请制作一个 ./tmp/0.1.1rc1-to-0.1.1rc2/（在 deepseek-harness 源码检出里执行）",
-      "expected_output": "检测到 tmp/0.1.1rc1-to-0.1.1rc2/ 已存在（技能诞生前的手工报告），先询问而非覆盖；31-commit 区间走内联单跑（不全量扇出）；merge-base 纯度通过；rc.1..rc.2 恰有一个 Revert commit（projection 注册形式），必须方向性上报为回滚。",
+      "prompt": "Check whether dsh-v0.1.1-rc.1 -> dsh-v0.1.1-rc.2 has more changes or reverts than rc.1 in terms of external compatibility. If so, produce a report in ./tmp/0.1.1rc1-to-0.1.1rc2/ (run inside the deepseek-harness source checkout).",
+      "expected_output": "Detect that tmp/0.1.1rc1-to-0.1.1rc2/ already exists (a hand-made report predating the skill); ask first instead of overwriting; the 31-commit range runs inline in a single pass (no full fan-out); merge-base purity passes; rc.1..rc.2 contains exactly one Revert commit (in the form of a projection registration) that must be reported directionally as a revert.",
       "files": []
     },
     {
       "id": 2,
-      "prompt": "对比 dsh-v0.1.0-rc.8 和 dsh-v0.1.1-rc.1，我主要关心 SDK/协议和 session 数据这两块的外部兼容，生成 upgrade 报告目录。",
-      "expected_output": "按用户关注点缩放为 2 个侦察面（SDK & 线上协议、会话数据）而非六面全量，但仍产出全套工件（含边界签名表）；两个格式守卫的值从两侧树读取并报告；报告目录 tmp/0.1.0rc8-to-0.1.1rc1/。",
+      "prompt": "Compare dsh-v0.1.0-rc.8 and dsh-v0.1.1-rc.1; I mainly care about external compatibility in the SDK/protocol and session-data areas. Generate an upgrade report directory.",
+      "expected_output": "Scale to the 2 recon surfaces matching the user's focus (SDK & wire protocol, session data) instead of all six, but still produce the full artifact set (including the boundary signature table); read the two format guards' values from both trees and report them; report directory tmp/0.1.0rc8-to-0.1.1rc1/.",
       "files": []
     },
     {
       "id": 3,
-      "prompt": "我没拉 deepseek-harness 源码，就在这个插件仓库里直接对比 0.1.2-alpha.1 和 0.1.2-alpha.2 两个 npm 版本，出个兼容报告。",
-      "expected_output": "npm 模式陷阱：0.1.2-alpha.1 从未发布到 npm——正确行为是物化脚本 exit 1 后向用户展示已发布清单与 dist-tags、说明缺口并确认替代对（如 rc.2 → alpha.2），绝不静默替换版本对继续审计；若用户确认替代对，则 materialize-npm 产出 a/、b/ 树、manifest-diff.txt 与 GitHub 富化的 commits.txt/reverts.txt，报告头部记录 Mode: npm packages 与版本出处。",
+      "prompt": "I have not cloned the deepseek-harness source — compare the two npm versions 0.1.2-alpha.1 and 0.1.2-alpha.2 directly inside this plugin repository and produce a compatibility report.",
+      "expected_output": "The npm-mode trap: 0.1.2-alpha.1 was never published to npm — the correct behavior is that after the materialization script exits 1, show the user the published list and dist-tags, explain the gap, and confirm a replacement pair (e.g. rc.2 → alpha.2); never silently substitute a version pair and continue the audit. If the user confirms a replacement pair, materialize-npm produces the a/ and b/ trees, manifest-diff.txt, and GitHub-enriched commits.txt/reverts.txt, and the report header records Mode: npm packages and version provenance.",
       "files": []
     },
     {
       "id": 4,
-      "prompt": "帮我审计 dsh-v0.1.0-rc.7 到 dsh-v0.1.0-rc.8 之间的 breaking changes 和回滚，输出报告目录，并和上一个区间的破坏密度对比一下。",
-      "expected_output": "337-commit 全量六面扇出 + merge-base 纯度检查 + 回滚清查 + 报告目录 tmp/0.1.0rc7-to-0.1.0rc8/。密度对比陷阱：rc.7→rc.8 是时间上最早的已审计对，正确行为是指出不存在可比较的前序对报告，而不是抓 tmp/ 里最新的目录（那是更晚的区间）或编造对比。",
+      "prompt": "Audit the breaking changes and reverts between dsh-v0.1.0-rc.7 and dsh-v0.1.0-rc.8, output a report directory, and compare the break density with the previous interval.",
+      "expected_output": "Full fan-out across all six recon surfaces for the 337-commit range + merge-base purity check + revert sweep + report directory tmp/0.1.0rc7-to-0.1.0rc8/. The density-comparison trap: rc.7→rc.8 is the chronologically earliest audited pair — the correct behavior is to point out that no comparable previous pair's report exists, not to grab the newest directory in tmp/ (which covers a later interval) or fabricate a comparison.",
       "files": []
     }
   ]

--- a/skills/dsh-upgrade-audit/examples/0.1.2alpha1-to-0.1.2alpha2/README.md
+++ b/skills/dsh-upgrade-audit/examples/0.1.2alpha1-to-0.1.2alpha2/README.md
@@ -1,13 +1,13 @@
 # Example: 0.1.2-alpha.1 → 0.1.2-alpha.2 audit report
 
-本 skill（源码模式）在 deepseek-harness 检出里产出的真实审计报告，区间 `dsh-v0.1.2-alpha.1..dsh-v0.1.2-alpha.2`（234 commits，其中 157 个非合并；1,604 files changed，+27,862 / −14,050）。
+A real audit report produced by this skill (source mode) in a deepseek-harness checkout, for the range `dsh-v0.1.2-alpha.1..dsh-v0.1.2-alpha.2` (234 commits, 157 of them non-merge; 1,604 files changed, +27,862 / −14,050).
 
-展示的输出契约全貌：
+It shows the full output contract:
 
-- `UPGRADE-ADAPTATION.md` — 头部区间统计与 merge-base 纯度说明、Verdict、§1 回滚分节（含方向性判定）、按消费者影响排序的破坏分节（每条带 **Adapt:** 行）、Confirmed unchanged、边界签名表、编号 Adaptation checklist
-- `CHANGELOG.md` — 按类型分类的 commit 清单，**必须包含 Reverts 分节**
+- `UPGRADE-ADAPTATION.md` — header range stats and merge-base purity note, Verdict, §1 reverts section (with directional judgments), breaking sections sorted by consumer impact (each entry with an **Adapt:** line), Confirmed unchanged, the boundary signature table, a numbered Adaptation checklist
+- `CHANGELOG.md` — commits categorized by type, **must include a Reverts section**
 
-机械工件（`commits.txt`、`files.txt`、`diffstat.txt`、全量 `.diff`）不入库，需要时在 deepseek-harness 检出里重新生成：
+Mechanical artifacts (`commits.txt`, `files.txt`, `diffstat.txt`, the full `.diff`) are not committed; regenerate them in a deepseek-harness checkout when needed:
 
 ```sh
 node <skill-dir>/scripts/gen-artifacts.mjs dsh-v0.1.2-alpha.1 dsh-v0.1.2-alpha.2 tmp/0.1.2alpha1-to-0.1.2alpha2

--- a/skills/dsh-upgrade-audit/references/audit-playbook.md
+++ b/skills/dsh-upgrade-audit/references/audit-playbook.md
@@ -1,74 +1,74 @@
-# Audit Playbook（审计手册）
+# Audit Playbook
 
-侦察派发模板、六面目标清单、报告骨架的参考文档。SKILL.md 负责阶段顺序，需要哪节读哪节。
+Reference for the recon dispatch template, the six recon-surface target lists, and the report skeleton. SKILL.md owns the phase sequencing; read only the section you need.
 
-## 六个标准侦察面
+## Six standard recon surfaces
 
-按区间规模合并或拆分（SKILL.md Phase 0）。目标是快路径；`files.txt` 或 `manifest-diff.txt` 显示清单没覆盖的面时，侦察应自行扩展。
+Merge or split them by interval size (SKILL.md Phase 0). The targets are the fast path; when `files.txt` or `manifest-diff.txt` shows a surface the list does not cover, extend the recon yourself.
 
-| # | 侦察面 | 目标（源码模式） | 目标（npm 模式） |
+| # | Recon surface | Targets (source mode) | Targets (npm mode) |
 |---|---|---|---|
-| 1 | Core API | `packages/core/**`（session、agent、agent-loop、tools、system-prompt、scope）、`packages/util/**` 的 src：导出增删改名、签名变化、事件 map、工具 schema、系统提示词结构 | `dsh-session`、`dsh-agent*`、`dsh-tools`、`dsh-system-prompt` 等包的 `lib/types/*.d.ts`（类型面）+ `lib/*.js`（运行时常量）+ package.json |
-| 2 | SDK & 线上协议 | `packages/sdk/**`、`packages/api/remotes`、`subagent-dsh-sdk`、`bundle/sdk-app`、`bundle/sdk-minimal`：JSON-RPC 方法、payload 字段（新增必填 = 线上破坏；删除 = 客户端破坏）、通知、协议常量、bundle 组成 | 对应 `dsh-sdk-*`、`dsh-api-remotes`、`dsh-subagent-dsh-sdk` 包的已发布 lib + 两棵树里 `dsh-headless`/`dsh-base` 等的 `cordis.patch.yml` |
-| 3 | CLI & 配置 | `apps/cli`、`packages/boot/**`、`packages/bundle/**`、`packages/settings/**`、`packages/credentials/**`、`packages/preset/**`、`docs/config-catalog.md`、`.github/workflows/release.yml`：命令/flag/环境变量、schemastery 键（删改名 = 配置作者破坏）、默认值、preset 名册、发布流程 | `dsh` 包（bin、lib 内 commander 定义与 --help）、各 bundle 包 `cordis.patch.yml` diff、`dsh-settings`/`dsh-agent-presets` 的 lib、GitHub 富化的 release 相关 commit |
-| 4 | Remote / BFF | `packages/api/gateway`、`packages/api/*-controller`、`packages/client/connection`、`packages/host/webserver`：流/journal/snapshot 事件、错误码词汇、HTTP 路由、连接状态机、鉴权流 | `dsh-api-gateway`、`dsh-api-*-controller`、`dsh-client-connection` 的已发布 lib：错误码常量、心跳默认值、事件名 |
-| 5 | 会话数据 | `packages/session/**`、`packages/session-query/**`、`packages/core/session`、`session-format-guard.expected.e2e.ts`：两个格式守卫、迁移还是拒绝（读守卫代码，不读 README）、JSONL 编码、投影/查询/导出面 | `dsh-session` + 补充包 `dsh-session-persistence-sqlite` 的 lib 常量与 `resources/sql/`、`dsh-session-query*`、`dsh-session-log-export` |
-| 6 | 回滚清查 | 全树：`git diff --name-status` 的 D/R（跳过测试/notes/i18n）、所有变更 `src/index.ts` 的导出删除、删掉的 CLI flag/配置键/preset/docs 章节；逐条归类「迁移了」还是「没了」 | `reverts.txt`（富化）+ `manifest-diff.txt` 全量过一遍：只在一棵树出现的包、exports/files/bin 收窄的包 |
+| 1 | Core API | `packages/core/**` (session, agent, agent-loop, tools, system-prompt, scope), `packages/util/**` src: export additions/removals/renames, signature changes, event maps, tool schemas, system-prompt structure | `lib/types/*.d.ts` (type surface) + `lib/*.js` (runtime constants) + package.json of packages such as `dsh-session`, `dsh-agent*`, `dsh-tools`, `dsh-system-prompt` |
+| 2 | SDK & wire protocol | `packages/sdk/**`, `packages/api/remotes`, `subagent-dsh-sdk`, `bundle/sdk-app`, `bundle/sdk-minimal`: JSON-RPC methods, payload fields (new required fields = wire breakage; removals = client breakage), notifications, protocol constants, bundle composition | published lib of the corresponding `dsh-sdk-*`, `dsh-api-remotes`, `dsh-subagent-dsh-sdk` packages + the `cordis.patch.yml` of `dsh-headless`/`dsh-base` etc. in both trees |
+| 3 | CLI & config | `apps/cli`, `packages/boot/**`, `packages/bundle/**`, `packages/settings/**`, `packages/credentials/**`, `packages/preset/**`, `docs/config-catalog.md`, `.github/workflows/release.yml`: commands/flags/environment variables, schemastery keys (removals/renames = config-author breakage), default values, preset roster, release flow | the `dsh` package (bin, commander definitions in lib and `--help`), `cordis.patch.yml` diffs of each bundle package, lib of `dsh-settings`/`dsh-agent-presets`, GitHub-enriched release-related commits |
+| 4 | Remote / BFF | `packages/api/gateway`, `packages/api/*-controller`, `packages/client/connection`, `packages/host/webserver`: stream/journal/snapshot events, error-code vocabulary, HTTP routes, connection state machine, auth flows | published lib of `dsh-api-gateway`, `dsh-api-*-controller`, `dsh-client-connection`: error-code constants, heartbeat defaults, event names |
+| 5 | Session data | `packages/session/**`, `packages/session-query/**`, `packages/core/session`, `session-format-guard.expected.e2e.ts`: the two format guards, migrate vs refuse (read the guard code, not the README), JSONL encoding, projection/query/export surface | lib constants and `resources/sql/` of `dsh-session` + supplement package `dsh-session-persistence-sqlite`, `dsh-session-query*`, `dsh-session-log-export` |
+| 6 | Revert sweep | whole tree: D/R entries in `git diff --name-status` (skip tests/notes/i18n), export removals in every changed `src/index.ts`, removed CLI flags/config keys/preset/docs sections; classify each entry as "migrated" or "gone" | `reverts.txt` (enrichment) + a full pass over `manifest-diff.txt`: packages present in only one tree, packages whose exports/files/bin narrowed |
 
-## 侦察派发模板
+## Recon dispatch template
 
-一批并行发出。每个 prompt 都带 Phase 2 共享事实（格式守卫、回滚清单、Python 行）、本契约、及其侦察面目标。
+Dispatch a parallel batch. Every prompt carries the Phase 2 shared facts (format guards, revert list, Python line), this contract, and the targets of its recon surface.
 
 ```
 # Goal
 Audit external-compatibility changes between <from> and <to> in <repo/mode>. External = observable by consumers outside the repo.
 
 # Constraints
-- READ-ONLY. 源码模式用 `git diff <from>..<to> -- <paths>` 和 `git show <tag>:<path>`；npm 模式只读 `a/`、`b/` 两棵已发布树。不 build、不 test、不 lint。
-- 每条发现分类：ADDED / REMOVED / CHANGED（before → after）/ RENAMED。REMOVED 放最前。
-- 每条带 包/路径、符号或字段、变化类型、影响面类别（SDK 消费者 / CLI 用户 / 配置作者 / 会话数据 / 模型可见 / 协议对端 / web UI / npm 安装者）。
-- 内部无关重构（私有 helper、测试、文档措辞）：聚合成一个计数，不逐条列。
-- 不确定就说不确定；没读过的不要猜。
+- READ-ONLY. Source mode: `git diff <from>..<to> -- <paths>` and `git show <tag>:<path>`; npm mode: read only the two published trees `a/` and `b/`. No build, no test, no lint.
+- Classify every finding: ADDED / REMOVED / CHANGED (before → after) / RENAMED. Put REMOVED first.
+- Each entry carries package/path, symbol or field, change type, and impact-surface class (SDK consumers / CLI users / config authors / session data / model-visible / protocol peers / web UI / npm installers).
+- Internal refactors unrelated to external compatibility (private helpers, tests, doc wording): aggregate into a single count; do not itemize.
+- If unsure, say unsure; do not guess about what you have not read.
 
 # Output
-Markdown：`## <facade>` → `### REMOVED` / `### CHANGED` / `### ADDED`，结尾一行判定："External-compat delta: <low/medium/high> — <一句话>"。
+Markdown: `## <facade>` → `### REMOVED` / `### CHANGED` / `### ADDED`; end with a one-line verdict: "External-compat delta: <low/medium/high> — <one sentence>".
 ```
 
-## 核验规则（Phase 4）
+## Verification rules (Phase 4)
 
-侦察输出是线索，不是发现。进入报告前：
+Recon output is leads, not findings. Before anything enters the report:
 
-1. **存在性主张**：两个树上分别 `git ls-tree <tag> --name-only <dir>` 或 ls 两棵已发布树。报"新增"的包/导出必须在 `from` 侧不存在。
-2. **删除主张**：`git show <to>:<path>` 或 `b/node_modules/...` 里不得再有该符号；找到替代品并点名，找不到就写「没了」。
-3. **取值主张**（默认值、常量、schema 版本）：在两侧树里读常量本身。
-4. **线上主张**（错误码、字段、路由）：diff 声明它的文件，不看 changelog。
-5. 核验不了的删掉，或保留为 `[INFERENCE]` 并写明缺什么证据。
+1. **Existence claims**: run `git ls-tree <tag> --name-only <dir>` on each tree, or list the two published trees. A package/export reported as "added" must not exist on the `from` side.
+2. **Removal claims**: the symbol must no longer be present in `git show <to>:<path>` or `b/node_modules/...`; name the replacement when you find one, write "gone" when you do not.
+3. **Value claims** (defaults, constants, schema versions): read the constant itself in both trees.
+4. **Wire claims** (error codes, fields, routes): diff the file that declares them; do not read the changelog.
+5. Anything unverifiable: drop it, or keep it as `[INFERENCE]` and state what evidence is missing.
 
-## UPGRADE-ADAPTATION.md 骨架
+## UPGRADE-ADAPTATION.md skeleton
 
-报告语言跟随用户；骨架如下（英文标题与 [examples/ 实例报告](../examples/0.1.2alpha1-to-0.1.2alpha2/UPGRADE-ADAPTATION.md) 一致）。
+Report language follows the user's language; the skeleton below uses the English headings of the [sample report under examples/](../examples/0.1.2alpha1-to-0.1.2alpha2/UPGRADE-ADAPTATION.md).
 
 ```markdown
 # Upgrade Adaptation: <to> ← <from>
 
-<一句话受众说明。工件清单。>
+<One-sentence note for the audience. Artifact list.>
 
 Range: `<from>` (<date>) → `<to>` (<date>). Release commit: `<sha>`. <N> commits total (<n> non-merge). <files> files changed, +<ins> / −<del>.
-[npm 模式加一行：Mode: npm packages (resolved <va> -> <vb>), GitHub enrichment <status>]
+[npm mode adds one line: Mode: npm packages (resolved <va> -> <vb>), GitHub enrichment <status>]
 
-History is merge-base-pure: `git merge-base <from> <to>` = <sha> = <from> itself. [不纯：停下解释漂移，不要继续。]
+History is merge-base-pure: `git merge-base <from> <to>` = <sha> = <from> itself. [If not pure: stop, explain the drift, and do not continue.]
 
 ## Verdict
-<直接回答比较性问题：破坏更多吗？有真回滚吗？与上一区间的密度对比。点名 1-3 个最重要事实。>
+<Answer the comparative question directly: more breakage? any real reverts? density vs. the previous interval. Name the 1–3 most important facts.>
 
 ## 1. Reverts (rollbacks relative to <from>)
-<每条 revert 一个编号项：sha、subject、方向变化、波及面。没有也要写"未发现"并说明查找方式。>
+<One numbered entry per revert: sha, subject, directional change, blast radius. When there are none, still write "none found" and explain how you looked.>
 
-## 2..N. 破坏分节（按消费者影响排序）
-<每面：REMOVED 在前，**BREAKING** + 消费者类别，before → after，替代品，**Adapt:** 行。确认安全的面各一行。>
+## 2..N. Breaking sections (sorted by consumer impact)
+<Per recon surface: REMOVED first, **BREAKING** + consumer class, before → after, replacement, an **Adapt:** line. One line per recon surface confirmed safe.>
 
 ## Confirmed unchanged (compatibility holds)
-<成立的互操作：协议、CLI、JSONL 日志、模型可见契约。每行带证据。>
+<Interop that holds: protocol, CLI, JSONL logs, model-visible contracts. Each line carries evidence.>
 
 ## Boundary-signature table
 | API surface | <from> | <to> | changed? |
@@ -84,14 +84,14 @@ History is merge-base-pure: `git merge-base <from> <to>` = <sha> = <from> itself
 | Known session event vocabulary | ... | ... | ... |
 
 ## Adaptation checklist
-<编号、祈使句、一条一个动作——上面点名的每类消费者一张迁移卡。>
+<Numbered, imperative, one action per item — one migration card per consumer class named above.>
 ```
 
-## 报告约定
+## Reporting conventions
 
-- "回滚"是方向性的：`from` 中存在、区间内被 revert 撤回的行为。修复性地恢复旧行为算；纯内部在途重构的 revert 不算，除非波及面跨出了某个侦察面。
-- 影响面类别是报告的索引方案：每条破坏都要点名谁会破（SDK 消费者 / CLI 用户 / 配置作者 / 会话数据 / 模型可见 / 协议对端 / web UI / npm 安装者）。
-- 边界签名表是记录摘要；正文分节是它的证据。表行与正文矛盾 = 报告有 bug。
-- 密度对比：`tmp/<prev-pair>/commits.txt` 存在时，在 Verdict 里并排报两个区间的非合并 commit 数与破坏数；**按时间序**取紧邻前一对。npm 模式的历史报告可能只有 `manifest-diff.txt` 可比，如实说明。
-- npm 模式富化的 `commits.txt` 受 GitHub compare API 限制：commit 列表最多 250 条（stats 里 `truncated: true`），大区间的回滚清单可能不全——报告须写明覆盖率；需要完整历史时改用源码模式，或按区间切片多次调用 compare。
-- 与 `plugin-upgrade` 的版本变更卡片衔接：报告的边界签名表与 §1 回滚可直接作为卡片素材；给卡片补「实战批注」时引用报告目录路径，不凭记忆转述。
+- Revert is directional: behavior present in `from` that a revert within the interval withdraws. A revert that restores old behavior as a fix counts; a revert of purely internal in-flight refactoring does not, unless its blast radius crosses a recon surface.
+- The impact-surface classes are the report's indexing scheme: every break must name who breaks (SDK consumers / CLI users / config authors / session data / model-visible / protocol peers / web UI / npm installers).
+- The boundary signature table is a summary record; the body sections are its evidence. A table row that contradicts the body = the report has a bug.
+- Density comparison: when `tmp/<prev-pair>/commits.txt` exists, report the two intervals' non-merge commit counts and break counts side by side in the Verdict; take the immediately preceding pair in **chronological order**. Historical npm-mode reports may offer only `manifest-diff.txt` for comparison — say so plainly.
+- npm-mode enriched `commits.txt` is subject to GitHub compare API limits: the commit list is capped at 250 entries (`truncated: true` in the stats), so a large interval's revert list may be incomplete — the report must state the coverage; when full history is needed, switch to source mode, or slice the interval into multiple compare calls.
+- Handoff to `plugin-upgrade` version-change cards: the report's boundary signature table and §1 reverts feed cards directly; when adding "field notes" to a card, cite the report directory path instead of restating from memory.

--- a/skills/plugin-upgrade/evals/evals.json
+++ b/skills/plugin-upgrade/evals/evals.json
@@ -3,26 +3,26 @@
   "evals": [
     {
       "id": 1,
-      "prompt": "以只读模式扫描 examples/legacy-plugin/ 这个夹具，输出七类触点体检表和命中的版本卡片。",
-      "expected_output": "七类触点（源码 patch、内部事件、服务/Remote、宿主目录、UI/命令、自建 HTTP 通道、子进程输出）全部命中；对应卡片映射到 A1-01/A1-02/A1-03/A1-04/A1-08（含 A2-01 回滚对）等；输出包含「未命中说明」与「必须验证」清单；全程不改文件。",
+      "prompt": "Scan the examples/legacy-plugin/ fixture in read-only mode and output the seven-touchpoint inspection table and the version cards that hit.",
+      "expected_output": "All seven touchpoints hit (source patches, internal events, services/Remote, host directories, UI/commands, custom HTTP channels, subprocess output); the corresponding cards map to A1-01/A1-02/A1-03/A1-04/A1-08 (including the A2-01 revert pair) and others; the output includes the \"no-hit notes\" and \"must verify\" checklist; no files are modified throughout.",
       "files": []
     },
     {
       "id": 2,
-      "prompt": "插件在 rc.2 上生产第三方 informational 持久事件（带 ignorable: true），现在要迁到 0.1.2-alpha.2。给出该触点的迁移步骤。",
-      "expected_output": "先读完整走廊折叠净状态：alpha.1 移除 ignorable、alpha.2 恢复（A1-02 → A2-01），因此不要“删了再加”；最终目标为 alpha.2 时保留/恢复 producer marker 并删除 alpha.1 时代的防御性删除；指出公开 Session.append 没有 ignorable 参数的能力缺口，不做 cast 假装已有公开入口；给出 reload/未知事件 fail-closed 的验证步骤。",
+      "prompt": "On rc.2 the plugin emits third-party informational persistent events (with ignorable: true) and now needs to migrate to 0.1.2-alpha.2. Give the migration steps for this touchpoint.",
+      "expected_output": "First read the full corridor-folding net state: alpha.1 removes ignorable, alpha.2 restores it (A1-02 → A2-01), so do not \"delete and re-add\"; when the final target is alpha.2, keep/restore the producer marker and remove the alpha.1-era defensive deletion; point out the capability gap that the public Session.append has no ignorable parameter — do not cast to pretend a public entry point exists; give the verification steps for reload and for fail-closed handling of unknown events.",
       "files": []
     },
     {
       "id": 3,
-      "prompt": "插件用 connection.rpc.handle('/x', handler, { authority: 'loopback' }) 注册自建通道，devDependencies 是 npm 0.1.1-rc.2，宿主将升到 0.1.2-alpha.2。怎么改？",
-      "expected_output": "识别签名漂移：alpha.1 起 handle() 移除第三参数且运行时忽略多余参数；由于 devDependencies 声明基线是 rc.2，采用双兼容写法保留第三参数（typecheck 对 rc.2 通过、alpha 运行时不变），并注明原因；同时提示自建通道必须经 connection 注册以获得统一认证（A1-08），不绕过 token；验证含真实冷启动与无认证 401。",
+      "prompt": "The plugin registers a custom channel with connection.rpc.handle('/x', handler, { authority: 'loopback' }), its devDependencies point at npm 0.1.1-rc.2, and the host will be upgraded to 0.1.2-alpha.2. What needs to change?",
+      "expected_output": "Recognize the signature drift: from alpha.1 on, handle() drops the third parameter and ignores extra arguments at runtime; because the declared devDependencies baseline is rc.2, use the dual-compatibility pattern to keep the third parameter (typecheck passes against rc.2, alpha runtime behavior unchanged) and note the reason; also point out that a custom channel must be registered through connection to get unified authentication (A1-08) — do not bypass the token; verification includes a real cold boot and an unauthenticated 401.",
       "files": []
     },
     {
       "id": 4,
-      "prompt": "我是插件作者。我的 Host + Web Client 插件自身版本 0.6.4，依赖 DSH 0.1.0-rc.6，使用 dsh-client-runtime、useSession(snapshot.nodes) 和 ctx.commands.execute(agent, line, signal)。请给出迁到 DSH 0.1.2-alpha.2 的源码升级方案。",
-      "expected_output": "进入 author-migrate 而不是已安装插件 update；分开记录插件自身 SemVer 与 DSH cohort，并指出 0.1.0-rc.6→rc.2 是 unsupported gap。删除 dsh-client-runtime，按 owning 包迁 ClientContext/SessionId/ConversationNode/CommandRowProps，useSession transcript 改 useChat 并按 order+nodes.get 读取 keyed store，Host execute 无图传 []。检查 dsh.client.inject、直接声明依赖与 type-only augmentation，临时 skipLibCheck false 防 implicit any；lockfile 不得混 cohort。最后再决定插件自身版本，并验证 test/build、pack filename/manifest、隔离 profile install、token→Cookie、boot entry、公告 bundle load/mount/remove。",
+      "prompt": "I am a plugin author. My Host + Web Client plugin is at version 0.6.4, depends on DSH 0.1.0-rc.6, and uses dsh-client-runtime, useSession(snapshot.nodes), and ctx.commands.execute(agent, line, signal). Give me a source upgrade plan to DSH 0.1.2-alpha.2.",
+      "expected_output": "Enter author-migrate rather than installed-plugin update; record the plugin's own SemVer and the DSH cohort separately, and note that 0.1.0-rc.6→rc.2 is an unsupported gap. Remove dsh-client-runtime and migrate ClientContext/SessionId/ConversationNode/CommandRowProps per owning package; switch useSession transcript to useChat and read the keyed store by order + nodes.get; Host execute passes [] when there is no graph. Check dsh.client.inject, directly declared dependencies, and type-only augmentation; temporarily set skipLibCheck to false to guard against implicit any; the lockfile must not mix cohorts. Decide the plugin's own version last, then verify test/build, pack filename/manifest, isolated-profile install, token→Cookie, boot entry, and advertised bundle load/mount/remove.",
       "files": []
     }
   ]


### PR DESCRIPTION
## Summary

English adaptation of the `dsh-upgrade-audit` playbook and the skill eval suites:

- `skills/dsh-upgrade-audit/references/audit-playbook.md` — translated in place; terminology unified to **recon surface** (the playbook previously mixed "facade"/"recon facade").
- `skills/dsh-upgrade-audit/examples/0.1.2alpha1-to-0.1.2alpha2/README.md` — translated; all facts, tags, commit counts and commands preserved.
- `skills/plugin-upgrade/evals/evals.json` + `skills/dsh-upgrade-audit/evals/evals.json` — prompts and expected outputs translated; card IDs, code identifiers and JSON structure intact.
- `skills/dsh-upgrade-audit/SKILL.md` — only the note line updated (the playbook is no longer kept in Chinese).

## Verification

- `node scripts/validate.mjs` / `validate-manifests.mjs` — pass
- Both evals.json parse; Han scan clean except the switcher word in SKILL.md.
