### PR TITLE
feat(benchmark): add real browser activation trap

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -11,7 +11,7 @@
 - **30 upgrade cards** — each records one real pitfall: what breaks, why, how to fix it, and which version the information comes from. Ordered by version, from 0.1.1 all the way to 0.1.2-alpha.2.
 - **12 general-purpose countermeasures** — some problems have nothing to do with the version (back up first, run old and new side by side, what to do when startup hangs). These live in one checklist.
 - **6 skills** — one unified workflow selects and coordinates stages, while the other five check upgrades, write plugins, test plugins, release plugins, and diff two dsh versions.
-- **21 exam questions (benchmark)** — tests whether an AI with our skill actually knows how to upgrade a plugin. Every question is auto-graded; one reproduces the real dsh-web v0.3.8 → v0.3.9 migration.
+- **23 exam questions (benchmark)** — tests whether an AI with our skill actually knows how to upgrade a plugin. Every question is auto-graded; one reproduces the real dsh-web v0.3.8 → v0.3.9 migration.
 - **Multiple validation reports** — we installed two real dsh versions in Docker and confirmed that following the cards really does fix plugins, followed by several rounds of agent benchmark runs.
 
 ## Quick Start
@@ -130,7 +130,7 @@ Upgrade the dsh-ads plugin to dsh-v0.1.2-alpha.2
 
 ## The exam (benchmark)
 
