### PR TITLE
feat(plugin-workflow): add guided lifecycle orchestration

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -20,6 +20,7 @@
       "Read"
     ],
     "defaultPrompt": [
+      "Inspect this DSH plugin and let me choose upgrade, testing, naming, and release stages",
       "Help me upgrade my DSH plugin to version X",
       "What breaking changes exist between DSH 0.1.1 and 0.1.2?"
     ]

--- a/README.en.md
+++ b/README.en.md
@@ -10,7 +10,7 @@
 
 - **30 upgrade cards** — each records one real pitfall: what breaks, why, how to fix it, and which version the information comes from. Ordered by version, from 0.1.1 all the way to 0.1.2-alpha.2.
 - **12 general-purpose countermeasures** — some problems have nothing to do with the version (back up first, run old and new side by side, what to do when startup hangs). These live in one checklist.
-- **5 skills** — check for upgrades, write new plugins, test plugins, release plugins, and diff two dsh versions. Each does one job.
+- **6 skills** — one unified workflow selects and coordinates stages, while the other five check upgrades, write plugins, test plugins, release plugins, and diff two dsh versions.
 - **6 exam questions (benchmark)** — tests whether an AI with our skill actually knows how to upgrade a plugin. Every question is auto-graded.
 - **Two validation reports** — we installed two real dsh versions in Docker and confirmed that following the cards really does fix plugins.
 
