### PR TITLE
feat(plugin-workflow): show a pre-run workflow menu

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -88,6 +88,16 @@ In Claude Code, invoke the skill by name (namespaced once the plugin is installe
 /dsh-plugin-upgrade-skill:plugin-upgrade 0.1.2
 ```
 
+When the unified entry point is invoked without an explicit workflow, it first lists all 7
+workflows and 12 optional capabilities. It recommends the read-only `health-check` but does not
+start it automatically. Reply with a workflow number or ID and add or remove capabilities before
+the phase ledger is created:
+
+```text
+Choose 1
+Choose compatibility-migration, plus docker-smoke and browser-check
+```
+
 You can also ask directly in the conversation (any agent); the skill triggers on its description. Read-only checks return results directly, while upgrades or migrations produce a plan first and wait for confirmation:
 
 ```

--- a/README.md
+++ b/README.md
@@ -93,6 +93,14 @@ Claude Code 中按名字调用 skill（插件安装后带命名空间）：
 /dsh-plugin-upgrade-skill:plugin-upgrade 0.1.2
 ```
 
+首次只调用统一入口、尚未说明目标流程时，它会先列出 7 个工作流程和 12 项可选能力，推荐只读
+`health-check` 但不会自动执行。回复流程编号或名称，并按需增减能力后，它才会生成阶段账本并开始：
+
+```text
+选择 1
+选择 compatibility-migration，加上 docker-smoke 和 browser-check
+```
+
 也可以直接在对话中提问（任意 agent），skill 按描述自动触发；只读检查直接给结果，升级或迁移会先出计划再等确认：
 
 ```

--- a/skills/plugin-workflow/SKILL.md
+++ b/skills/plugin-workflow/SKILL.md
@@ -7,7 +7,30 @@ description: Coordinate the complete DeepSeek Harness plugin lifecycle across in
 
 Act as the workflow controller. Let the user choose outcomes and optional proof before execution, route each selected stage to its owning Skill, preserve one phase ledger, and return one evidence-backed report. Do not copy the detailed rules of an owning Skill into this Skill.
 
-## Start with read-only discovery
+## Show the pre-run menu first
+
+When the user has not explicitly selected a workflow, present the workflow and capability
+tables below before running any phase. Match the user's language, mark `health-check` as the
+recommended first-run choice, and wait for a selection. A recommendation is not a selection:
+do not silently default to `health-check`, start discovery, or execute a capability.
+
+Accept a workflow number, workflow ID, or unambiguous natural-language outcome. Let the user
+add or remove capabilities in the same reply, for example `3 + docker-smoke + browser-check`.
+Briefly identify which selected capabilities are read-only and which will later cross a
+confirmation boundary.
+
+The bundled planner renders the same deterministic menu and remains read-only:
+
+```sh
+node <plugin-workflow-skill>/scripts/plan-workflow.mjs
+# Equivalent explicit form:
+node <plugin-workflow-skill>/scripts/plan-workflow.mjs --menu
+```
+
+If the user already selected an outcome and supplied enough context, preserve that choice and
+continue without showing the menu again.
+
+## Continue with read-only discovery
 
 Inspect only enough context to make the choices concrete:
 
@@ -15,8 +38,6 @@ Inspect only enough context to make the choices concrete:
 2. Identify whether the target is the DSH monorepo, an external plugin source repository, an installed plugin, or a packed artifact.
 3. Record the plugin source identity, current DSH version, requested target version, package manager, available scripts, plugin surfaces, and existing naming declaration.
 4. Mark missing inputs as `unknown`. Do not install dependencies, run package scripts, start containers, edit files, or query a remote registry during discovery.
-
-If the user has already selected an outcome and supplied enough context, preserve that choice instead of asking again. Otherwise present the following compact menu and wait for selection. Default to `health-check` when the request is ambiguous.
 
 ## Choose one workflow
 
@@ -47,7 +68,7 @@ Then let the user include or exclude these capabilities. Recommend the smallest 
 | Build and inspect a package artifact | `package-artifact` | On for package/release and full lifecycle workflows |
 | Publish an artifact or release | `release` | Off unless external release intent is explicit |
 
-For a repeatable plan, normalize the selection with the bundled read-only planner. Read [`references/workflow-selection.schema.json`](references/workflow-selection.schema.json) when another tool needs to produce the input JSON.
+After the user chooses, normalize the selection with the bundled read-only planner. Read [`references/workflow-selection.schema.json`](references/workflow-selection.schema.json) when another tool needs to produce the input JSON.
 
 ```sh
 node <plugin-workflow-skill>/scripts/plan-workflow.mjs \
@@ -57,7 +78,7 @@ node <plugin-workflow-skill>/scripts/plan-workflow.mjs \
   --surface ordinary-plugin
 ```
 
-Use `--format json` for automation, or `--selection <selection.json>` for a persisted input that follows the schema. The planner validates conflicts and required dependencies, emits deterministic phase IDs and confirmation boundaries, and never executes the selected phases. Treat its output as the initial ledger, not as user approval.
+Use `--format json` for automation, or `--selection <selection.json>` for a persisted input that follows the schema. Calling the planner without a selection prints the menu instead of creating a default plan. The planner validates conflicts and required dependencies, emits deterministic phase IDs and confirmation boundaries, and never executes the selected phases. Treat its output as the initial ledger, not as user approval.
 
 Do not treat `registry-query` as a reservation. Do not treat `registry-register` as required for local plugin use. A local plugin and the central registry may share a display name; only concrete identifiers on the same runtime surface can conflict, and the naming owner must report those exact matches.
 

--- a/skills/plugin-workflow/scripts/plan-workflow.check.mjs
+++ b/skills/plugin-workflow/scripts/plan-workflow.check.mjs
@@ -8,7 +8,9 @@ import {
   CAPABILITY_IDS,
   SELECTION_SCHEMA_VERSION,
   WORKFLOW_IDS,
+  buildWorkflowMenu,
   buildWorkflowPlan,
+  renderMenuMarkdown,
   renderMarkdown,
   validateSelection,
 } from './plan-workflow.mjs'
@@ -46,6 +48,17 @@ export async function runWorkflowPlannerChecks() {
   const schema = JSON.parse(await readFile(schemaPath, 'utf8'))
   assert.deepEqual(WORKFLOW_IDS, schema.properties.workflow.enum)
   assert.deepEqual(CAPABILITY_IDS, schema.$defs.capability.enum)
+
+  const menu = buildWorkflowMenu()
+  assert.equal(menu.readOnly, true)
+  assert.equal(menu.requiresSelection, true)
+  assert.equal(menu.recommendedWorkflow, 'health-check')
+  assert.deepEqual(menu.workflows.map((workflow) => workflow.id), WORKFLOW_IDS)
+  assert.deepEqual(menu.capabilities.map((capability) => capability.id), CAPABILITY_IDS)
+  const menuMarkdown = renderMenuMarkdown(menu)
+  assert.match(menuMarkdown, /workflow menu \(read-only\)/)
+  assert.match(menuMarkdown, /recommended for first run/)
+  assert.match(menuMarkdown, /No discovery, install, test, repository write, or publication has started/)
 
   const health = buildWorkflowPlan(selection())
   assert.equal(health.readOnly, true)
@@ -107,6 +120,23 @@ export async function runWorkflowPlannerChecks() {
 
   const tempRoot = await mkdtemp(join(tmpdir(), 'dsh-workflow-plan-'))
   try {
+    const noArgs = await runCli([])
+    assert.equal(noArgs.code, 0, noArgs.stderr)
+    assert.match(noArgs.stdout, /workflow menu \(read-only\)/)
+    assert.doesNotMatch(noArgs.stdout, /Phase ledger/)
+
+    const menuJson = await runCli(['--menu', '--format', 'json'])
+    assert.equal(menuJson.code, 0, menuJson.stderr)
+    assert.equal(JSON.parse(menuJson.stdout).requiresSelection, true)
+
+    const explicitHealth = await runCli(['--workflow', 'health-check', '--format', 'json'])
+    assert.equal(explicitHealth.code, 0, explicitHealth.stderr)
+    assert.deepEqual(JSON.parse(explicitHealth.stdout).ledger.map((phase) => phase.capability), ['discovery', 'touchpoint-scan'])
+
+    const capabilityWithoutWorkflow = await runCli(['--include', 'docker-smoke'])
+    assert.equal(capabilityWithoutWorkflow.code, 1)
+    assert.match(capabilityWithoutWorkflow.stderr, /select a workflow with --workflow/)
+
     const inputPath = join(tempRoot, 'selection.json')
     const input = selection({ workflow: 'test-only', include: ['functional-probe'] })
     await writeFile(inputPath, `${JSON.stringify(input, null, 2)}\n`, 'utf8')
@@ -128,5 +158,5 @@ export async function runWorkflowPlannerChecks() {
 const invokedPath = process.argv[1] ? pathToFileURL(resolve(process.argv[1])).href : undefined
 if (invokedPath === import.meta.url) {
   await runWorkflowPlannerChecks()
-  console.log('Workflow planner checks OK: schema sync, deterministic defaults, dependency gates, confirmations, read-only CLI')
+  console.log('Workflow planner checks OK: pre-run menu, schema sync, explicit selections, dependency gates, confirmations, read-only CLI')
 }

--- a/skills/plugin-workflow/scripts/plan-workflow.mjs
+++ b/skills/plugin-workflow/scripts/plan-workflow.mjs
@@ -15,44 +15,52 @@ export const PLUGIN_STATES = Object.freeze([...selectionSchema.properties.plugin
 
 const WORKFLOWS = {
   'health-check': {
+    outcome: 'Read-only plugin and upgrade-risk report',
     defaults: ['touchpoint-scan'],
   },
   'upgrade-target': {
+    outcome: 'Upgrade an installed plugin to an explicit version',
     defaults: ['static-tests', 'rollback'],
     core: { capability: 'upgrade-installed', owner: 'plugin-upgrade', confirmations: ['repository-writes', 'dependency-runtime'] },
   },
   'compatibility-migration': {
+    outcome: 'Adapt plugin source to an exact DSH target',
     defaults: ['dsh-audit', 'touchpoint-scan', 'static-tests', 'docker-smoke', 'functional-probe', 'rollback'],
     core: { capability: 'source-migration', owner: 'plugin-upgrade', confirmations: ['repository-writes'] },
   },
   'test-only': {
+    outcome: 'Validate an existing source tree or artifact',
     defaults: ['static-tests'],
   },
   'naming-registry': {
+    outcome: 'Validate identifiers and optionally check or register a cloud ID',
     defaults: ['naming-local'],
   },
   'package-release': {
+    outcome: 'Prepare and optionally publish a release',
     defaults: ['static-tests', 'docker-smoke', 'functional-probe', 'rollback', 'package-artifact'],
   },
   'full-lifecycle': {
+    outcome: 'Migrate, validate, name, package, and optionally publish',
     defaults: ['dsh-audit', 'touchpoint-scan', 'static-tests', 'docker-smoke', 'functional-probe', 'rollback', 'package-artifact'],
     core: { capability: 'source-migration', owner: 'plugin-upgrade', confirmations: ['repository-writes'] },
   },
 }
 
 const CAPABILITIES = {
-  'dsh-audit': { owner: 'dsh-upgrade-audit', confirmations: [] },
-  'touchpoint-scan': { owner: 'plugin-upgrade', confirmations: [] },
-  'naming-local': { owner: 'plugin-write', confirmations: [] },
-  'registry-query': { owner: 'plugin-write', confirmations: [], requires: ['naming-local'] },
-  'static-tests': { owner: 'plugin-test', confirmations: ['dependency-runtime'] },
-  'docker-smoke': { owner: 'plugin-test', confirmations: ['dependency-runtime'] },
-  'functional-probe': { owner: 'plugin-test', confirmations: ['dependency-runtime'] },
-  'browser-check': { owner: 'plugin-test', confirmations: ['dependency-runtime'] },
-  rollback: { owner: 'plugin-upgrade', confirmations: [] },
-  'package-artifact': { owner: 'plugin-release', confirmations: ['dependency-runtime'], requires: ['static-tests'] },
-  'registry-register': { owner: 'plugin-write', confirmations: ['external-publication'], requires: ['registry-query'] },
+  'dsh-audit': { description: 'DSH version compatibility audit', owner: 'dsh-upgrade-audit', confirmations: [] },
+  'touchpoint-scan': { description: 'Seven-touchpoint plugin scan', owner: 'plugin-upgrade', confirmations: [] },
+  'naming-local': { description: 'Offline naming declaration validation', owner: 'plugin-write', confirmations: [] },
+  'registry-query': { description: 'Central cloud registry lookup', owner: 'plugin-write', confirmations: [], requires: ['naming-local'] },
+  'static-tests': { description: 'Typecheck, unit tests, and build', owner: 'plugin-test', confirmations: ['dependency-runtime'] },
+  'docker-smoke': { description: 'Exact-version Docker cold start', owner: 'plugin-test', confirmations: ['dependency-runtime'] },
+  'functional-probe': { description: 'One real functional path', owner: 'plugin-test', confirmations: ['dependency-runtime'] },
+  'browser-check': { description: 'Browser validation for Web Client surfaces', owner: 'plugin-test', confirmations: ['dependency-runtime'] },
+  rollback: { description: 'Rollback rehearsal or recipe', owner: 'plugin-upgrade', confirmations: [] },
+  'package-artifact': { description: 'Build and inspect a package artifact', owner: 'plugin-release', confirmations: ['dependency-runtime'], requires: ['static-tests'] },
+  'registry-register': { description: 'Central cloud ID registration', owner: 'plugin-write', confirmations: ['external-publication'], requires: ['registry-query'] },
   release: {
+    description: 'Publish an artifact or release',
     owner: 'plugin-release',
     confirmations: ['external-publication'],
     requires: ['package-artifact', 'functional-probe', 'rollback'],
@@ -238,6 +246,73 @@ function escapeCell(value) {
   return String(value).replaceAll('|', '\\|')
 }
 
+export function buildWorkflowMenu() {
+  return {
+    schemaVersion: SELECTION_SCHEMA_VERSION,
+    readOnly: true,
+    requiresSelection: true,
+    recommendedWorkflow: 'health-check',
+    workflows: WORKFLOW_IDS.map((id, index) => ({
+      choice: index + 1,
+      id,
+      outcome: WORKFLOWS[id].outcome,
+      defaultCapabilities: [...WORKFLOWS[id].defaults],
+    })),
+    capabilities: CAPABILITY_IDS.map((id) => ({
+      id,
+      description: CAPABILITIES[id].description,
+      owner: CAPABILITIES[id].owner,
+      confirmations: [...CAPABILITIES[id].confirmations],
+      defaultFor: WORKFLOW_IDS.filter((workflow) => WORKFLOWS[workflow].defaults.includes(id)),
+    })),
+    replyExamples: [
+      'health-check',
+      '3 + docker-smoke + browser-check',
+      'compatibility-migration, exclude browser-check',
+    ],
+  }
+}
+
+export function renderMenuMarkdown(menu = buildWorkflowMenu()) {
+  const lines = [
+    '# DSH plugin workflow menu (read-only)',
+    '',
+    'No workflow has been selected. Choose one workflow and optionally add or remove capabilities.',
+    '',
+    '## Workflows',
+    '',
+    '| Choice | Workflow | Outcome | Default capabilities |',
+    '|---:|---|---|---|',
+  ]
+  for (const workflow of menu.workflows) {
+    const recommendation = workflow.id === menu.recommendedWorkflow ? ' (recommended for first run)' : ''
+    const defaults = workflow.defaultCapabilities.map((id) => `\`${id}\``).join(', ') || 'none'
+    lines.push(`| ${workflow.choice} | \`${escapeCell(workflow.id)}\`${recommendation} | ${escapeCell(workflow.outcome)} | ${defaults} |`)
+  }
+
+  lines.push(
+    '',
+    '## Optional capabilities',
+    '',
+    '| Capability | Purpose | Owner | Later confirmation |',
+    '|---|---|---|---|',
+  )
+  for (const capability of menu.capabilities) {
+    const confirmations = capability.confirmations.map((id) => BOUNDARY_LABELS[id]).join(', ') || 'none (read-only)'
+    lines.push(`| \`${escapeCell(capability.id)}\` | ${escapeCell(capability.description)} | \`$${escapeCell(capability.owner)}\` | ${escapeCell(confirmations)} |`)
+  }
+
+  lines.push(
+    '',
+    '## Reply with a selection',
+    '',
+    ...menu.replyExamples.map((example) => `- \`${example}\``),
+    '',
+    'Showing this menu is read-only. No discovery, install, test, repository write, or publication has started.',
+  )
+  return `${lines.join('\n')}\n`
+}
+
 export function renderMarkdown(plan) {
   const selected = plan.capabilities.filter((entry) => entry.selected)
   const excluded = plan.capabilities.filter((entry) => entry.source === 'user-exclude')
@@ -274,7 +349,7 @@ function splitList(value) {
 }
 
 function usage() {
-  return `Usage:\n  node skills/plugin-workflow/scripts/plan-workflow.mjs --workflow <id> [--include a,b] [--exclude a,b] [--surface a,b] [--plugin-state existing|new] [--format markdown|json]\n  node skills/plugin-workflow/scripts/plan-workflow.mjs --selection <selection.json> [--format markdown|json]\n\nThe command is read-only. It creates a plan but never executes a selected phase.\n`
+  return `Usage:\n  node skills/plugin-workflow/scripts/plan-workflow.mjs [--menu] [--format markdown|json]\n  node skills/plugin-workflow/scripts/plan-workflow.mjs --workflow <id> [--include a,b] [--exclude a,b] [--surface a,b] [--plugin-state existing|new] [--format markdown|json]\n  node skills/plugin-workflow/scripts/plan-workflow.mjs --selection <selection.json> [--format markdown|json]\n\nWith no selection, the command prints the pre-run menu. It is read-only and never executes a selected phase.\n`
 }
 
 function parseArgs(argv) {
@@ -282,6 +357,10 @@ function parseArgs(argv) {
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index]
     if (arg === '--help' || arg === '-h') return { help: true }
+    if (arg === '--menu') {
+      options.menu = true
+      continue
+    }
     const value = argv[++index]
     if (value === undefined) throw new Error(`missing value for ${arg}`)
     if (arg === '--workflow') options.workflow = value
@@ -294,6 +373,10 @@ function parseArgs(argv) {
     else throw new Error(`unknown option: ${arg}`)
   }
   if (!['json', 'markdown'].includes(options.format)) throw new Error('--format must be markdown or json')
+  const hasInlineSelection = ['workflow', 'include', 'exclude', 'surfaces', 'pluginState'].some((key) => options[key] !== undefined)
+  if (options.menu && (options.selectionPath || hasInlineSelection)) {
+    throw new Error('--menu cannot be combined with a workflow selection')
+  }
   if (options.selectionPath && ['workflow', 'include', 'exclude', 'surfaces', 'pluginState'].some((key) => options[key] !== undefined)) {
     throw new Error('--selection cannot be combined with inline selection options')
   }
@@ -302,9 +385,10 @@ function parseArgs(argv) {
 
 async function loadInput(options) {
   if (options.selectionPath) return JSON.parse(await new Promise((accept, reject) => readFile(resolve(options.selectionPath), 'utf8', (error, data) => error ? reject(error) : accept(data))))
+  if (!options.workflow) throw new Error('select a workflow with --workflow before creating a plan')
   return {
     schemaVersion: SELECTION_SCHEMA_VERSION,
-    workflow: options.workflow ?? 'health-check',
+    workflow: options.workflow,
     include: options.include ?? [],
     exclude: options.exclude ?? [],
     surfaces: options.surfaces ?? ['ordinary-plugin'],
@@ -319,8 +403,18 @@ if (invokedPath === import.meta.url) {
     if (options.help) {
       process.stdout.write(usage())
     } else {
-      const plan = buildWorkflowPlan(await loadInput(options))
-      process.stdout.write(options.format === 'json' ? `${JSON.stringify(plan, null, 2)}\n` : renderMarkdown(plan))
+      const hasSelectionDetails = ['include', 'exclude', 'surfaces', 'pluginState'].some((key) => options[key] !== undefined)
+      if (!options.menu && !options.selectionPath && !options.workflow && hasSelectionDetails) {
+        throw new Error('select a workflow with --workflow before adding selection details')
+      }
+      const hasSelection = options.selectionPath || options.workflow
+      if (options.menu || !hasSelection) {
+        const menu = buildWorkflowMenu()
+        process.stdout.write(options.format === 'json' ? `${JSON.stringify(menu, null, 2)}\n` : renderMenuMarkdown(menu))
+      } else {
+        const plan = buildWorkflowPlan(await loadInput(options))
+        process.stdout.write(options.format === 'json' ? `${JSON.stringify(plan, null, 2)}\n` : renderMarkdown(plan))
+      }
     }
   } catch (error) {
     process.stderr.write(`plan-workflow: ${error.message}\n${usage()}`)


### PR DESCRIPTION
# 中文

## 摘要

改进 `plugin-workflow` 的首次使用体验：当用户尚未明确选择工作流时，统一入口先展示 7 个工作流程、12 项可选能力、默认能力、负责 Skill 和后续确认边界，然后等待用户选择。`health-check` 仍作为新手推荐项，但不再被静默执行。

显式传入 `--workflow` 或选择文件时，原有阶段账本行为保持不变。

## 关联 Issue

没有关联 Issue。本改进来自首次使用统一入口时，功能菜单容易被默认 `health-check` 跳过的实际反馈。已检查现有开放 Issue 和 PR，未发现重叠实现；本 PR 是已合并 #87 的后续体验改进。

## 复现

变更前，无参数运行：

```text
node skills/plugin-workflow/scripts/plan-workflow.mjs
```

规划器会直接使用 `health-check` 默认值并生成阶段账本。用户在执行前看不到完整工作流与能力选择，也不容易区分“推荐”与“已经选择”。

变更后，同一命令只输出只读菜单，并明确说明尚未开始 discovery、安装、测试、仓库写入或发布。只有明确选择工作流后才创建计划。

## 根因

`SKILL.md` 一方面要求请求不明确时展示菜单并等待，另一方面又允许默认进入 `health-check`；规划器对缺失 workflow 的空值回退进一步固化了这个冲突。结果是统一入口具备选择模型，但首次调用可能绕过选择阶段。

## 修复

- 将“先展示运行前菜单”设为统一入口的明确首要规则。
- 无参数或 `--menu` 时输出确定性的 Markdown 菜单；`--format json` 输出同构数据。
- 菜单列出全部工作流、能力、owning Skill、默认能力和基础确认边界。
- 支持编号、工作流 ID 和自然语言选择示例。
- 未选择工作流却传入 `--include`、`--exclude`、surface 或 plugin state 时明确报错，避免静默忽略参数。
- 保留显式 `--workflow` 和 `--selection` 的既有计划输出。
- 同步中英文 README 的首次使用说明。

主要优势：

- **更容易发现能力**：新用户不需要先阅读整个仓库，就能看到 7 个流程和 12 项能力。
- **更安全**：推荐项不等于授权，不会在用户选择前启动任何阶段。
- **更透明**：能力负责人和后续写入、运行、发布确认边界在执行前可见。
- **更适合自动化**：同一菜单提供稳定 Markdown 与 JSON 输出。
- **保持兼容**：已经明确工作流的调用方式和阶段账本没有改变。

## 范围检查

- [x] 已检查现有 Issue 和 PR；没有开放的重叠实现，#87 已合并。
- [x] 本变更不包含 DSH 版本专属事实，不需要 tag、commit 或一手版本来源。
- [x] 本变更不修改迁移卡，因此没有 `#1`-`#7` 触点或卡片 ID。
- [x] Host、Web Client 和普通插件 surface 选择保持独立且行为不变。

## 验证

已通过：

```text
npm test
node skills/plugin-workflow/scripts/plan-workflow.check.mjs
node --input-type=module -e "import { buildWorkflowMenu } from './skills/plugin-workflow/scripts/plan-workflow.mjs'; ..."
git diff --check
```

`npm test` 覆盖全部 6 个 Skill 的结构与 manifest 校验、20 个 benchmark 任务注册校验、15 个任务注册测试、运行时验证器检查和 6 个 Docker smoke runner 单元测试。工作流专测覆盖无参数菜单、`--menu --format json`、显式 `health-check` 账本、缺少工作流时拒绝能力参数，以及原有依赖和确认边界。

一个额外的 PowerShell 管道 JSON 断言因 Windows 管道在输入前加入 U+FEFF BOM 而无法解析；该命令未作为通过证据。随后改用 Node 直接导入同一菜单构造函数，确认 7 个工作流、12 项能力和 `requiresSelection: true`，验证通过。

## 证据

- 固定提交：[`5c74583f65df030da242f35656ab60d56888c534`](https://github.com/zp-home/dsh-plugin-upgrade-skill/commit/5c74583f65df030da242f35656ab60d56888c534)

## 限制与剩余风险

- CLI 的确定性菜单目前使用英文；交互式 Skill 明确要求匹配用户语言。
- 没有启动真实 Docker、浏览器、DSH profile、中央注册或发布流程，因为本变更只影响执行前选择和只读规划器。
- 菜单展示基础确认边界；插件新建状态等上下文相关边界仍由用户选择后的阶段账本精确计算。

## 发布说明

首次运行 DSH 插件统一工作流时，现在会先展示完整流程与能力菜单并等待选择，不再自动进入推荐的健康检查。

---

# English

## Summary

Improve the first-run experience of `plugin-workflow`. When no workflow has been selected, the unified entry point now shows all 7 workflows, 12 optional capabilities, workflow defaults, owning Skills, and later confirmation boundaries before waiting for a choice. `health-check` remains the recommended first-run option, but it is no longer selected or executed silently.

Existing phase-ledger behavior remains unchanged when `--workflow` or a selection file is supplied explicitly.

## Related Issue

There is no related Issue. This follows direct first-run feedback that the capability menu could be skipped by the implicit `health-check` default. Existing open Issues and PRs were checked and no overlapping implementation was found. This PR is a focused usability follow-up to merged PR #87.

## Reproduction

Before this change, running the planner without arguments:

```text
node skills/plugin-workflow/scripts/plan-workflow.mjs
```

immediately applied the `health-check` default and emitted a phase ledger. Users did not see the complete workflow and capability choices first, and the distinction between a recommendation and a selection was unclear.

After this change, the same command emits only the read-only menu and states that discovery, installation, testing, repository writes, and publication have not started. A plan is created only after an explicit workflow selection.

## Root Cause

`SKILL.md` required the controller to show a menu and wait when intent was ambiguous, but also allowed it to default to `health-check`. The planner reinforced that conflict with a nullish fallback for a missing workflow. The selection model existed, but the first invocation could bypass it.

## Fix

- Make the pre-run menu the explicit first rule of the unified entry point.
- Emit a deterministic Markdown menu with no arguments or `--menu`, with equivalent data from `--format json`.
- List every workflow, capability, owning Skill, workflow default, and base confirmation boundary.
- Document number, workflow ID, and natural-language selection examples.
- Reject capability, surface, or plugin-state details when no workflow is selected instead of silently ignoring them.
- Preserve existing plan output for explicit `--workflow` and `--selection` calls.
- Synchronize the Chinese and English first-run documentation.

Key advantages:

- **Better discoverability**: new users see all 7 workflows and 12 capabilities without reading the full repository first.
- **Safer intent handling**: a recommendation is not authorization, so no phase starts before the user chooses.
- **Earlier transparency**: ownership and later write, runtime, and publication boundaries are visible before execution.
- **Automation-friendly output**: the same menu has stable Markdown and JSON representations.
- **Backward compatibility**: explicit workflow calls and their phase ledgers retain their existing behavior.

## Scope Checklist

- [x] Existing Issues and PRs were checked; there is no open overlap and PR #87 is merged.
- [x] This change makes no DSH-version-specific claims, so exact version tags and first-party version sources are not applicable.
- [x] No migration cards are changed, so touchpoints `#1`-`#7` and card IDs are not applicable.
- [x] Host, Web Client, and ordinary plugin surface choices remain distinct and unchanged.

## Verification

Passed:

```text
npm test
node skills/plugin-workflow/scripts/plan-workflow.check.mjs
node --input-type=module -e "import { buildWorkflowMenu } from './skills/plugin-workflow/scripts/plan-workflow.mjs'; ..."
git diff --check
```

`npm test` covered structural and manifest validation for all 6 Skills, the 20-task benchmark registry, 15 task-registry tests, runtime verifier checks, and 6 Docker smoke-runner unit tests. Focused workflow tests cover the no-argument menu, `--menu --format json`, the explicit `health-check` ledger, rejection of capability options without a workflow, and the existing dependency and confirmation gates.

One additional PowerShell-pipeline JSON assertion was environment-limited because the Windows pipeline prepended a U+FEFF BOM. It is not reported as passing evidence. The equivalent assertion was rerun by importing the menu builder directly in Node and passed with 7 workflows, 12 capabilities, and `requiresSelection: true`.

## Evidence

- Pinned commit: [`5c74583f65df030da242f35656ab60d56888c534`](https://github.com/zp-home/dsh-plugin-upgrade-skill/commit/5c74583f65df030da242f35656ab60d56888c534)

## Limits And Residual Risk

- The deterministic CLI menu is currently English; interactive Skill instructions require matching the user's language.
- No real Docker container, browser, DSH profile, central registration, or publication flow was started because this change affects only pre-run selection and the read-only planner.
- The menu shows base confirmation boundaries. Context-dependent boundaries, such as new-plugin naming writes, are resolved precisely in the phase ledger after selection.

## Release Notes

The DSH plugin workflow now shows the complete workflow and capability menu before the first run and waits for an explicit selection instead of automatically entering the recommended health check.
