### PR TITLE
docs(plugin-test): same-payload in-place re-verification section

### DIFF
--- a/skills/plugin-test/references/version-migration-testing.md
+++ b/skills/plugin-test/references/version-migration-testing.md
@@ -39,3 +39,14 @@ Cover permissions and approvals, peer dependencies and packaged artifacts, and p
 6. **Cross-cohort claim**: when one artifact claims to support multiple host versions, repeat levels 3–5 on every claimed version.
 
 Typechecking, config parsing, mock Contexts, and credential-free pipelines are not runtime compatibility proof. List every unavailable provider credential, operating system, browser, PTY, or destructive data migration as an unverified boundary.
+
+## 4. Re-Verify Old Artifacts In Place (Same-Payload Control)
+
+After the upgrade, take output produced *before* it — old session messages, stored renders, earlier exports — and re-verify it in place on the new version. The payload is identical by construction, so any change isolates to the layer that interprets it. This is the cheapest control experiment available: no new fixture, no new session, one reload.
+
+Two rules from a measured case (2026-08-31, empty-table forensics against a 0.1.2-alpha.2 host):
+
+1. **When a third-party plugin owns the rendering, the new host version is not the first suspect.** A message surface that broke "after the upgrade" turned out to be a third-party UI widget dropping data during extraction; the host's own markdown pipeline, driven with the real parse chain, reproduced all seven table-syntax variants correctly. Attribution flipped only when the same old message was re-rendered in place after upgrading the widget — same payload, 1 row × 0 cells before, 17 rows × 51 cells after. Without the in-place control, the bug would have been filed upstream against the wrong owner.
+2. **Change one layer at a time and re-check the same artifact between steps.** In-place re-verification of unchanged payloads turns "which layer broke it" from an argument into a bisect: host upgrade first, re-check; renderer upgrade next, re-check. The artifact never changes, so every diff belongs to exactly one step.
+
+Full case write-up with the forensic chain: [dsh-assembler migration ledger, "empty-table" section](https://github.com/TT-Wang/dsh-assembler/blob/main/docs/research/dsh-alpha2-migration.md).


### PR DESCRIPTION
Adds §4 "Re-Verify Old Artifacts In Place (Same-Payload Control)" to `version-migration-testing.md`.

## Why

The existing ladder (§3) covers proof strength for *new* validation runs. It lacks the cheapest control experiment available after an upgrade: re-verifying output produced *before* the upgrade, in place. The payload is identical by construction, so any change isolates to the layer that interprets it — no new fixture, no new session, one reload.

## The measured case behind the two rules

2026-08-31, empty-table forensics against a 0.1.2-alpha.2 host: a message surface that broke "after the upgrade" was nearly filed as a host regression. The host's own markdown parse chain reproduced all seven table-syntax variants correctly; the actual culprit was a third-party UI widget dropping data during extraction. Attribution flipped only when the same old message was re-rendered in place after upgrading the widget — same payload, 1 row × 0 cells before, 17 rows × 51 cells after. Full forensic chain linked in the section.

Rules distilled: (1) when a third-party plugin owns the rendering, the new host version is not the first suspect; (2) change one layer at a time and re-check the same artifact between steps — the diff then belongs to exactly one step.

## Verification

- `node scripts/validate.mjs` → Validation OK; plugin-test's standalone rule respected (no cross-skill references, links stay inside the skill or point to https sources).

## Boundaries

Single measured case, client-rendering scope. The method generalizes to any layer that interprets stored payloads, but the evidence here is one incident.