@@ -82,6 +82,8 @@ cp -r dsh-plugin-upgrade-skill/skills/* .cursor/skills/
 In Claude Code, invoke the skill by name (namespaced once the plugin is installed):
 
 ```
+/plugin-workflow
+/dsh-plugin-upgrade-skill:plugin-workflow
 /plugin-upgrade 0.1.2
 /dsh-plugin-upgrade-skill:plugin-upgrade 0.1.2
 ```
@@ -89,14 +91,16 @@ In Claude Code, invoke the skill by name (namespaced once the plugin is installe
 You can also ask directly in the conversation (any agent); the skill triggers on its description. Read-only checks return results directly, while upgrades or migrations produce a plan first and wait for confirmation:
 
 ```
+Inspect this DSH plugin and let me choose upgrade, testing, cloud naming, and release stages.
 What breaking changes are there for upgrading my plugin from 0.1.1 to 0.1.2?
 Upgrade the dsh-ads plugin to dsh-v0.1.2-alpha.2
 ```
 
-## What each of the 5 skills does
+## What each of the 6 skills does
 
 | Skill | What it's for |
 | --- | --- |
+| [plugin-workflow](skills/plugin-workflow/) | The unified entry point. Choose inspection, upgrade, testing, naming and registration, packaging, and release capabilities before execution; receive a phase ledger with separate write, runtime, and publication confirmations |
 | [plugin-upgrade](skills/plugin-upgrade/) | The main one. Checks whether a plugin needs upgrading, performs the upgrade, adapts old plugins to a new dsh version |
 | [plugin-write](skills/plugin-write/) | Writing new plugins, with naming rules and a name-collision check |
 | [plugin-test](skills/plugin-test/) | Testing whether a plugin change is correct, including a Docker smoke test (actually boots dsh with your plugin) |
@@ -126,10 +130,16 @@ The [benchmark/](benchmark/) folder has 6 upgrade exam questions with auto-gradi
 
 ## Use it inside your project
 
-Copy the whole `skills/plugin-upgrade/` folder into your project:
+For the unified workflow, copy the complete `skills/` directory because `plugin-workflow` routes each phase to the other five owning Skills. If you only need upgrades, you can copy `skills/plugin-upgrade/` by itself:
 
 ```text
-<your-project>/.agents/skills/plugin-upgrade/
+<your-project>/.agents/skills/
+├── plugin-workflow/
+├── plugin-upgrade/
+├── plugin-write/
+├── plugin-test/
+├── plugin-release/
+└── dsh-upgrade-audit/
 ```
 
 Keep `SKILL.md` and the `references/` folder inside — don't copy just one file. You can also point DSH's local skill loader at the `skills/` directory of this repo.
@@ -140,7 +150,7 @@ Keep `SKILL.md` and the `references/` folder inside — don't copy just one file
 skills/<skill-name>/
 ├── SKILL.md        # how the skill triggers and what it does
 ├── references/     # upgrade cards and detailed material
-├── scripts/        # small executable tools (plugin-upgrade ships a read-only migration planner and a runtime verifier)
+├── scripts/        # small executable tools, including migration, workflow, and runtime verification planners
 └── examples/       # example code (read-only, do not run)
 scripts/validate.mjs            # repo self-check
 scripts/validate-manifests.mjs  # multi-agent manifest self-check

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 - **30 张升级说明卡**：每张卡记录一个真实的坑——什么坏了、为什么坏、怎么修、信息来源是哪个版本。按版本排好序，从 0.1.1 一路到 0.1.2-alpha.2。
 - **12 条通用对策**：有些坑和版本无关（比如"先备份再动手""新旧版本怎么共存"），这些写成了一份对策清单。
-- **5 个 skill**：查升级、写新插件、测插件、发插件、对比两个版本的差别，各管一件事。
+- **6 个 skill**：一个统一工作流负责选择和编排，另外五个分别负责查升级、写新插件、测插件、发插件和对比两个版本的差别。
 - **6 道考题（benchmark）**：用来测"AI 装了我们的 skill 之后到底会不会升级插件"，每道题都有自动判分。
 - **两份验证报告**：我们在 docker 里真的装了两个版本的 dsh，验证了"按卡片做就能修好插件"。
 
@@ -87,6 +87,8 @@ cp -r dsh-plugin-upgrade-skill/skills/* .cursor/skills/
 Claude Code 中按名字调用 skill（插件安装后带命名空间）：
 
 ```
+/plugin-workflow
+/dsh-plugin-upgrade-skill:plugin-workflow
 /plugin-upgrade 0.1.2
 /dsh-plugin-upgrade-skill:plugin-upgrade 0.1.2
 ```
@@ -94,14 +96,16 @@ Claude Code 中按名字调用 skill（插件安装后带命名空间）：
 也可以直接在对话中提问（任意 agent），skill 按描述自动触发；只读检查直接给结果，升级或迁移会先出计划再等确认：
 
 ```
+先检查这个 DSH 插件，让我选择要不要升级、测试、查云端命名或发布
 我需要把插件从 0.1.1 升级到 0.1.2，有哪些破坏性变更？
 帮我把 dsh-ads 这个插件升级到 dsh-v0.1.2-alpha.2
 ```
 
-## 5 个 skill 各自管什么
+## 6 个 skill 各自管什么
 
 | Skill | 干什么用 |
 | --- | --- |
+| [plugin-workflow](skills/plugin-workflow/) | 统一入口。运行前选择检查、升级、测试、命名注册、打包发布等功能，生成阶段账本并分别确认写入、运行和外部发布 |
 | [plugin-upgrade](skills/plugin-upgrade/) | 主角。检查插件要不要升级、执行升级、把老插件适配到新 dsh 版本 |
 | [plugin-write](skills/plugin-write/) | 写新插件，附命名规范和查重（避免和别人插件撞名） |
 | [plugin-test](skills/plugin-test/) | 测插件改得对不对，含 docker 冒烟测试（装上 dsh 真启动一遍） |
@@ -131,10 +135,16 @@ Claude Code 中按名字调用 skill（插件安装后带命名空间）：
 
 ## 项目里直接用
 
-把 `skills/plugin-upgrade/` 整个文件夹复制到你的项目里：
+使用统一工作流时，把整个 `skills/` 目录复制到项目里，因为 `plugin-workflow` 会把每个阶段交给另外五个 owning Skill。只需要升级能力时，也可以单独复制 `skills/plugin-upgrade/`：
 
 ```text
-<your-project>/.agents/skills/plugin-upgrade/
+<your-project>/.agents/skills/
+├── plugin-workflow/
+├── plugin-upgrade/
+├── plugin-write/
+├── plugin-test/
+├── plugin-release/
+└── dsh-upgrade-audit/
 ```
 
 注意保留里面的 `SKILL.md` 和 `references/` 文件夹，别只复制一个文件。也可以让 DSH 本地的 skill 加载方式直接指向本仓库的 `skills/` 目录。
@@ -145,7 +155,7 @@ Claude Code 中按名字调用 skill（插件安装后带命名空间）：
 skills/<skill-name>/
 ├── SKILL.md        # skill 的说明书（怎么触发、怎么干活）
 ├── references/     # 升级说明卡和详细资料
-├── scripts/        # 可执行的小工具（plugin-upgrade 内含只读迁移规划器和运行时验证器）
+├── scripts/        # 可执行的小工具（含迁移规划器、工作流计划器和运行时验证器）
 └── examples/       # 示例代码（只读，不要运行）
 scripts/validate.mjs            # 仓库自检
 scripts/validate-manifests.mjs  # 多 agent 清单自检

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "validate:naming": "node skills/plugin-write/scripts/validate-names.check.mjs",
     "validate:registry": "node skills/plugin-write/scripts/query-registry.check.mjs",
     "verify:runtime": "node skills/plugin-upgrade/scripts/verify-runtime.check.mjs",
-    "test:smoke": "node --test skills/plugin-test/scripts/docker-release-smoke.test.mjs"
+    "test:smoke": "node --test skills/plugin-test/scripts/docker-release-smoke.test.mjs",
+    "validate:workflow": "node skills/plugin-workflow/scripts/plan-workflow.check.mjs"
   }
 }

--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -276,10 +276,19 @@ try {
   fail(registryCheckFile, `registry query check failed: ${error.stack ?? error.message}`)
 }
 
+// Workflow selections must be deterministic, schema-backed, dependency-safe, and read-only.
+const workflowCheckFile = join(root, 'skills', 'plugin-workflow', 'scripts', 'plan-workflow.check.mjs')
+try {
+  const { runWorkflowPlannerChecks } = await import(pathToFileURL(workflowCheckFile).href)
+  await runWorkflowPlannerChecks()
+} catch (error) {
+  fail(workflowCheckFile, `workflow planner check failed: ${error.stack ?? error.message}`)
+}
+
 if (failures.length) {
   console.error(`Validation failed (${failures.length}):`)
   for (const failure of failures) console.error(`- ${failure}`)
   process.exit(1)
 }
 
-console.log(`Validation OK: ${skillEntries.length} skill, ${cardFiles.length} card sets, ${totalCards} cards, ${markdownFiles.length} Markdown files, 7 touchpoint fixtures, 2 face contracts, read-only planner, offline naming validator, read-only registry v2 query`)
+console.log(`Validation OK: ${skillEntries.length} skill, ${cardFiles.length} card sets, ${totalCards} cards, ${markdownFiles.length} Markdown files, 7 touchpoint fixtures, 2 face contracts, read-only migration and workflow planners, offline naming validator, read-only registry v2 query`)

--- a/skills/README.en.md
+++ b/skills/README.en.md
@@ -36,6 +36,7 @@ Requirements:
 
 | Skill | What it does | Author |
 |---|---|---|
+| [plugin-workflow](plugin-workflow/) | Select and coordinate inspection, upgrades, tests, naming registration, release, and rollback with one phase ledger and separate confirmation boundaries | [@oh-my-dsh](https://github.com/oh-my-dsh) |
 | [plugin-upgrade](plugin-upgrade/) | Read-only inspection, installed-plugin upgrades, host compatibility migration; seven touchpoints + version cards + safe rollback | [@oh-my-dsh](https://github.com/oh-my-dsh) |
 | [plugin-write](plugin-write/) | Write DSH plugins, choose the extension form for the target Harness version, and distinguish official single-repo rules from external plugin rules | [@omdsh-dev](https://github.com/omdsh-dev) |
 | [plugin-test](plugin-test/) | Choose the test level for DSH plugin changes, covering real combinations, release artifacts, and target-version product entry points | [@omdsh-dev](https://github.com/omdsh-dev) |

--- a/skills/README.md
+++ b/skills/README.md
@@ -36,6 +36,7 @@ description: 一句话说明做什么、何时触发，以及重要的只读/写
 
 | Skill | 说明 | 作者 |
 |---|---|---|
+| [plugin-workflow](plugin-workflow/) | 统一选择并编排检查、升级、测试、命名注册、发布与回滚，维护阶段账本和独立授权边界 | [@oh-my-dsh](https://github.com/oh-my-dsh) |
 | [plugin-upgrade](plugin-upgrade/) | 只读检查、已安装插件升级、宿主兼容迁移；七类触点 + 版本卡片 + 安全回滚 | [@oh-my-dsh](https://github.com/oh-my-dsh) |
 | [plugin-write](plugin-write/) | 编写 DSH 插件，按目标 Harness 版本选择扩展形态，并区分官方单仓与外部插件规则 | [@omdsh-dev](https://github.com/omdsh-dev) |
 | [plugin-test](plugin-test/) | 为 DSH 插件变更选择测试层级，并覆盖真实组合、发布产物与目标版本产品入口 | [@omdsh-dev](https://github.com/omdsh-dev) |

--- a/skills/plugin-workflow/SKILL.md
+++ b/skills/plugin-workflow/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: plugin-workflow
+description: Coordinate the complete DeepSeek Harness plugin lifecycle across inspection, host compatibility upgrades, tests, naming and central registry checks, packaging, release, and rollback. Use when a user wants one guided workflow, asks which plugin capabilities to run, requests a pre-run feature menu, or needs several DSH plugin Skills chained with a unified status report. Default to read-only discovery and require separate confirmation before repository writes, dependency or runtime execution, and external publication.
+---
+
+# Coordinate the DSH Plugin Lifecycle
+
+Act as the workflow controller. Let the user choose outcomes and optional proof before execution, route each selected stage to its owning Skill, preserve one phase ledger, and return one evidence-backed report. Do not copy the detailed rules of an owning Skill into this Skill.
+
+## Start with read-only discovery
+
+Inspect only enough context to make the choices concrete:
+
+1. Read repository instructions and inspect Git status without changing it.
+2. Identify whether the target is the DSH monorepo, an external plugin source repository, an installed plugin, or a packed artifact.
+3. Record the plugin source identity, current DSH version, requested target version, package manager, available scripts, plugin surfaces, and existing naming declaration.
+4. Mark missing inputs as `unknown`. Do not install dependencies, run package scripts, start containers, edit files, or query a remote registry during discovery.
+
+If the user has already selected an outcome and supplied enough context, preserve that choice instead of asking again. Otherwise present the following compact menu and wait for selection. Default to `health-check` when the request is ambiguous.
+
+## Choose one workflow
+
+| Workflow | Outcome | Default stages |
+|---|---|---|
+| `health-check` | Read-only plugin and upgrade-risk report | discovery, optional DSH audit, seven-touchpoint scan |
+| `upgrade-target` | Upgrade an installed plugin to an explicit version | discovery, upgrade, static checks, rollback record |
+| `compatibility-migration` | Adapt plugin source to an exact DSH target | discovery, DSH audit, seven-touchpoint migration, static and runtime tests |
+| `test-only` | Validate an existing source tree or artifact | discovery, selected test levels, report |
+| `naming-registry` | Validate identifiers and optionally check or register a cloud ID | discovery, offline naming, registry query, optional registration |
+| `package-release` | Prepare and optionally publish a release | discovery, required test gates, pack, consumer smoke, optional publication |
+| `full-lifecycle` | Migrate, validate, name, package, and optionally publish | all applicable stages in dependency order |
+
+Then let the user include or exclude these capabilities. Recommend the smallest set that proves their stated outcome and state which recommended items are still unselected.
+
+| Capability | Choice | Default |
+|---|---|---|
+| DSH version compatibility audit | `dsh-audit` | On for compatibility migration; otherwise off |
+| Seven-touchpoint plugin scan | `touchpoint-scan` | On for health checks and migrations |
+| Typecheck, unit tests, and build | `static-tests` | On after source changes and before packaging |
+| Exact-version Docker cold start | `docker-smoke` | On for migrations and release candidates when Docker is available |
+| One real functional path | `functional-probe` | On for migrations and releases |
+| Browser validation | `browser-check` | On only for Web Client or UI surfaces |
+| Offline naming declaration validation | `naming-local` | On for new external plugins; otherwise opt-in |
+| Central cloud registry lookup | `registry-query` | Off until selected; read-only |
+| Central cloud ID registration | `registry-register` | Off; requires reviewed external publication |
+| Rollback rehearsal or recipe | `rollback` | Recipe on for every write workflow; rehearsal is opt-in |
+| Package and publish | `release` | Off unless release intent is explicit |
+
+Do not treat `registry-query` as a reservation. Do not treat `registry-register` as required for local plugin use. A local plugin and the central registry may share a display name; only concrete identifiers on the same runtime surface can conflict, and the naming owner must report those exact matches.
+
+## Build the phase ledger
+
+Create one row per selected or dependency-required stage before execution:
+
+| Phase | Capability | Owner | Status | Evidence or blocker |
+|---|---|---|---|---|
+| `P01` | discovery | `plugin-workflow` | `selected` | target and source identity |
+
+Use only these status values:
+
+- `selected`: chosen and not yet completed;
+- `completed`: finished with evidence;
+- `blocked`: attempted or required but unable to proceed;
+- `skipped`: applicable but deliberately not run;
+- `not_applicable`: irrelevant to the detected plugin surface or workflow.
+
+Never turn an unavailable or unselected check into `completed`. When a phase is blocked, mark dependent phases `blocked` or `skipped` with the dependency reason and continue only with independent, authorized phases.
+
+## Route each stage to its owner
+
+Before executing a stage, load and follow its owning Skill. If the owner is unavailable, mark the phase `blocked`; do not recreate its implementation from memory.
+
+| Stage | Owning Skill | Boundary |
+|---|---|---|
+| Installed update or source compatibility migration | `$plugin-upgrade` | Inspect first; confirm before config, dependency, or source changes |
+| New plugin code or offline naming declaration | `$plugin-write` | Follow the exact target Harness contract |
+| Static, runtime, Docker, functional, or browser validation | `$plugin-test` | Select the minimum sufficient levels and preserve evidence |
+| Package, release gates, publication, and release rollback | `$plugin-release` | Confirm publication separately |
+| DSH host version-to-version evidence | `$dsh-upgrade-audit` | Keep generated evidence separate from plugin source changes |
+
+Run stages in dependency order:
+
+1. discovery and source identity;
+2. DSH audit when selected;
+3. upgrade or implementation changes;
+4. offline naming and optional registry query;
+5. static tests;
+6. Docker, functional, and browser proof;
+7. release preparation and artifact inspection;
+8. external registration or publication.
+
+Skip stages that are not selected unless an owning Skill makes them a hard gate for a later selected stage. In that case, add the gate to the ledger, explain why it is required, and obtain any needed confirmation before running it.
+
+## Enforce three confirmation boundaries
+
+Group planned actions by boundary and never use approval for one boundary as approval for another:
+
+1. **Repository writes**: show exact files, intended changes, and rollback scope before editing source, configuration, manifests, or lockfiles.
+2. **Dependency and runtime execution**: show package-manager commands, lifecycle-script risk, containers, services, browsers, credentials, and expected generated outputs before installs or nontrivial runtime tests. Ordinary read-only Git and file inspection does not need confirmation.
+3. **External publication**: immediately before pushing commits or tags, opening a registry PR, publishing npm artifacts, or changing a hub/collection, show the exact destination and payload and obtain separate confirmation.
+
+If a selected phase crosses more than one boundary, confirm each boundary when it becomes actionable. Never request or expose secrets merely to complete a phase.
+
+## Maintain and report evidence
+
+Update the ledger after every phase, including failures and explicit skips. Keep exact versions, source SHAs, commands, exit codes, report paths, and uncovered boundaries. Before finishing, verify that every selected capability has a terminal status.
+
+Return one report containing:
+
+1. workflow and capability selection;
+2. source and target identities;
+3. final phase ledger;
+4. changes made and commits created;
+5. test and registry evidence;
+6. blocked, skipped, and unverified boundaries;
+7. rollback instructions limited to paths owned by this workflow;
+8. publication state, clearly distinguishing local validation, no reviewed registry match, reviewed registration, and released artifacts.
+
+Do not summarize a partial cold start as functional compatibility, a registry no-match as a reserved ID, or a prepared artifact as published.

--- a/skills/plugin-workflow/SKILL.md
+++ b/skills/plugin-workflow/SKILL.md
@@ -44,7 +44,20 @@ Then let the user include or exclude these capabilities. Recommend the smallest 
 | Central cloud registry lookup | `registry-query` | Off until selected; read-only |
 | Central cloud ID registration | `registry-register` | Off; requires reviewed external publication |
 | Rollback rehearsal or recipe | `rollback` | Recipe on for every write workflow; rehearsal is opt-in |
-| Package and publish | `release` | Off unless release intent is explicit |
+| Build and inspect a package artifact | `package-artifact` | On for package/release and full lifecycle workflows |
+| Publish an artifact or release | `release` | Off unless external release intent is explicit |
+
+For a repeatable plan, normalize the selection with the bundled read-only planner. Read [`references/workflow-selection.schema.json`](references/workflow-selection.schema.json) when another tool needs to produce the input JSON.
+
+```sh
+node <plugin-workflow-skill>/scripts/plan-workflow.mjs \
+  --workflow compatibility-migration \
+  --include registry-query \
+  --exclude browser-check \
+  --surface ordinary-plugin
+```
+
+Use `--format json` for automation, or `--selection <selection.json>` for a persisted input that follows the schema. The planner validates conflicts and required dependencies, emits deterministic phase IDs and confirmation boundaries, and never executes the selected phases. Treat its output as the initial ledger, not as user approval.
 
 Do not treat `registry-query` as a reservation. Do not treat `registry-register` as required for local plugin use. A local plugin and the central registry may share a display name; only concrete identifiers on the same runtime surface can conflict, and the naming owner must report those exact matches.
 

--- a/skills/plugin-workflow/agents/openai.yaml
+++ b/skills/plugin-workflow/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "DSH Plugin Workflow"
+  short_description: "Plan and coordinate the DSH plugin lifecycle"
+  default_prompt: "Use $plugin-workflow to inspect this DSH plugin and let me choose upgrade, testing, naming, and release stages."

--- a/skills/plugin-workflow/references/workflow-selection.schema.json
+++ b/skills/plugin-workflow/references/workflow-selection.schema.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/oh-my-dsh/dsh-plugin-upgrade-skill/blob/main/skills/plugin-workflow/references/workflow-selection.schema.json",
+  "title": "DSH plugin workflow selection",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "workflow"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "const": "dsh-plugin-workflow/v1"
+    },
+    "workflow": {
+      "enum": [
+        "health-check",
+        "upgrade-target",
+        "compatibility-migration",
+        "test-only",
+        "naming-registry",
+        "package-release",
+        "full-lifecycle"
+      ]
+    },
+    "include": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/capability"
+      },
+      "default": []
+    },
+    "exclude": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/capability"
+      },
+      "default": []
+    },
+    "surfaces": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "enum": [
+          "host",
+          "ordinary-plugin",
+          "web-client"
+        ]
+      },
+      "default": [
+        "ordinary-plugin"
+      ]
+    },
+    "pluginState": {
+      "enum": [
+        "existing",
+        "new"
+      ],
+      "default": "existing"
+    }
+  },
+  "$defs": {
+    "capability": {
+      "enum": [
+        "dsh-audit",
+        "touchpoint-scan",
+        "static-tests",
+        "docker-smoke",
+        "functional-probe",
+        "browser-check",
+        "naming-local",
+        "registry-query",
+        "registry-register",
+        "rollback",
+        "package-artifact",
+        "release"
+      ]
+    }
+  }
+}

--- a/skills/plugin-workflow/scripts/plan-workflow.check.mjs
+++ b/skills/plugin-workflow/scripts/plan-workflow.check.mjs
@@ -1,0 +1,132 @@
+import assert from 'node:assert/strict'
+import { spawn } from 'node:child_process'
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+import {
+  CAPABILITY_IDS,
+  SELECTION_SCHEMA_VERSION,
+  WORKFLOW_IDS,
+  buildWorkflowPlan,
+  renderMarkdown,
+  validateSelection,
+} from './plan-workflow.mjs'
+
+const script = fileURLToPath(new URL('./plan-workflow.mjs', import.meta.url))
+const schemaPath = fileURLToPath(new URL('../references/workflow-selection.schema.json', import.meta.url))
+
+function selection(overrides = {}) {
+  return {
+    schemaVersion: SELECTION_SCHEMA_VERSION,
+    workflow: 'health-check',
+    include: [],
+    exclude: [],
+    surfaces: ['ordinary-plugin'],
+    pluginState: 'existing',
+    ...overrides,
+  }
+}
+
+function runCli(args) {
+  return new Promise((accept, reject) => {
+    const child = spawn(process.execPath, [script, ...args], { stdio: ['ignore', 'pipe', 'pipe'] })
+    let stdout = ''
+    let stderr = ''
+    child.stdout.setEncoding('utf8')
+    child.stderr.setEncoding('utf8')
+    child.stdout.on('data', (chunk) => { stdout += chunk })
+    child.stderr.on('data', (chunk) => { stderr += chunk })
+    child.on('error', reject)
+    child.on('close', (code) => accept({ code, stdout, stderr }))
+  })
+}
+
+export async function runWorkflowPlannerChecks() {
+  const schema = JSON.parse(await readFile(schemaPath, 'utf8'))
+  assert.deepEqual(WORKFLOW_IDS, schema.properties.workflow.enum)
+  assert.deepEqual(CAPABILITY_IDS, schema.$defs.capability.enum)
+
+  const health = buildWorkflowPlan(selection())
+  assert.equal(health.readOnly, true)
+  assert.deepEqual(health.ledger.map((phase) => phase.capability), ['discovery', 'touchpoint-scan'])
+  assert.equal(health.confirmations.length, 0)
+
+  const migration = buildWorkflowPlan(selection({
+    workflow: 'compatibility-migration',
+    surfaces: ['web-client'],
+  }))
+  assert.deepEqual(migration.ledger.map((phase) => phase.capability), [
+    'discovery',
+    'dsh-audit',
+    'touchpoint-scan',
+    'source-migration',
+    'static-tests',
+    'docker-smoke',
+    'functional-probe',
+    'browser-check',
+    'rollback',
+  ])
+  assert(migration.confirmations.some((entry) => entry.boundary === 'repository-writes'))
+  assert(migration.confirmations.some((entry) => entry.boundary === 'dependency-runtime'))
+  assert(!migration.confirmations.some((entry) => entry.boundary === 'external-publication'))
+
+  const registration = buildWorkflowPlan(selection({
+    workflow: 'naming-registry',
+    include: ['registry-register'],
+  }))
+  const registrationCapabilities = new Map(registration.capabilities.map((entry) => [entry.id, entry]))
+  assert.equal(registrationCapabilities.get('registry-register').source, 'user-include')
+  assert.equal(registrationCapabilities.get('registry-query').source, 'required-by:registry-register')
+  assert(registration.confirmations.some((entry) => entry.boundary === 'external-publication'))
+
+  const newPlugin = buildWorkflowPlan(selection({ workflow: 'full-lifecycle', pluginState: 'new' }))
+  assert(newPlugin.ledger.some((phase) => phase.capability === 'plugin-implementation' && phase.owner === 'plugin-write'))
+  assert(newPlugin.ledger.some((phase) => phase.capability === 'naming-local' && phase.confirmations.includes('repository-writes')))
+
+  assert.throws(
+    () => buildWorkflowPlan(selection({ workflow: 'package-release', include: ['release'], exclude: ['functional-probe'] })),
+    /release requires excluded capability functional-probe/,
+  )
+  assert.throws(
+    () => validateSelection(selection({ include: ['registry-query'], exclude: ['registry-query'] })),
+    /both included and excluded/,
+  )
+  assert.throws(() => validateSelection(selection({ workflow: 'unknown' })), /workflow must be one of/)
+  assert.throws(() => validateSelection({ ...selection(), extra: true }), /unknown property/)
+
+  const markdown = renderMarkdown(migration)
+  assert.match(markdown, /workflow plan \(read-only\)/)
+  assert.match(markdown, /does not grant execution approval/)
+  assert.doesNotMatch(markdown, /External publication/)
+  const releaseMarkdown = renderMarkdown(buildWorkflowPlan(selection({
+    workflow: 'package-release',
+    include: ['release'],
+  })))
+  assert.match(releaseMarkdown, /External publication/)
+
+  const tempRoot = await mkdtemp(join(tmpdir(), 'dsh-workflow-plan-'))
+  try {
+    const inputPath = join(tempRoot, 'selection.json')
+    const input = selection({ workflow: 'test-only', include: ['functional-probe'] })
+    await writeFile(inputPath, `${JSON.stringify(input, null, 2)}\n`, 'utf8')
+    const before = await readFile(inputPath, 'utf8')
+    const result = await runCli(['--selection', inputPath, '--format', 'json'])
+    const after = await readFile(inputPath, 'utf8')
+    assert.equal(result.code, 0, result.stderr)
+    assert.equal(after, before, 'Planner must not modify the selection file')
+    assert.equal(JSON.parse(result.stdout).selection.workflow, 'test-only')
+
+    const invalid = await runCli(['--workflow', 'naming-registry', '--include', 'registry-query', '--exclude', 'naming-local'])
+    assert.equal(invalid.code, 1)
+    assert.match(invalid.stderr, /registry-query requires excluded capability naming-local/)
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true })
+  }
+}
+
+const invokedPath = process.argv[1] ? pathToFileURL(resolve(process.argv[1])).href : undefined
+if (invokedPath === import.meta.url) {
+  await runWorkflowPlannerChecks()
+  console.log('Workflow planner checks OK: schema sync, deterministic defaults, dependency gates, confirmations, read-only CLI')
+}

--- a/skills/plugin-workflow/scripts/plan-workflow.mjs
+++ b/skills/plugin-workflow/scripts/plan-workflow.mjs
@@ -1,0 +1,329 @@
+#!/usr/bin/env node
+import { readFile, readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+const selectionSchema = JSON.parse(
+  readFileSync(new URL('../references/workflow-selection.schema.json', import.meta.url), 'utf8'),
+)
+
+export const SELECTION_SCHEMA_VERSION = selectionSchema.properties.schemaVersion.const
+export const WORKFLOW_IDS = Object.freeze([...selectionSchema.properties.workflow.enum])
+export const CAPABILITY_IDS = Object.freeze([...selectionSchema.$defs.capability.enum])
+export const SURFACE_IDS = Object.freeze([...selectionSchema.properties.surfaces.items.enum])
+export const PLUGIN_STATES = Object.freeze([...selectionSchema.properties.pluginState.enum])
+
+const WORKFLOWS = {
+  'health-check': {
+    defaults: ['touchpoint-scan'],
+  },
+  'upgrade-target': {
+    defaults: ['static-tests', 'rollback'],
+    core: { capability: 'upgrade-installed', owner: 'plugin-upgrade', confirmations: ['repository-writes', 'dependency-runtime'] },
+  },
+  'compatibility-migration': {
+    defaults: ['dsh-audit', 'touchpoint-scan', 'static-tests', 'docker-smoke', 'functional-probe', 'rollback'],
+    core: { capability: 'source-migration', owner: 'plugin-upgrade', confirmations: ['repository-writes'] },
+  },
+  'test-only': {
+    defaults: ['static-tests'],
+  },
+  'naming-registry': {
+    defaults: ['naming-local'],
+  },
+  'package-release': {
+    defaults: ['static-tests', 'docker-smoke', 'functional-probe', 'rollback', 'package-artifact'],
+  },
+  'full-lifecycle': {
+    defaults: ['dsh-audit', 'touchpoint-scan', 'static-tests', 'docker-smoke', 'functional-probe', 'rollback', 'package-artifact'],
+    core: { capability: 'source-migration', owner: 'plugin-upgrade', confirmations: ['repository-writes'] },
+  },
+}
+
+const CAPABILITIES = {
+  'dsh-audit': { owner: 'dsh-upgrade-audit', confirmations: [] },
+  'touchpoint-scan': { owner: 'plugin-upgrade', confirmations: [] },
+  'naming-local': { owner: 'plugin-write', confirmations: [] },
+  'registry-query': { owner: 'plugin-write', confirmations: [], requires: ['naming-local'] },
+  'static-tests': { owner: 'plugin-test', confirmations: ['dependency-runtime'] },
+  'docker-smoke': { owner: 'plugin-test', confirmations: ['dependency-runtime'] },
+  'functional-probe': { owner: 'plugin-test', confirmations: ['dependency-runtime'] },
+  'browser-check': { owner: 'plugin-test', confirmations: ['dependency-runtime'] },
+  rollback: { owner: 'plugin-upgrade', confirmations: [] },
+  'package-artifact': { owner: 'plugin-release', confirmations: ['dependency-runtime'], requires: ['static-tests'] },
+  'registry-register': { owner: 'plugin-write', confirmations: ['external-publication'], requires: ['registry-query'] },
+  release: {
+    owner: 'plugin-release',
+    confirmations: ['external-publication'],
+    requires: ['package-artifact', 'functional-probe', 'rollback'],
+  },
+}
+
+for (const id of CAPABILITY_IDS) {
+  if (!CAPABILITIES[id]) throw new Error(`selection schema capability has no planner definition: ${id}`)
+}
+for (const id of Object.keys(CAPABILITIES)) {
+  if (!CAPABILITY_IDS.includes(id)) throw new Error(`planner capability is missing from selection schema: ${id}`)
+}
+
+const PHASE_ORDER = [
+  'dsh-audit',
+  'touchpoint-scan',
+  'core',
+  'naming-local',
+  'registry-query',
+  'static-tests',
+  'docker-smoke',
+  'functional-probe',
+  'browser-check',
+  'rollback',
+  'package-artifact',
+  'registry-register',
+  'release',
+]
+
+const BOUNDARY_LABELS = {
+  'repository-writes': 'Repository writes',
+  'dependency-runtime': 'Dependency and runtime execution',
+  'external-publication': 'External publication',
+}
+
+function assertPlainObject(value, name) {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`${name} must be an object`)
+  }
+}
+
+function validateEnum(value, allowed, name) {
+  if (!allowed.includes(value)) throw new Error(`${name} must be one of: ${allowed.join(', ')}`)
+}
+
+function validateUniqueEnumArray(value, allowed, name) {
+  if (!Array.isArray(value)) throw new Error(`${name} must be an array`)
+  if (new Set(value).size !== value.length) throw new Error(`${name} must not contain duplicates`)
+  for (const item of value) validateEnum(item, allowed, `${name} item`)
+  return [...value]
+}
+
+export function validateSelection(input) {
+  assertPlainObject(input, 'selection')
+  const allowedKeys = new Set(['schemaVersion', 'workflow', 'include', 'exclude', 'surfaces', 'pluginState'])
+  for (const key of Object.keys(input)) {
+    if (!allowedKeys.has(key)) throw new Error(`selection contains unknown property: ${key}`)
+  }
+
+  if (input.schemaVersion !== SELECTION_SCHEMA_VERSION) {
+    throw new Error(`schemaVersion must be ${SELECTION_SCHEMA_VERSION}`)
+  }
+  validateEnum(input.workflow, WORKFLOW_IDS, 'workflow')
+  const include = validateUniqueEnumArray(input.include ?? [], CAPABILITY_IDS, 'include')
+  const exclude = validateUniqueEnumArray(input.exclude ?? [], CAPABILITY_IDS, 'exclude')
+  const surfaces = validateUniqueEnumArray(input.surfaces ?? ['ordinary-plugin'], SURFACE_IDS, 'surfaces')
+  if (surfaces.length === 0) throw new Error('surfaces must contain at least one item')
+  const pluginState = input.pluginState ?? 'existing'
+  validateEnum(pluginState, PLUGIN_STATES, 'pluginState')
+
+  const conflicts = include.filter((id) => exclude.includes(id))
+  if (conflicts.length) throw new Error(`capabilities cannot be both included and excluded: ${conflicts.join(', ')}`)
+
+  return {
+    schemaVersion: SELECTION_SCHEMA_VERSION,
+    workflow: input.workflow,
+    include,
+    exclude,
+    surfaces,
+    pluginState,
+  }
+}
+
+function chooseCapabilities(selection) {
+  const selected = new Map()
+  const excluded = new Set(selection.exclude)
+  const select = (id, source) => {
+    if (!excluded.has(id) && !selected.has(id)) selected.set(id, source)
+  }
+
+  for (const id of WORKFLOWS[selection.workflow].defaults) select(id, 'workflow-default')
+  if (selection.surfaces.includes('web-client') && ['compatibility-migration', 'package-release', 'full-lifecycle'].includes(selection.workflow)) {
+    select('browser-check', 'surface-default')
+  }
+  if (selection.pluginState === 'new' && ['naming-registry', 'full-lifecycle'].includes(selection.workflow)) {
+    select('naming-local', 'plugin-state-default')
+  }
+  for (const id of selection.include) select(id, 'user-include')
+
+  const enableDependencies = (id, chain = []) => {
+    for (const dependency of CAPABILITIES[id].requires ?? []) {
+      if (excluded.has(dependency)) {
+        throw new Error(`${id} requires excluded capability ${dependency}`)
+      }
+      if (!selected.has(dependency)) selected.set(dependency, `required-by:${id}`)
+      if (chain.includes(dependency)) throw new Error(`capability dependency cycle: ${[...chain, dependency].join(' -> ')}`)
+      enableDependencies(dependency, [...chain, id])
+    }
+  }
+  for (const id of [...selected.keys()]) enableDependencies(id)
+
+  return selected
+}
+
+function resolveCore(selection) {
+  const base = WORKFLOWS[selection.workflow].core
+  if (!base) return undefined
+  if (selection.workflow === 'full-lifecycle' && selection.pluginState === 'new') {
+    return { capability: 'plugin-implementation', owner: 'plugin-write', confirmations: ['repository-writes'] }
+  }
+  return base
+}
+
+function capabilityPhase(id, selection) {
+  const definition = CAPABILITIES[id]
+  let owner = definition.owner
+  let confirmations = [...definition.confirmations]
+  if (id === 'naming-local' && selection.pluginState === 'new') confirmations = ['repository-writes']
+  if (id === 'rollback' && ['package-release', 'full-lifecycle'].includes(selection.workflow)) owner = 'plugin-release'
+  return { capability: id, owner, confirmations }
+}
+
+export function buildWorkflowPlan(input) {
+  const selection = validateSelection(input)
+  const chosen = chooseCapabilities(selection)
+  const core = resolveCore(selection)
+  const rawPhases = [
+    { capability: 'discovery', owner: 'plugin-workflow', confirmations: [] },
+  ]
+
+  for (const slot of PHASE_ORDER) {
+    if (slot === 'core') {
+      if (core) rawPhases.push(core)
+      continue
+    }
+    if (chosen.has(slot)) rawPhases.push(capabilityPhase(slot, selection))
+  }
+
+  const ledger = rawPhases.map((phase, index) => ({
+    phase: `P${String(index + 1).padStart(2, '0')}`,
+    capability: phase.capability,
+    owner: phase.owner,
+    status: 'selected',
+    confirmations: phase.confirmations,
+    evidence: null,
+  }))
+
+  const confirmations = Object.keys(BOUNDARY_LABELS).flatMap((boundary) => {
+    const phases = ledger.filter((phase) => phase.confirmations.includes(boundary)).map((phase) => phase.phase)
+    return phases.length ? [{ boundary, label: BOUNDARY_LABELS[boundary], phases, granted: false }] : []
+  })
+
+  return {
+    schemaVersion: SELECTION_SCHEMA_VERSION,
+    readOnly: true,
+    selection,
+    capabilities: CAPABILITY_IDS.map((id) => ({
+      id,
+      selected: chosen.has(id),
+      source: chosen.get(id) ?? (selection.exclude.includes(id) ? 'user-exclude' : 'not-selected'),
+    })),
+    ledger,
+    confirmations,
+    notes: [
+      'This plan is read-only and does not grant execution approval.',
+      'Load each owning Skill before executing its phase.',
+      'A selected external-publication phase still requires just-in-time confirmation.',
+    ],
+  }
+}
+
+function escapeCell(value) {
+  return String(value).replaceAll('|', '\\|')
+}
+
+export function renderMarkdown(plan) {
+  const selected = plan.capabilities.filter((entry) => entry.selected)
+  const excluded = plan.capabilities.filter((entry) => entry.source === 'user-exclude')
+  const lines = [
+    '# DSH plugin workflow plan (read-only)',
+    '',
+    `- Workflow: \`${plan.selection.workflow}\``,
+    `- Plugin state: \`${plan.selection.pluginState}\``,
+    `- Surfaces: ${plan.selection.surfaces.map((item) => `\`${item}\``).join(', ')}`,
+    `- Selected capabilities: ${selected.length ? selected.map((item) => `\`${item.id}\``).join(', ') : 'none'}`,
+    `- Explicitly excluded: ${excluded.length ? excluded.map((item) => `\`${item.id}\``).join(', ') : 'none'}`,
+    '- Planning is read-only and does not grant execution approval.',
+    '',
+    '## Phase ledger',
+    '',
+    '| Phase | Capability | Owner | Status | Confirmation |',
+    '|---|---|---|---|---|',
+  ]
+  for (const phase of plan.ledger) {
+    lines.push(`| ${phase.phase} | \`${escapeCell(phase.capability)}\` | \`$${escapeCell(phase.owner)}\` | \`${phase.status}\` | ${phase.confirmations.map((item) => `\`${item}\``).join(', ') || 'none'} |`)
+  }
+
+  lines.push('', '## Confirmation boundaries', '')
+  if (!plan.confirmations.length) lines.push('- None. The selected workflow is read-only.')
+  for (const confirmation of plan.confirmations) {
+    lines.push(`- **${confirmation.label}**: ${confirmation.phases.join(', ')}; not granted.`)
+  }
+  lines.push('', '## Notes', '', ...plan.notes.map((note) => `- ${note}`))
+  return `${lines.join('\n')}\n`
+}
+
+function splitList(value) {
+  return value.split(',').map((item) => item.trim()).filter(Boolean)
+}
+
+function usage() {
+  return `Usage:\n  node skills/plugin-workflow/scripts/plan-workflow.mjs --workflow <id> [--include a,b] [--exclude a,b] [--surface a,b] [--plugin-state existing|new] [--format markdown|json]\n  node skills/plugin-workflow/scripts/plan-workflow.mjs --selection <selection.json> [--format markdown|json]\n\nThe command is read-only. It creates a plan but never executes a selected phase.\n`
+}
+
+function parseArgs(argv) {
+  const options = { format: 'markdown' }
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]
+    if (arg === '--help' || arg === '-h') return { help: true }
+    const value = argv[++index]
+    if (value === undefined) throw new Error(`missing value for ${arg}`)
+    if (arg === '--workflow') options.workflow = value
+    else if (arg === '--include') options.include = splitList(value)
+    else if (arg === '--exclude') options.exclude = splitList(value)
+    else if (arg === '--surface') options.surfaces = splitList(value)
+    else if (arg === '--plugin-state') options.pluginState = value
+    else if (arg === '--selection') options.selectionPath = value
+    else if (arg === '--format') options.format = value
+    else throw new Error(`unknown option: ${arg}`)
+  }
+  if (!['json', 'markdown'].includes(options.format)) throw new Error('--format must be markdown or json')
+  if (options.selectionPath && ['workflow', 'include', 'exclude', 'surfaces', 'pluginState'].some((key) => options[key] !== undefined)) {
+    throw new Error('--selection cannot be combined with inline selection options')
+  }
+  return options
+}
+
+async function loadInput(options) {
+  if (options.selectionPath) return JSON.parse(await new Promise((accept, reject) => readFile(resolve(options.selectionPath), 'utf8', (error, data) => error ? reject(error) : accept(data))))
+  return {
+    schemaVersion: SELECTION_SCHEMA_VERSION,
+    workflow: options.workflow ?? 'health-check',
+    include: options.include ?? [],
+    exclude: options.exclude ?? [],
+    surfaces: options.surfaces ?? ['ordinary-plugin'],
+    pluginState: options.pluginState ?? 'existing',
+  }
+}
+
+const invokedPath = process.argv[1] ? pathToFileURL(resolve(process.argv[1])).href : undefined
+if (invokedPath === import.meta.url) {
+  try {
+    const options = parseArgs(process.argv.slice(2))
+    if (options.help) {
+      process.stdout.write(usage())
+    } else {
+      const plan = buildWorkflowPlan(await loadInput(options))
+      process.stdout.write(options.format === 'json' ? `${JSON.stringify(plan, null, 2)}\n` : renderMarkdown(plan))
+    }
+  } catch (error) {
+    process.stderr.write(`plan-workflow: ${error.message}\n${usage()}`)
+    process.exitCode = 1
+  }
+}


### PR DESCRIPTION
# 中文

## 摘要

新增顶层 `plugin-workflow` Skill，让用户在运行前选择检查、升级、兼容迁移、测试、命名注册、打包发布和完整生命周期等工作流，并在一个阶段账本中汇总结果。默认仅做只读发现，仓库写入、依赖或运行时执行、外部发布分别确认。

本 PR 采用小提交逐步推送，共分三笔：第一笔加入生命周期路由、功能菜单、所有权路由、确认边界和统一报告契约；第二笔加入机器可校验的选择协议、确定性只读计划器和回归检查；第三笔同步中英文入口文档和 Codex 默认提示。

## 关联 Issue

没有关联 Issue。本变更来自对现有多个独立 DSH 插件 Skill 缺少统一入口和运行前功能选择的改进需求。

## 现状

仓库已有升级、插件编写、测试、发布和 DSH 版本审计 Skill，但使用者需要自行决定调用顺序，也没有共享的阶段状态或统一报告。只运行升级检查时，Docker 冷启动、功能探针、浏览器验证或中央命名注册表查询不会自动进入同一个可审计流程。

## 原因

各项能力的详细规则分别由对应 Skill 持有，这是正确的所有权边界；缺失的是一个只负责选择、排序、授权和汇总的顶层控制器。若把详细规则复制到新入口中，会形成两套容易漂移的实现。

## 实现

- 新增 `plugin-workflow`，提供七种工作流和可选能力菜单。
- 把升级、编写、测试、发布和版本审计阶段路由到现有 owning Skill。
- 使用 `selected`、`completed`、`blocked`、`skipped` 和 `not_applicable` 维护统一阶段账本。
- 将仓库写入、依赖或运行时执行、外部发布划分为三个独立确认边界。
- 增加 Codex `agents/openai.yaml` 接口元数据，并在 Skill 索引中登记入口。
- 增加 `dsh-plugin-workflow/v1` JSON Schema，校验工作流、能力包含/排除、插件表面和新建/已有状态。
- 增加只读 `plan-workflow.mjs`，按依赖顺序补齐硬门禁，拒绝冲突选择，并输出稳定的 JSON 或 Markdown 阶段账本。
- 将计划器专测接入根校验，同时保留上游已有的运行时验证和 Docker smoke tests。
- 在中英文 README 和 Skill 索引中公开统一入口、调用示例和完整安装结构，并给 Codex manifest 增加工作流选择提示。

## 验证

已通过：

- `npm test`
- `npm run validate:workflow`
- `python quick_validate.py skills/plugin-workflow`
- `git diff --check`

`npm test` 在最新上游 `main` 上同时通过 6 个 Skill 的结构检查、manifest 校验、运行时验证器检查和 Docker smoke runner 的 6 个 Node 测试。计划器专测覆盖 schema 同步、确定性默认项、依赖门禁、独立确认边界、CLI 只读性和错误退出；另外直接捕获并解析了一个包含 10 个阶段的 JSON 计划。没有启动真实 Docker 镜像，也没有执行外部发布。

## 证据

- 第一阶段提交：[`bc55f096fbd47dc964a17813cb1ac319ad3915cf`](https://github.com/zp-home/dsh-plugin-upgrade-skill/commit/bc55f096fbd47dc964a17813cb1ac319ad3915cf)
- 第二阶段提交：[`ab40a862d06b7127e93124b9224bbfa909344cc9`](https://github.com/zp-home/dsh-plugin-upgrade-skill/commit/ab40a862d06b7127e93124b9224bbfa909344cc9)
- 第三阶段提交：[`8c96426f28ec0aead0f953d4a57fa351aa930841`](https://github.com/zp-home/dsh-plugin-upgrade-skill/commit/8c96426f28ec0aead0f953d4a57fa351aa930841)

## 限制与剩余风险

计划器只生成初始账本，不执行选中的阶段，也不代替各 owning Skill 更新执行结果。没有运行需要独立代理的前向测试，也没有触发依赖安装、真实容器、浏览器、中央注册或发布操作。

## 发布说明

DSH 插件维护现在有统一的工作流入口，可在执行前选择所需功能，并分别确认代码修改、运行测试和外部发布。

---

# English

## Summary

Add a top-level `plugin-workflow` Skill that lets users choose inspection, upgrade, compatibility migration, testing, naming and registration, packaging and release, or a full lifecycle workflow before execution. Results are tracked in one phase ledger. Discovery is read-only by default, with separate confirmations for repository writes, dependency or runtime execution, and external publication.

This PR is split into three small independently verified commits: the first adds lifecycle routing, the capability menu, ownership routing, confirmation boundaries, and the unified reporting contract; the second adds a machine-validated selection contract, a deterministic read-only planner, and regression checks; the third synchronizes the Chinese and English entry documentation and the Codex default prompt.

## Related Issue

There is no related Issue. This change addresses the missing unified entry point and pre-run capability selection across the existing DSH plugin Skills.

## Current Behavior

The repository already has Skills for upgrades, plugin authoring, testing, releases, and DSH version audits. Users currently have to choose and order them manually, with no shared phase state or unified report. Running an upgrade inspection alone does not automatically place Docker cold starts, functional probes, browser checks, or central naming registry queries in one auditable workflow.

## Root Cause

Detailed rules correctly belong to their existing owning Skills. What was missing was a top-level controller responsible only for selection, ordering, authorization, and aggregation. Copying the detailed rules into the new entry point would create a second implementation that could drift.

## Implementation

- Add `plugin-workflow` with seven workflows and an optional capability menu.
- Route upgrade, authoring, testing, release, and version-audit stages to their existing owning Skills.
- Maintain one phase ledger with `selected`, `completed`, `blocked`, `skipped`, and `not_applicable` states.
- Separate repository writes, dependency or runtime execution, and external publication into independent confirmation boundaries.
- Add Codex `agents/openai.yaml` interface metadata and list the new entry in the Skill index.
- Add a `dsh-plugin-workflow/v1` JSON Schema for workflows, capability inclusion and exclusion, plugin surfaces, and new or existing plugin state.
- Add the read-only `plan-workflow.mjs` planner, which adds required gates in dependency order, rejects conflicting selections, and emits stable JSON or Markdown phase ledgers.
- Integrate focused planner checks into root validation while preserving the upstream runtime verifier and Docker smoke tests.
- Expose the unified entry point, invocation examples, and complete installation structure in both READMEs and the Skill index, and add a workflow-selection prompt to the Codex manifest.

## Verification

Passed:

- `npm test`
- `npm run validate:workflow`
- `python quick_validate.py skills/plugin-workflow`
- `git diff --check`

On the latest upstream `main`, `npm test` passed structural checks for all six Skills, manifest validation, runtime verifier checks, and six Node tests for the Docker smoke runner. Focused planner checks cover schema synchronization, deterministic defaults, dependency gates, separate confirmation boundaries, read-only CLI behavior, and error exits. A 10-phase JSON plan was also captured directly and parsed successfully. No real Docker image was started and no external publication was performed.

## Evidence

- First-stage commit: [`bc55f096fbd47dc964a17813cb1ac319ad3915cf`](https://github.com/zp-home/dsh-plugin-upgrade-skill/commit/bc55f096fbd47dc964a17813cb1ac319ad3915cf)
- Second-stage commit: [`ab40a862d06b7127e93124b9224bbfa909344cc9`](https://github.com/zp-home/dsh-plugin-upgrade-skill/commit/ab40a862d06b7127e93124b9224bbfa909344cc9)
- Third-stage commit: [`8c96426f28ec0aead0f953d4a57fa351aa930841`](https://github.com/zp-home/dsh-plugin-upgrade-skill/commit/8c96426f28ec0aead0f953d4a57fa351aa930841)

## Limits And Residual Risk

The planner creates only the initial ledger. It does not execute selected phases or replace each owning Skill when execution results update the ledger. Forward testing that requires independent agents was not run, and no dependency installation, real container, browser, central registration, or release operation was triggered.

## Release Notes

DSH plugin maintenance now has one workflow entry point where users can select capabilities before execution and confirm code changes, runtime tests, and external publication separately.
