### PR TITLE
i18n(scripts): English comments and messages in repo validators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,7 @@ __pycache__/
 dist/
 build/
 
-# Benchmark runtime artifacts（v1 自研 harness 遗留；现格式产物走 harbor trial 目录）
+# Benchmark runtime artifacts (leftover from the v1 in-house harness; current-format artifacts go to the harbor trial directory)
 benchmark/agent-output/
 benchmark/scorecard.json
 jobs/

--- a/scripts/validate-manifests.mjs
+++ b/scripts/validate-manifests.mjs
@@ -1,12 +1,12 @@
 #!/usr/bin/env node
 /**
- * 校验多 agent 清单文件的一致性。
+ * Validate consistency across the multi-agent manifest files.
  *
- * 检查项：
- * 1. 所有清单 JSON 可解析
- * 2. 各清单声明的 version 一致
- * 3. 清单指向的 skills 目录存在
- * 4. skills/ 下每个 skill 有带 name/description 前置元数据的 SKILL.md
+ * Checks:
+ * 1. Every manifest JSON parses
+ * 2. All manifests declare the same version
+ * 3. The skills directory each manifest points to exists
+ * 4. Every skill under skills/ has a SKILL.md with name/description frontmatter
  */
 
 import { readFileSync, existsSync, readdirSync, statSync } from 'node:fs'
@@ -17,18 +17,18 @@ const root = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 const errors = []
 const fail = (msg) => errors.push(msg)
 
-/** 读取并解析 JSON；失败时记录错误并返回 null。 */
+/** Read and parse JSON; record the error and return null on failure. */
 function readJson(rel) {
   const abs = join(root, rel)
-  if (!existsSync(abs)) return fail(`缺少清单文件：${rel}`), null
+  if (!existsSync(abs)) return fail(`Missing manifest file: ${rel}`), null
   try {
     return JSON.parse(readFileSync(abs, 'utf8'))
   } catch (error) {
-    return fail(`${rel} JSON 解析失败：${error.message}`), null
+    return fail(`Failed to parse ${rel} JSON: ${error.message}`), null
   }
 }
 