-The [benchmark/](benchmark/) folder has 21 upgrade exam questions with auto-grading, in [Harbor](https://github.com/harbor-framework/harbor) task format: each question is a self-contained task (its own container with dsh preinstalled, plus an automatic verifier). Run `harbor run -p benchmark/tasks/<task-id> -a <agent>` to get a 0–1 score. Run the same AI twice — once with this skill installed, once without — and the score difference is the skill's real effect. See [benchmark/README.md](benchmark/README.md) for details. Seven validation reports sit in the same folder: [validation-report-2026-08-30.md](benchmark/validation-report-2026-08-30.md) (the earlier migration/benchmark validation record), [validation-report-2026-08-31.md](benchmark/validation-report-2026-08-31.md) (end-to-end validation after the Harbor format rework), [validation-report-2026-08-31-auth-v1.md](benchmark/validation-report-2026-08-31-auth-v1.md) (BENCHMARK-AUTH-v1 unattended-authorization validation), and four 2026-09-01 Codex + `gpt-5.6-luna` runs ([18-task batch with the skill](benchmark/validation-report-2026-09-01-codex-gpt-5.6-luna-other-18.md), [18-task batch with no Harbor-injected skill](benchmark/validation-report-2026-09-01-codex-gpt-5.6-luna-other-18-no-injected-skill.md), [real-repository task with the skill](benchmark/validation-report-2026-09-01.md), [real-repository task with no Harbor-injected skill](benchmark/validation-report-2026-09-01-h8-dsh-web-alpha2-no-skill.md)).
+The [benchmark/](benchmark/) folder has 23 upgrade exam questions with auto-grading, in [Harbor](https://github.com/harbor-framework/harbor) task format: each question is a self-contained task (its own container with dsh preinstalled, plus an automatic verifier). Run `harbor run -p benchmark/tasks/<task-id> -a <agent>` to get a 0–1 score. Run the same AI twice — once with this skill installed, once without — and the score difference is the skill's real effect. See [benchmark/README.md](benchmark/README.md) for details. Seven validation reports sit in the same folder: [validation-report-2026-08-30.md](benchmark/validation-report-2026-08-30.md) (the earlier migration/benchmark validation record), [validation-report-2026-08-31.md](benchmark/validation-report-2026-08-31.md) (end-to-end validation after the Harbor format rework), [validation-report-2026-08-31-auth-v1.md](benchmark/validation-report-2026-08-31-auth-v1.md) (BENCHMARK-AUTH-v1 unattended-authorization validation), and four 2026-09-01 Codex + `gpt-5.6-luna` runs ([18-task batch with the skill](benchmark/validation-report-2026-09-01-codex-gpt-5.6-luna-other-18.md), [18-task batch with no Harbor-injected skill](benchmark/validation-report-2026-09-01-codex-gpt-5.6-luna-other-18-no-injected-skill.md), [real-repository task with the skill](benchmark/validation-report-2026-09-01.md), [real-repository task with no Harbor-injected skill](benchmark/validation-report-2026-09-01-h8-dsh-web-alpha2-no-skill.md)).
 
 ## References
 
@@ -164,7 +164,7 @@ skills/<skill-name>/
 └── examples/       # example code (read-only, do not run)
 scripts/validate.mjs            # repo self-check
 scripts/validate-manifests.mjs  # multi-agent manifest self-check
-benchmark/                      # 21 exam questions + grader + validation report
+benchmark/                      # 23 exam questions + grader + validation report
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 - **30 张升级说明卡**：每张卡记录一个真实的坑——什么坏了、为什么坏、怎么修、信息来源是哪个版本。按版本排好序，从 0.1.1 一路到 0.1.2-alpha.2。
 - **12 条通用对策**：有些坑和版本无关（比如"先备份再动手""新旧版本怎么共存"），这些写成了一份对策清单。
 - **6 个 skill**：一个统一工作流负责选择和编排，另外五个分别负责查升级、写新插件、测插件、发插件和对比两个版本的差别。
-- **21 道考题（benchmark）**：用来测"AI 装了我们的 skill 之后到底会不会升级插件"，每道题都有自动判分；其中包含 dsh-web v0.3.8 → v0.3.9 的真实迁移。
+- **23 道考题（benchmark）**：用来测"AI 装了我们的 skill 之后到底会不会升级插件"，每道题都有自动判分；其中包含 dsh-web v0.3.8 → v0.3.9 的真实迁移。
 - **多份验证报告**：我们在 docker 里真的装了两个版本的 dsh，验证了"按卡片做就能修好插件"；此后又用 Codex 等 agent 做了多轮 benchmark 实测。
 
 ## 快速开始
@@ -133,7 +133,7 @@ Claude Code 中按名字调用 skill（插件安装后带命名空间）：
 
 ## 考题（benchmark）
 
-[benchmark/](benchmark/) 目录下有 21 道升级考题和自动判分，采用 [Harbor](https://github.com/harbor-framework/harbor) 任务格式：每题一个自包含任务（自带 dsh 环境的容器 + 自动 verifier），`harbor run -p benchmark/tasks/<题号> -a <agent>` 即可出 0~1 分。同一只 AI 装 skill 做一遍、不装做一遍，分差就是 skill 的实际效果。详见 [benchmark/README.md](benchmark/README.md)。同目录还有多份验证报告：[validation-report-2026-08-30.md](benchmark/validation-report-2026-08-30.md)（此前的迁移/benchmark 验证记录）、[validation-report-2026-08-31.md](benchmark/validation-report-2026-08-31.md)（Harbor 格式改造后的端到端验证）、[validation-report-2026-08-31-auth-v1.md](benchmark/validation-report-2026-08-31-auth-v1.md)（BENCHMARK-AUTH-v1 无人值守授权验证），以及四份 2026-09-01 的 Codex + `gpt-5.6-luna` 实测报告（[带 skill 的其余 18 题](benchmark/validation-report-2026-09-01-codex-gpt-5.6-luna-other-18.md)、[不带 skill 的其余 18 题](benchmark/validation-report-2026-09-01-codex-gpt-5.6-luna-other-18-no-injected-skill.md)、[带 skill 的真实仓库题](benchmark/validation-report-2026-09-01.md)、[不带 skill 的真实仓库题](benchmark/validation-report-2026-09-01-h8-dsh-web-alpha2-no-skill.md)）。
+[benchmark/](benchmark/) 目录下有 23 道升级考题和自动判分，采用 [Harbor](https://github.com/harbor-framework/harbor) 任务格式：每题一个自包含任务（自带 dsh 环境的容器 + 自动 verifier），`harbor run -p benchmark/tasks/<题号> -a <agent>` 即可出 0~1 分。同一只 AI 装 skill 做一遍、不装做一遍，分差就是 skill 的实际效果。详见 [benchmark/README.md](benchmark/README.md)。同目录还有多份验证报告：[validation-report-2026-08-30.md](benchmark/validation-report-2026-08-30.md)（此前的迁移/benchmark 验证记录）、[validation-report-2026-08-31.md](benchmark/validation-report-2026-08-31.md)（Harbor 格式改造后的端到端验证）、[validation-report-2026-08-31-auth-v1.md](benchmark/validation-report-2026-08-31-auth-v1.md)（BENCHMARK-AUTH-v1 无人值守授权验证），以及四份 2026-09-01 的 Codex + `gpt-5.6-luna` 实测报告（[带 skill 的其余 18 题](benchmark/validation-report-2026-09-01-codex-gpt-5.6-luna-other-18.md)、[不带 skill 的其余 18 题](benchmark/validation-report-2026-09-01-codex-gpt-5.6-luna-other-18-no-injected-skill.md)、[带 skill 的真实仓库题](benchmark/validation-report-2026-09-01.md)、[不带 skill 的真实仓库题](benchmark/validation-report-2026-09-01-h8-dsh-web-alpha2-no-skill.md)）。
 
 ## 参考资源
 
@@ -167,7 +167,7 @@ skills/<skill-name>/
 └── examples/       # 示例代码（只读，不要运行）
 scripts/validate.mjs            # 仓库自检
 scripts/validate-manifests.mjs  # 多 agent 清单自检
-benchmark/                      # 21 道考题 + 判分 + 验证报告
+benchmark/                      # 23 道考题 + 判分 + 验证报告
 ```
 
 ## 想贡献？

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,8 +1,8 @@
 # dsh plugin upgrade tasks (benchmark v2.3 · Harbor format)
 
-The 22 plugin-upgrade tasks measure one thing: **once an AI has our upgrade skill
+The 23 plugin-upgrade tasks measure one thing: **once an AI has our upgrade skill
 installed, will it actually upgrade the plugin**. The first 10 are written exams (read
-the code, produce the answer); the last 12 are hands-on (actually install dsh and run
+the code, produce the answer); the last 13 are hands-on (actually install dsh and run
 the plugin — whether it is alive is obvious at a glance). Every task ships with
 auto-grading, so no human marking is involved.
 
@@ -31,6 +31,7 @@ honestly instead of quietly fixing it and pretending nothing happened).
 | M5-token-auth-smoke | Hands-on | The plugin's self-built /ping channel answers with no host authentication: does it move the registration behind the host's unified token/cookie auth and prove it with a browserless 401/200 smoke |
 | H8-fire-drill | Hands-on | One release, three plugins with three different trap states (legacy host plane with a "switch to remote" bait, a naked /ping channel, an unpublished dependency cohort) plus a fake "publish --force" procedure: can it run the full diagnose → fix → deploy → release drill in order, with a browserless token smoke and correct release gates |
 | H9-dsh-web-alpha2 | Hands-on | Can it migrate the real dsh-web v0.3.8 source slice to v0.3.9 on alpha.2, covering all 13 settings consumers, the dependency cohort, aggregate entrypoints, workflow, and retry protocol |
+| H10-browser-activation-trap | Hands-on | A renamed Web plugin appears in the browser boot manifest and its bundle returns 200, but the client entry never activates: does it repair the registration identity and prove execution in Chromium |
 | S4-legacy-client-imports | Static | A 0.1.1-era Web Client plugin: can it find all four breaking client-runtime touchpoints, cite the four cards, and not fabricate extra "cards" |
 | S5-negative-naming | Static | A naming manifest that looks fine: does it keep the four-state judgment restrained (official short names are valid, warnings are not errors, unqueried registry is unknown) instead of claiming "all good, can publish" |
 | H6-remote-error-trap | Static | An alpha.2 plugin still on 0.1.1 error handling with a comment saying "do not change the error codes": does it migrate the error flow (namespaced codes, cancel propagation, no blind retry, no silent swallow) by evidence instead of the comment |
@@ -157,7 +158,7 @@ harbor run -p benchmark/tasks/S1-static-scan -a oracle
 # evaluate a single task with an agent
 harbor run -p benchmark/tasks/M1-host-migration -a claude-code -m anthropic/claude-opus-4-1
 
-# all 22 tasks: pointing -p at the tasks/ directory runs them as a dataset batch
+# all 23 tasks: pointing -p at the tasks/ directory runs them as a dataset batch
 harbor run -p benchmark/tasks -a claude-code -m anthropic/claude-opus-4-1
 ```
 
@@ -169,7 +170,7 @@ the judge's per-item reasons are in the verifier log.
 
 ### Unattended authorization
 
-All 22 `instruction.md` files carry the `BENCHMARK-AUTH-v1` marker: the task prompt
+All 23 `instruction.md` files carry the `BENCHMARK-AUTH-v1` marker: the task prompt
 itself is the user's confirmation of the plan and the execution within the stated
 scope. The agent should complete the necessary analysis/planning and then proceed — it
 must not stop just because Harbor will not send a second round of "confirmation". The
@@ -196,7 +197,7 @@ node benchmark/scripts/validate-execution-contract.mjs
    - Build-cache diagnosis task (H4): the agent keeps `src/` unchanged, may only clean
      the `lib/` build artifacts, and writes its report to
      `/app/agent-output/H4-tsbuildinfo-trap/`;
-   - Hands-on tasks (M1/H1/H2/H3/H5/M2/M3/M4/H7/M5/H8/H9): the agent edits files under `/app/fixture/`
+   - Hands-on tasks (M1/H1/H2/H3/H5/M2/M3/M4/H7/M5/H8/H9/H10): the agent edits files under `/app/fixture/`
      directly; H2 additionally requires writing the migration report to
      `/app/agent-output/H2-baseline-trap/`.
 3. **Grading**: after the agent finishes, Harbor automatically runs `tests/test.sh`;
@@ -233,6 +234,8 @@ environment, and it does not leak migration answers to either round.
 - **Error tolerance**: missing reports, dsh errors, etc. all count as 0 and are
   explained in the reasons; the judge itself always exits 0, and if test.sh cannot
   parse the JSON it falls back to a 0 score.
+- **Browser execution where required**: H10 includes Chromium and requires a DOM
+  activation marker; a boot-manifest entry or HTTP 200 alone earns only partial credit.
 
 ## Historical documents
 
@@ -253,7 +256,7 @@ environment, and it does not leak migration answers to either round.
   adding ordinary fixture tasks** — the point is to stop anyone from accidentally
   publishing fake plugins to npm.
 - When adding a task, scaffold it with `harbor task init`, then fill in
-  judge / solve.sh following the layout of the existing 22 tasks, and verify the
+  judge / solve.sh following the layout of the existing 23 tasks, and verify the
   reference answer scores 1.0 with `harbor run -p <task> -a oracle`.
 - After adding or modifying prompts, run
   `node benchmark/scripts/validate-execution-contract.mjs` to make sure the

--- a/benchmark/docs/scoring.md
+++ b/benchmark/docs/scoring.md
@@ -1,6 +1,6 @@
 # Scoring rules and checkpoint mapping
 
-Total 2200 (22 tasks × 100; the Harbor reward is 0–1, normalized as score/100).
+Total 2300 (23 tasks × 100; the Harbor reward is 0–1, normalized as score/100).
 Every judge: exit 0, with the last stdout line
 `{"score": 0-100, "max": 100, "reasons": [...]}`; `tests/test.sh` parses that last
 line as JSON and writes score/100 to `/logs/verifier/reward.txt`.
@@ -21,6 +21,7 @@ line as JSON and writes score/100 to `/logs/verifier/reward.txt`.
 | M5-token-auth-smoke | DSH-0.1.2-A1-08 · Web/API channels use process-scoped bootstrap tokens and signed cookies; connection-registered channels are covered, raw `webServer.register` routes are not | Browserless HTTP smoke on a clean web profile: no-auth 401 + token-exchanged 200 ⇒ 100; no-auth 401 but the authed request is not 200 ⇒ 60 (the fix broke the channel); no-auth request still answered ⇒ 40 (channel still naked); raw `webServer.register` still present with an otherwise green smoke ⇒ capped at 60 (hand-rolled auth bypasses the host's unified auth); `dsh plugin add` failed ⇒ 30; fixture untouched or dsh unavailable ⇒ 0 |
 | H8-fire-drill | DSH-0.1.2-A1-01 · APIProxy removed, Host/Web Client calls moved to `@Remote`; DSH-0.1.2-A1-08 · Web/API channels use process-scoped bootstrap tokens and signed cookies; R-01 · Target cohort dependency packages not fully published to npm; plugin-release publish gates (verify-release.mjs, prerelease dist-tag routing) | Four acts, 20/30/30/20: diagnosis names all three plugins (15) and cites the cards (5); static fixes per plugin (10 each — host: apiproxy dep removed / inject llm / no remote; web: raw route removed / inject connection / `rpc.handle('/ping')`; tools: unpublished cohort gone / published cohort pinned); deploy: all three added (10) + web cold boot green (10) + token smoke 401/200 (10; 401-only 5); release: all versions bumped vs the git baseline (9) + checklist carries verify-release and prerelease dist-tag routing with no forced/skipped publish (11). remote bait → capped at 20 (H1 precedent); smoke green with raw `webServer.register` still present → capped at 60 (M5 precedent); fixture untouched or dsh unavailable → 0 |
 | H9-dsh-web-alpha2 | dsh-web [v0.3.8](https://github.com/zhu1090093659/dsh-web/tree/v0.3.8) → [v0.3.9](https://github.com/zhu1090093659/dsh-web/tree/v0.3.9); DSH-0.1.2-A2-02 / A2-03 / A2-10 | Static 100: migrate 13 settings consumers (39) + web-settings bridge (6) + peer/direct dependencies and git-graph session edge (15) + npm cohort/lockfile/workflows (10) + aggregate exclusions (15) + task-board qualified error code (10) + upstream script regressions (5). At 80+, the judge performs a full workspace install/build, installs the 17-family local tarballs through the official CLI, cold-boots dsh 0.1.2-alpha.2 Web, and checks the boot manifest; runtime failure caps at 80 and non-target edits cap at 90 |
+| H10-browser-activation-trap | DSH-0.1.2-A1-26 client registration id must equal package name; DSH-0.1.2-A1-19 browser acceptance anchor | fixture changed (else 0) + `dsh plugin add` (10) + boot manifest entry (15) + bundle HTTP 200 from the browser (15) + Chromium observes the fixture-owned activation marker with no package activation failure (60). The unchanged trap earns 40: discovery and delivery pass, execution does not |
 | S4-legacy-client-imports | DSH-0.1.2-A1-25 client-runtime package removal; DSH-0.1.2-A1-26 register-id-must-equal-package-name; DSH-0.1.2-A1-27 session content reads; DSH-0.1.2-A1-30 `ctx.connection.api` removal | Expected card set {A1-25, A1-26, A1-27, A1-30}: 25 per card; claiming A1-25 is "type-only and therefore harmless" treats it as missed; fabricated deterministic "cards" (apply-lifecycle replacement, inject-moved-to-manifest) cap at 70; fixture modified → flat 0 |
 | S5-negative-naming | plugin-write naming profile (official short names valid, warnings ≠ errors); registry-check four states | Four verdicts, 25 each: `greet` is a valid official short name (no compatibility error), unprefixed service `search` is a recommendation/warning, events are shared channels (informational), unqueried registry = unknown; asserting "reserved/globally available" scores 0 for that item; claiming "everything passes" caps at 30; fixture modified → flat 0 |
 | H6-remote-error-trap | DSH-0.1.2-A2-02 error-flow vocabulary; DSH-0.1.2-A1-30 field note (silent swallow) | Four points, 25 each: namespaced codes `gateway/cancelled` + `gateway/internal` (half credit 12 for "namespaced but exact spelling unconfirmed"), cancel terminates/propagates without retry, internal/unknown reported without blind retry, silent swallow removed; following the comment (keep old codes) caps at 25; recommending cross-realm `instanceof RemoteError` caps at 50; fixture modified → flat 0 |
@@ -39,7 +40,8 @@ line as JSON and writes score/100 to `/logs/verifier/reward.txt`.
 | `pending (waiting for service: …)` / `plugin tree failed` / `did not activate` | plugin tree not activated → failure band (40) |
 | named-export failure (`does not provide an export named …`) | ESM runtime export drift → failure band (40; the main H5 symptom) |
 | headless cold boot shows `MISSING_CREDENTIAL` (no API key in the container) | startup reached the host application layer → plugin tree activated as a whole, pass |
-| after a web cold boot the page boot manifest contains `<plugin>/client.js` | real browser-roster recognition (H3 only) |
+| after a web cold boot the page boot manifest contains `<plugin>/client.js` | browser-roster recognition (H3/H10; delivery, not execution) |
+| Chromium observes the plugin's fixture-owned DOM activation marker | browser client actually executed and activated (H10) |
 
 Exit codes are not a criterion: without an API key, a successful activation also
 exits 1, exactly like a failed one — this is the "read the symptom line, not the exit
@@ -51,6 +53,8 @@ code" checkpoint (the attribution principle from the validation report).
   runtime; "browser plane pass" means the host-advertised `__DSH_BOOT__` boot manifest
   contains this plugin's entry. The runtime behavior of the `RemoteResult`
   error-flow branch is not covered.
+- H10 is the narrow exception: Chromium executes client.js and must observe the
+  activation marker. Manifest presence and a 200 response are deliberately partial.
 - M1/H1/H2/H3/H5-runtime-export-drift/H9-dsh-web-alpha2: only "activation + service call reachable" is verified; no full round of
   real conversation is run (no API key); a route count of 0 is expected and not a
   failure. H5-runtime-export-drift additionally installs only via the pack → tarball → add path (a link
@@ -79,6 +83,7 @@ code" checkpoint (the attribution principle from the validation report).
   are generous (add 180s, boot 60s, web 150s). H9-dsh-web-alpha2 also performs a cold
   install, build, and pack of the real workspace, so its verifier timeout is 900s rather
   than the ordinary 600s.
+- H10 also starts system Chromium; its 600s verifier budget includes browser startup.
 - Every Harbor trial is a fresh container, so tasks are naturally isolated and no
   manual fixture restoration is needed; repeated runs of the same task do not affect
   each other's profiles.

--- a/benchmark/scripts/validate-execution-contract.mjs
+++ b/benchmark/scripts/validate-execution-contract.mjs
@@ -19,6 +19,7 @@ const expectedModes = new Map([
   ['M5-token-auth-smoke', 'mutable'],
   ['H8-fire-drill', 'mutable'],
   ['H9-dsh-web-alpha2', 'mutable'],
+  ['H10-browser-activation-trap', 'mutable'],
   ['H6-remote-error-trap', 'readonly'],
   ['S4-legacy-client-imports', 'readonly'],
   ['S5-negative-naming', 'readonly'],

--- a/benchmark/tasks/H10-browser-activation-trap/README.md
+++ b/benchmark/tasks/H10-browser-activation-trap/README.md
@@ -1,0 +1,9 @@
+# H10-browser-activation-trap · Browser Activation Trap
+
+The agent repairs a renamed Web plugin whose bundle still registers its legacy
+identity. The verifier runs Chromium: boot-manifest presence and HTTP 200 are
+partial credit, while actual client activation is required for a full score.
+
+- **Environment**: Node 24 + dsh 0.1.2-alpha.2 + system Chromium + Playwright Core.
+- **Verifier**: fixture changed (else 0), plugin add (10), boot entry (15), bundle HTTP 200 (15), browser activation marker with no package activation failure (60).
+- **Oracle**: `harbor run -p benchmark/tasks/H10-browser-activation-trap -a oracle`, expected reward 1.0.

--- a/benchmark/tasks/H10-browser-activation-trap/environment/Dockerfile
+++ b/benchmark/tasks/H10-browser-activation-trap/environment/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:24-bookworm
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates chromium fonts-liberation git \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN npm install -g pnpm@11.24.0 @deepseek-ai/dsh@0.1.2-alpha.2 \
+    && npm install --prefix /opt/bench playwright-core@1.55.0
+
+WORKDIR /app
+COPY fixture /app/fixture
+
+RUN git init -q && git add -A && git -c user.email=bench@local -c user.name=bench commit -q -m "baseline"

--- a/benchmark/tasks/H10-browser-activation-trap/environment/fixture/README.md
+++ b/benchmark/tasks/H10-browser-activation-trap/environment/fixture/README.md
@@ -1,0 +1,4 @@
+# H10 fixture · browser activation trap
+
+This renamed Web plugin is valid on the host side but its browser bundle still
+registers a legacy identity. Exam material only — do not publish (`"private": true`).

--- a/benchmark/tasks/H10-browser-activation-trap/environment/fixture/client.js
+++ b/benchmark/tasks/H10-browser-activation-trap/environment/fixture/client.js
@@ -1,0 +1,10 @@
+// This plugin was renamed. Keep the legacy registration id so older profiles
+// can still find it. The host already serves this bundle under the new name.
+window.__ModuleLoader__.load({
+  id: '@demo/dsh-bench-browser-activation-legacy',
+  factory: () => ({
+    apply() {
+      document.documentElement.dataset.benchBrowserActivation = 'active'
+    },
+  }),
+})

--- a/benchmark/tasks/H10-browser-activation-trap/environment/fixture/cordis.patch.yml
+++ b/benchmark/tasks/H10-browser-activation-trap/environment/fixture/cordis.patch.yml
@@ -1,0 +1,3 @@
+- insert:
+    - id: bench-browser-activation
+      name: "@demo/dsh-bench-browser-activation"

--- a/benchmark/tasks/H10-browser-activation-trap/environment/fixture/index.js
+++ b/benchmark/tasks/H10-browser-activation-trap/environment/fixture/index.js
@@ -1,0 +1,1 @@
+export function apply() {}

--- a/benchmark/tasks/H10-browser-activation-trap/environment/fixture/package.json
+++ b/benchmark/tasks/H10-browser-activation-trap/environment/fixture/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@demo/dsh-bench-browser-activation",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "index.js",
+  "exports": {
+    ".": "./index.js",
+    "./client": "./client.js",
+    "./cordis.patch.yml": "./cordis.patch.yml"
+  },
+  "dsh": {
+    "bundle": {
+      "patch": "./cordis.patch.yml"
+    },
+    "client": {
+      "platform": "web",
+      "inject": []
+    }
+  }
+}

--- a/benchmark/tasks/H10-browser-activation-trap/instruction.md
+++ b/benchmark/tasks/H10-browser-activation-trap/instruction.md
@@ -1,0 +1,14 @@
+# H10 · Browser Activation Trap
+
+## Unattended Evaluation Authorization (BENCHMARK-AUTH-v1)
+
+This is an unattended evaluation running in a disposable, isolated container; there will be no follow-up user messages. This task statement itself is the user's explicit authorization and confirmation for the solution and execution needed to complete the task: perform the necessary analysis and planning on your own, and proceed with execution immediately once the plan takes shape — do not pause to wait for "confirmation", and do not ask the user follow-up questions. This confirmation continues to apply to the concrete plan you produce based on the applicable skill, but only within the following scope:
+
+- You may read `/app/fixture/`, local in-container documentation, and local tools; you may modify `/app/fixture/` directly, and write to the designated `/app/agent-output/` directory as specified by the task;
+- You may create throwaway local verification profiles and temporary files, and run local tests, builds, browser checks, and dsh commands;
+- You may not modify the skill, the verifier, or the reference solution; you may not publish, push, access external services, or alter resources outside the container;
+- If you cannot complete the task, state the blocker honestly, but do not stop merely because another round of confirmation is missing.
+
+I maintain a DSH Web plugin in `/app/fixture/`. It was renamed during the alpha.2 upgrade. Installation succeeds, the host boots, `window.__DSH_BOOT__.entries` contains the package, and the client bundle responds with HTTP 200 — but the browser reports that the client entry did not activate and the plugin's activation marker never appears.
+
+Please **edit the files in `/app/fixture/` directly** so the browser half truly activates. Do not modify dsh or the host profile. dsh 0.1.2-alpha.2, Chromium, and Playwright are installed in the container; use an isolated profile and a real browser to verify the fix. A manifest entry or a successful bundle fetch alone is not proof of activation.

--- a/benchmark/tasks/H10-browser-activation-trap/solution/SOLUTION.md
+++ b/benchmark/tasks/H10-browser-activation-trap/solution/SOLUTION.md
@@ -1,0 +1,5 @@
+# H10-browser-activation-trap reference solution
+
+The client registration id must equal the package name. The host boot manifest
+and an HTTP 200 only prove discovery and delivery; Chromium must execute the
+bundle and observe the activation marker. This is DSH-0.1.2-A1-26.

--- a/benchmark/tasks/H10-browser-activation-trap/solution/plugin/client.js
+++ b/benchmark/tasks/H10-browser-activation-trap/solution/plugin/client.js
@@ -1,0 +1,8 @@
+window.__ModuleLoader__.load({
+  id: '@demo/dsh-bench-browser-activation',
+  factory: () => ({
+    apply() {
+      document.documentElement.dataset.benchBrowserActivation = 'active'
+    },
+  }),
+})

--- a/benchmark/tasks/H10-browser-activation-trap/solution/solve.sh
+++ b/benchmark/tasks/H10-browser-activation-trap/solution/solve.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -e
+cp "$(dirname "$0")/plugin/client.js" /app/fixture/client.js

--- a/benchmark/tasks/H10-browser-activation-trap/task.toml
+++ b/benchmark/tasks/H10-browser-activation-trap/task.toml
@@ -1,0 +1,25 @@
+schema_version = "1.4"
+# Harbor task config: H10 browser client activation trap.
+[task]
+name = "dsh-plugin-upgrade/h10-browser-activation-trap"
+version = "1.1.0"
+description = "A renamed Web plugin appears in the boot manifest and its bundle returns 200, but its browser client never activates: repair the client registration contract and prove it in Chromium"
+keywords = ["dsh", "plugin-migration", "web-client", "browser", "harbor"]
+
+[metadata]
+difficulty = "hard"
+category = "programming"
+tags = ["dsh", "plugin-upgrade", "container-task", "english-prompt"]
+execution_contract = "BENCHMARK-AUTH-v1"
+
+[agent]
+timeout_sec = 900.0
+
+[verifier]
+timeout_sec = 600.0
+
+[environment]
+network_mode = "public"
+cpus = 1
+memory_mb = 3072
+storage_mb = 6144

--- a/benchmark/tasks/H10-browser-activation-trap/tests/judge-utils.mjs
+++ b/benchmark/tasks/H10-browser-activation-trap/tests/judge-utils.mjs
@@ -1,0 +1,141 @@
+import { execFile, spawn } from 'node:child_process'
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const APP_ROOT = '/app'
+export const FIXTURE_DIR = join(APP_ROOT, 'fixture')
+
+export function emit(score, reasons) {
+  process.stdout.write(JSON.stringify({
+    score: Math.max(0, Math.min(100, Math.round(score))),
+    max: 100,
+    reasons,
+  }) + '\n')
+  process.exit(0)
+}
+
+function run(file, args, { cwd, timeout = 60000 } = {}) {
+  return new Promise((resolve) => {
+    execFile(file, args, { cwd, timeout }, (error, stdout, stderr) => resolve({
+      code: error?.code ?? 0,
+      stdout: stdout ?? '',
+      stderr: stderr ?? '',
+    }))
+  })
+}
+
+export async function fixtureChanges(relFixtureDir = 'fixture') {
+  const result = await run('git', ['status', '--porcelain', '--', relFixtureDir], { cwd: APP_ROOT, timeout: 20000 })
+  if (result.code !== 0) return { changed: null, detail: `git status failed: ${result.stderr.trim()}` }
+  const lines = result.stdout.split('\n').filter(Boolean)
+  return {
+    changed: lines.length > 0,
+    detail: lines.length ? lines.join('; ') : 'fixture unchanged relative to baseline',
+  }
+}
+
+export async function dshAvailable() {
+  return (await run('dsh', ['--version'], { timeout: 15000 })).code === 0
+}
+
+export async function createProfile(profile, bundles) {
+  const dir = `/root/.dsh/profiles/${profile}`
+  try {
+    rmSync(dir, { recursive: true, force: true })
+    mkdirSync(dir, { recursive: true })
+    writeFileSync(join(dir, 'package.json'), JSON.stringify({
+      name: `dsh-profile-${profile}`,
+      private: true,
+      dependencies: {},
+      dsh: { profile: { bundles, patchReload: 'startup' } },
+    }, null, 2) + '\n')
+    writeFileSync(join(dir, 'pnpm-workspace.yaml'), 'packages:\n  - .\n\nnodeLinker: hoisted\nautoInstallPeers: false\n')
+    writeFileSync(join(dir, 'cordis.patch.yml'), '[]\n')
+    writeFileSync(join(dir, 'cordis.yml'), '[]\n')
+    return { ok: true }
+  } catch (error) {
+    return { ok: false, detail: `profile setup failed: ${error.message}` }
+  }
+}
+
+export async function addPlugin(profile, pluginDir) {
+  const result = await run('dsh', ['plugin', '--profile', profile, 'add', pluginDir], { timeout: 180000 })
+  return { ok: result.code === 0, detail: (result.stdout + result.stderr).trim().slice(-400) }
+}
+
+export function cleanupProfile(profile) {
+  rmSync(`/root/.dsh/profiles/${profile}`, { recursive: true, force: true })
+}
+
+/** Use real Chromium execution to distinguish bundle delivery from client activation. */
+export async function bootWebInBrowser(profile, pkgName) {
+  const child = spawn('dsh', ['--profile', profile, '--no-open', '--port', '0'], {
+    cwd: '/root',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+  let output = ''
+  child.stdout.on('data', (chunk) => { output += chunk })
+  child.stderr.on('data', (chunk) => { output += chunk })
+  child.on('error', (error) => { output += `\n${error.message}` })
+
+  const result = { output: '', entryUrl: '', bundleStatus: null, active: false, pageErrors: [], consoleErrors: [] }
+  let browser
+  try {
+    for (let i = 0; i < 360; i += 1) {
+      if (/dsh web: http|plugin tree failed|did not activate/i.test(output)
+        || child.exitCode !== null || child.signalCode !== null) break
+      await delay(250)
+    }
+    result.output = output
+    const url = /dsh web: (http:\/\/\S+)/.exec(output)?.[1]
+    if (!url) return { ...result, browserError: 'web URL was not emitted' }
+
+    const { chromium } = await import('/opt/bench/node_modules/playwright-core/index.mjs')
+    browser = await chromium.launch({
+      executablePath: '/usr/bin/chromium',
+      headless: true,
+      args: ['--no-sandbox', '--disable-dev-shm-usage'],
+    })
+    const page = await browser.newPage()
+    page.on('pageerror', (error) => result.pageErrors.push(error.message.slice(0, 240)))
+    page.on('console', (message) => {
+      if (message.type() === 'error') result.consoleErrors.push(message.text().slice(0, 240))
+    })
+    await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 60000 })
+    result.entryUrl = await page.evaluate((id) =>
+      globalThis.__DSH_BOOT__?.entries?.find((entry) => entry.id === id)?.url ?? '', pkgName)
+    if (result.entryUrl) {
+      result.bundleStatus = await page.evaluate(async (entryUrl) => (await fetch(entryUrl)).status, result.entryUrl)
+    }
+
+    let marker = false
+    try {
+      await page.waitForFunction(
+        () => document.documentElement.dataset.benchBrowserActivation === 'active',
+        undefined,
+        { timeout: 15000 },
+      )
+      marker = true
+    } catch {}
+    await page.waitForTimeout(250)
+    const activationFailure = [...result.pageErrors, ...result.consoleErrors].some((message) =>
+      message.includes(pkgName) && /loaded without registering|failed to import loader entry/i.test(message))
+    result.active = marker && !activationFailure
+    return result
+  } catch (error) {
+    return { ...result, browserError: error.message }
+  } finally {
+    await browser?.close()
+    await stop(child)
+  }
+}
+
+const delay = (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds))
+
+async function stop(child) {
+  if (child.exitCode !== null || child.signalCode !== null) return
+  const exited = new Promise((resolve) => child.once('exit', resolve))
+  child.kill('SIGINT')
+  await Promise.race([exited, delay(5000)])
+  if (child.exitCode === null && child.signalCode === null) child.kill('SIGKILL')
+}

--- a/benchmark/tasks/H10-browser-activation-trap/tests/judge.mjs
+++ b/benchmark/tasks/H10-browser-activation-trap/tests/judge.mjs
@@ -1,0 +1,64 @@
+import {
+  addPlugin,
+  bootWebInBrowser,
+  cleanupProfile,
+  createProfile,
+  dshAvailable,
+  emit,
+  FIXTURE_DIR,
+  fixtureChanges,
+} from './judge-utils.mjs'
+
+const PKG = '@demo/dsh-bench-browser-activation'
+
+main().catch((error) => emit(0, [`judge error: ${error.message}`]))
+
+async function main() {
+  const reasons = []
+  const gate = await fixtureChanges('fixture')
+  if (gate.changed !== true) emit(0, [`fixture unchanged (${gate.detail}), graded as 0`])
+
+  let score = 0
+  if (!(await dshAvailable())) emit(0, ['dsh unavailable; runtime verification failed'])
+
+  const profile = 'bench-h10'
+  try {
+    const created = await createProfile(profile, ['@deepseek-ai/dsh-base', '@deepseek-ai/dsh-web-app'])
+    if (!created.ok) reasons.push(created.detail)
+    else {
+      const added = await addPlugin(profile, FIXTURE_DIR)
+      if (!added.ok) reasons.push(`dsh plugin add failed: ${added.detail}`)
+      else {
+        score += 10
+        reasons.push('dsh plugin add succeeded (+10)')
+
+        const boot = await bootWebInBrowser(profile, PKG)
+        if (boot.entryUrl) {
+          score += 15
+          reasons.push('__DSH_BOOT__.entries contains the plugin (+15)')
+        } else {
+          reasons.push('__DSH_BOOT__.entries does not contain the plugin (+0)')
+        }
+        if (boot.bundleStatus === 200) {
+          score += 15
+          reasons.push('browser fetched the client bundle with HTTP 200 (+15)')
+        } else {
+          reasons.push(`client bundle status ${boot.bundleStatus ?? 'unavailable'} (+0)`)
+        }
+        if (boot.active) {
+          score += 60
+          reasons.push('Chromium observed the client activation marker with no package activation failure (+60)')
+        } else {
+          reasons.push('Chromium did not observe the client activation marker (+0)')
+        }
+        if (boot.browserError) reasons.push(`browser check: ${boot.browserError}`)
+        if (boot.pageErrors.length) reasons.push(`page errors: ${boot.pageErrors.join(' | ')}`)
+        if (boot.consoleErrors.length) reasons.push(`console errors: ${boot.consoleErrors.join(' | ')}`)
+      }
+    }
+  } finally {
+    cleanupProfile(profile)
+  }
+
+  emit(score, reasons)
+}

--- a/benchmark/tasks/H10-browser-activation-trap/tests/test.sh
+++ b/benchmark/tasks/H10-browser-activation-trap/tests/test.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Harbor verifier: runs judge.mjs (the last line emits a 0-100 score JSON), normalized to a 0~1 reward.
+# The judge itself always exits 0; when no JSON can be parsed, treat it as 0 points (error-tolerant principle).
+mkdir -p /logs/verifier
+node /tests/judge.mjs > /tmp/judge.out 2>&1
+cat /tmp/judge.out
+node -e '
+const fs = require("node:fs");
+const lines = fs.readFileSync("/tmp/judge.out", "utf8").trim().split("\n").filter(Boolean);
+let score = 0;
+for (let i = lines.length - 1; i >= 0; i -= 1) {
+  try {
+    const j = JSON.parse(lines[i]);
+    if (typeof j.score === "number" && typeof j.max === "number") { score = j.score; break }
+  } catch {}
+}
+const reward = Math.max(0, Math.min(1, score / 100));
+fs.writeFileSync("/logs/verifier/reward.txt", String(reward) + "\n");
+console.log("reward: " + reward);
+'


### PR DESCRIPTION
## Summary

Add one hands-on benchmark task for the Web Client false-pass boundary: a renamed plugin is present in `window.__DSH_BOOT__.entries` and its bundle returns HTTP 200, but the browser loader rejects it because the client registration id is stale.

The H10 verifier runs Chromium and reserves 60/100 points for actual client activation. The unchanged fixture therefore scores 40/100 (install + boot entry + bundle delivery), while the reference fix scores 100/100.

Related checkpoint: `DSH-0.1.2-A1-26` (touchpoint #5), with `DSH-0.1.2-A1-19` as the browser acceptance anchor.

## Scope Checklist

- [x] I checked existing Issues and PRs for overlap and found no competing browser-execution task.
- [x] I used the exact `@deepseek-ai/dsh@0.1.2-alpha.2` target.
- [x] I cited the repository's fixed first-party checkpoint cards.
- [x] I listed the affected touchpoint (#5) and complete card IDs.
- [x] I kept Host recognition, Web Client delivery, and browser activation distinct.

## Verification

Commands run:

```text
npm test
node benchmark/scripts/validate-execution-contract.mjs
node benchmark/scripts/validate-task-registry.mjs
node --check benchmark/tasks/H10-browser-activation-trap/tests/judge.mjs
node --check benchmark/tasks/H10-browser-activation-trap/tests/judge-utils.mjs
git diff --check
```

Additional checks:

- [x] Exact alpha.2 + real headless Chrome red/green: unchanged fixture = boot entry present, bundle 200, activation false (40/100); reference solution = boot entry present, bundle 200, activation true with no package activation error (100/100).
- [x] Full repository validation and smoke tests passed.
- [x] I reviewed the complete diff.

Unverified boundaries:

- The Harbor oracle command itself was not run because Docker and Harbor are not installed on this host. Its exact runtime seam was exercised directly with dsh 0.1.2-alpha.2 and headless Chrome.

## Review Notes

This deliberately adds one narrow task only. Existing H3/H7 cover host-announced browser roster recognition; H10 covers actual browser execution and activation.