-// 1–2. 清单可解析且版本一致
+// 1–2. Manifests parse and versions agree
 const manifests = {
   '.claude-plugin/plugin.json': readJson('.claude-plugin/plugin.json'),
   '.claude-plugin/marketplace.json': readJson('.claude-plugin/marketplace.json'),
@@ -40,72 +40,72 @@ const versions = new Map()
 for (const [rel, manifest] of Object.entries(manifests)) {
   if (!manifest) continue
   const found = manifest.version ?? manifest.plugins?.[0]?.version
-  if (!found) fail(`${rel} 未声明 version`)
+  if (!found) fail(`${rel} does not declare a version`)
   else versions.set(rel, found)
 }
 const distinct = new Set(versions.values())
 if (distinct.size > 1) {
   const detail = [...versions].map(([rel, v]) => `${rel}=${v}`).join(', ')
-  fail(`清单版本不一致：${detail}`)
+  fail(`Manifest versions are inconsistent: ${detail}`)
 }
 
-// 3. skills 目录存在
+// 3. Skills directory exists
 for (const [rel, manifest] of Object.entries(manifests)) {
   const skills = manifest?.skills
   if (typeof skills !== 'string') continue
-  if (!existsSync(join(root, skills))) fail(`${rel} 的 skills 路径不存在：${skills}`)
+  if (!existsSync(join(root, skills))) fail(`Skills path in ${rel} does not exist: ${skills}`)
 }
 
-// 4. 每个 skill 有合法 SKILL.md 前置元数据
+// 4. Every skill has valid SKILL.md frontmatter
 const skillsDir = join(root, 'skills')
 const skillNames = existsSync(skillsDir)
   ? readdirSync(skillsDir).filter((entry) => statSync(join(skillsDir, entry)).isDirectory())
   : []
-if (skillNames.length === 0) fail('skills/ 下没有任何 skill 目录')
+if (skillNames.length === 0) fail('No skill directories under skills/')
 
 for (const name of skillNames) {
   const rel = `skills/${name}/SKILL.md`
   const abs = join(root, rel)
   if (!existsSync(abs)) {
-    fail(`缺少 ${rel}`)
+    fail(`Missing ${rel}`)
     continue
   }
   const text = readFileSync(abs, 'utf8')
   const frontmatter = /^---\r?\n([\s\S]*?)\r?\n---/.exec(text)
   if (!frontmatter) {
-    fail(`${rel} 缺少 YAML 前置元数据`)
+    fail(`${rel} is missing YAML frontmatter`)
     continue
   }
   const body = frontmatter[1]
   const declared = /^name:\s*(.+)$/m.exec(body)?.[1].trim()
-  if (!declared) fail(`${rel} 前置元数据缺少 name`)
-  else if (declared !== name) fail(`${rel} 的 name「${declared}」与目录名「${name}」不一致`)
-  if (!/^description:\s*\S/m.test(body)) fail(`${rel} 前置元数据缺少 description`)
+  if (!declared) fail(`${rel} frontmatter is missing name`)
+  else if (declared !== name) fail(`name "${declared}" in ${rel} does not match directory name "${name}"`)
+  if (!/^description:\s*\S/m.test(body)) fail(`${rel} frontmatter is missing description`)
 }
 
 // Distribution docs must use commands supported by the current CLI surfaces.
 // README.en.md mirrors README.md, so both are held to the same rules to prevent drift.
 for (const doc of ['README.md', 'README.en.md']) {
   const text = readFileSync(join(root, doc), 'utf8')
-  if (/\bcodex plugin add\b/.test(text)) fail(`${doc} 使用不存在的 codex plugin add`)
-  if (!/codex plugin marketplace add/.test(text)) fail(`${doc} 缺少 Codex marketplace add 安装路径`)
-  if (/git config --global url\./.test(text)) fail(`${doc} 不得建议全局重写 GitHub URL`)
+  if (/\bcodex plugin add\b/.test(text)) fail(`${doc} uses the nonexistent codex plugin add`)
+  if (!/codex plugin marketplace add/.test(text)) fail(`${doc} is missing the Codex marketplace add install path`)
+  if (/git config --global url\./.test(text)) fail(`${doc} must not advise globally rewriting GitHub URLs`)
 }
 
 // The conventional local entry point must run both dependency-free validators.
 const rootPackage = readJson('package.json')
 const validateScript = rootPackage?.scripts?.validate ?? ''
 if (!validateScript.includes('scripts/validate.mjs') || !validateScript.includes('scripts/validate-manifests.mjs')) {
-  fail('package.json scripts.validate 必须串联两个 validator')
+  fail('package.json scripts.validate must chain both validators')
 }
-if (rootPackage?.scripts?.test !== 'npm run validate') fail('package.json scripts.test 必须委托 npm run validate')
+if (rootPackage?.scripts?.test !== 'npm run validate') fail('package.json scripts.test must delegate to npm run validate')
 
 if (errors.length > 0) {
-  console.error('清单校验失败：')
+  console.error('Manifest validation failed:')
   for (const error of errors) console.error(`  - ${error}`)
   process.exit(1)
 }
 
 const version = distinct.values().next().value
-console.log(`清单校验通过：${Object.keys(manifests).length} 个清单，版本 ${version}`)
-console.log(`skills：${skillNames.join(', ')}`)
+console.log(`Manifest validation passed: ${Object.keys(manifests).length} manifests, version ${version}`)
+console.log(`skills: ${skillNames.join(', ')}`)


### PR DESCRIPTION
## Summary

Small English-adaptation cleanup in the repo tooling:

- `scripts/validate-manifests.mjs` — comments and human-readable messages translated; all logic, regexes and functional string literals byte-identical.
- `.gitignore` — the benchmark-artifacts comment translated to English.

## Verification

- `node scripts/validate.mjs` / `validate-manifests.mjs` / `node --check` — all pass; zero Han characters remain.
