### PR TITLE
feat(benchmark): add Harbor run result aggregator

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -301,13 +301,14 @@ node benchmark/scripts/summarize-runs.mjs \
   --group run:jobs/<job>/<other-trial>/result.json
 
 # paired 3-run comparison (per-task medians, group A − group B)
+# note: the same file cannot feed both groups — duplicate inputs are hard errors
 node benchmark/scripts/summarize-runs.mjs \
-  --group with-skill:jobs/r1/S1-static-scan__x/result.json \
-  --group with-skill:jobs/r2/S1-static-scan__y/result.json \
-  --group with-skill:jobs/r3/S1-static-scan__z/result.json \
-  --group no-skill:jobs/r1/S1-static-scan__x/result.json \
-  --group no-skill:jobs/r2/S1-static-scan__y/result.json \
-  --group no-skill:jobs/r3/S1-static-scan__z/result.json
+  --group with-skill:jobs/with-skill/r1/S1-static-scan__x/result.json \
+  --group with-skill:jobs/with-skill/r2/S1-static-scan__y/result.json \
+  --group with-skill:jobs/with-skill/r3/S1-static-scan__z/result.json \
+  --group no-skill:jobs/no-skill/r1/S1-static-scan__x/result.json \
+  --group no-skill:jobs/no-skill/r2/S1-static-scan__y/result.json \
+  --group no-skill:jobs/no-skill/r3/S1-static-scan__z/result.json
 ```
 
 Behavior:

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -289,6 +289,43 @@ runs keep the same task image and prompt.
   published `HostConnectionService` implementations and records the supplied legacy
   authority object; a mock-only green result cannot earn the cohort points.
 
+## Summarizing Harbor runs
+
+After running trials, aggregate the real Harbor `result.json` files with the bundled
+deterministic summarizer instead of relying on Harbor's built-in mean:
+
+```sh
+# single group, repeated trials across files
+node benchmark/scripts/summarize-runs.mjs \
+  --group run:jobs/<job>/<trial>/result.json \
+  --group run:jobs/<job>/<other-trial>/result.json
+
+# paired 3-run comparison (per-task medians, group A − group B)
+node benchmark/scripts/summarize-runs.mjs \
+  --group with-skill:jobs/r1/S1-static-scan__x/result.json \
+  --group with-skill:jobs/r2/S1-static-scan__y/result.json \
+  --group with-skill:jobs/r3/S1-static-scan__z/result.json \
+  --group no-skill:jobs/r1/S1-static-scan__x/result.json \
+  --group no-skill:jobs/r2/S1-static-scan__y/result.json \
+  --group no-skill:jobs/r3/S1-static-scan__z/result.json
+```
+
+Behavior:
+
+- accepts trial-level and job-level `result.json` (job-level files are expanded from
+  `reward_stats` / `exception_stats`);
+- repeated trials of the same task aggregate per task (mean / median / min / max /
+  perfect) — later runs never overwrite earlier ones;
+- exactly two groups produce a paired per-task-median comparison with
+  improved / tied / regressed counts; a task present in only one group is listed as
+  missing and excluded from the delta aggregates, never treated as 0;
+- rewards are extracted from the trial records only — Harbor's precomputed aggregate
+  mean is not used, so stopped/unscored trials cannot distort the score;
+- trials without a reward are anomalies (never scored as 0); a scored trial that also
+  records an execution exception keeps its reward and is flagged;
+- default output is Markdown (`--format json` for machine-readable raw numbers);
+  duplicate inputs and malformed rewards are hard errors.
+
 ## Historical documents
 
 All validation and result reports live in [`results/`](results/). When opening a PR

--- a/benchmark/scripts/summarize-runs.mjs
+++ b/benchmark/scripts/summarize-runs.mjs
@@ -1,0 +1,480 @@
+// benchmark/scripts/summarize-runs.mjs
+//
+// Deterministic Harbor run aggregator: turns real Harbor `result.json` files into a
+// reproducible benchmark summary. It extracts rewards from the raw trial records
+// instead of trusting Harbor's built-in aggregate mean, which is misleading when a
+// job contains stopped/unscored trials or when a task ran in a separate job.
+//
+// Two Harbor result.json shapes are supported:
+//   1. trial-level (has `verifier_result`): one trial record per file;
+//   2. job-level   (has `stats.evals`): expanded into per-trial records from
+//      `reward_stats.reward` and `exception_stats`.
+// Anything else is an unsupported schema and fails loudly.
+//
+// Semantics:
+//   - only records with a verifier reward are scored; 0 <= reward <= 1 (else fail);
+//   - no-reward / exception / cancelled records are anomalies, never scored as 0;
+//   - a scored trial that also records an execution exception keeps its reward and
+//     is flagged as an anomaly (real runs produced AgentTimeoutError with a 1.0
+//     verifier report);
+//   - repeated trials of the same task aggregate per task (mean/median/min/max/
+//     perfect), the last run does not overwrite the earlier ones;
+//   - the exact same source file (or the same trial id) loaded twice is a hard
+//     error so results cannot be silently doubled.
+//
+// Usage:
+//   node benchmark/scripts/summarize-runs.mjs \
+//     --group with-skill:/path/to/run1/result.json \
+//     --group with-skill:/path/to/run2/result.json \
+//     --group no-skill:/path/to/run1/result.json \
+//     [--format markdown|json]
+import { existsSync, readFileSync } from 'node:fs'
+import { basename, resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+const MAX_DECIMALS = 4
+
+// ── CLI argument parsing ───────────────────────────────────────────────────────
+
+export function parseGroupArgs(argv) {
+  const groups = new Map() // label -> { label, paths }
+  let format = 'markdown'
+  const seen = new Set()
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i]
+    if (arg === '--format') {
+      const value = argv[++i]
+      if (value !== 'markdown' && value !== 'json') {
+        throw new Error(`--format must be "markdown" or "json", got: ${value ?? '(missing)'}`)
+      }
+      format = value
+      continue
+    }
+    if (arg === '--group') {
+      const spec = argv[++i]
+      if (spec === undefined) throw new Error('--group requires "<label>:<result.json>"')
+      const colon = spec.indexOf(':')
+      if (colon <= 0) throw new Error(`--group must be "<label>:<result.json>", got: ${spec}`)
+      const label = spec.slice(0, colon).trim()
+      const path = resolve(spec.slice(colon + 1))
+      if (!label) throw new Error(`--group has an empty label: ${spec}`)
+      if (seen.has(path)) {
+        throw new Error(`duplicate input file listed twice: ${path}`)
+      }
+      seen.add(path)
+      if (!groups.has(label)) groups.set(label, { label, paths: [] })
+      groups.get(label).paths.push(path)
+      continue
+    }
+    throw new Error(`unknown argument: ${arg}`)
+  }
+  if (groups.size === 0) throw new Error('no --group given; pass at least one --group <label>:<result.json>')
+  return { groups: [...groups.values()].map((group) => ({ label: group.label, paths: group.paths })), format }
+}
+
+// ── Loading and normalization ──────────────────────────────────────────────────
+
+export function loadResultFile(path) {
+  if (!existsSync(path)) throw new Error(`result file not found: ${path}`)
+  let parsed
+  try {
+    parsed = JSON.parse(readFileSync(path, 'utf8'))
+  } catch (error) {
+    throw new Error(`result file is not valid JSON: ${path} (${error.message})`)
+  }
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error(`result file is not a JSON object: ${path}`)
+  }
+  return parsed
+}
+
+// One normalized trial record plus per-file anomalies/notes.
+export function normalizeFile(parsed, label, sourceFile) {
+  const anomalies = []
+  const notes = []
+  const common = {
+    group: label,
+    sourceFile,
+    trialId: typeof parsed.id === 'string' ? parsed.id : null,
+    taskId: null,
+    agent: parsed.agent_info?.name ?? parsed.config?.agent?.name ?? null,
+    model: parsed.agent_info?.model_info ?? parsed.config?.agent?.model_name ?? null,
+  }
+  if (parsed.verifier_result !== undefined || parsed.verifier_result === null) {
+    const records = normalizeTrialLevel(parsed, common, anomalies, notes)
+    return { records, anomalies, notes }
+  }
+  if (parsed.stats && typeof parsed.stats === 'object' && parsed.stats.evals && typeof parsed.stats.evals === 'object') {
+    const records = normalizeJobLevel(parsed, common, anomalies, notes)
+    return { records, anomalies, notes }
+  }
+  throw new Error(`unsupported Harbor result.json schema: ${sourceFile} (has neither "verifier_result" nor "stats.evals")`)
+}
+
+function extractReward(rewards, sourceFile) {
+  if (rewards === undefined || rewards === null) return null
+  if (typeof rewards !== 'object' || Array.isArray(rewards)) {
+    throw new Error(`malformed "verifier_result.rewards" in ${sourceFile}: expected an object`)
+  }
+  const keys = Object.keys(rewards)
+  if (keys.length === 0) return null
+  const key = keys.includes('reward') ? 'reward' : keys[0]
+  const value = rewards[key]
+  if (typeof value !== 'number' || Number.isNaN(value) || value < 0 || value > 1) {
+    throw new Error(`malformed reward in ${sourceFile}: ${JSON.stringify(value)} (must be a number in [0, 1])`)
+  }
+  return value
+}
+
+function normalizeTrialLevel(parsed, common, anomalies, notes) {
+  const reward = extractReward(parsed.verifier_result?.rewards, common.sourceFile)
+  const hasException = parsed.exception_info !== null && parsed.exception_info !== undefined
+  const taskId = normalizeTaskId(parsed, common, notes)
+  const record = {
+    ...common,
+    taskId,
+    reward,
+    scored: reward !== null,
+    status: reward !== null ? (hasException ? 'completed-with-exception' : 'completed') : (hasException ? 'exception' : 'unscored'),
+    exception: hasException ? describeException(parsed.exception_info) : null,
+  }
+  if (reward !== null && hasException) {
+    anomalies.push({ type: 'scored-with-exception', group: common.group, taskId, trialId: common.trialId, source: common.sourceFile, message: `scored trial has execution exception (${record.exception}); reward kept` })
+  } else if (reward === null && hasException) {
+    anomalies.push({ type: 'exception', group: common.group, taskId, trialId: common.trialId, source: common.sourceFile, message: `trial has an exception and no verifier reward (${record.exception})` })
+  } else if (reward === null) {
+    anomalies.push({ type: 'no-reward', group: common.group, taskId, trialId: common.trialId, source: common.sourceFile, message: 'trial has no verifier reward (stopped/cancelled/setup failure); excluded from scored statistics' })
+  }
+  return [record]
+}
+
+function normalizeJobLevel(parsed, common, anomalies, notes) {
+  const records = []
+  const seenTrialNames = new Set()
+  const exceptionsByName = new Map()
+  for (const evalKey of Object.keys(parsed.stats.evals)) {
+    const evalStats = parsed.stats.evals[evalKey]
+    const rewardStats = evalStats?.reward_stats
+    const exceptionStats = evalStats?.exception_stats
+    if (rewardStats && typeof rewardStats === 'object') {
+      for (const rewardKey of Object.keys(rewardStats)) {
+        const entries = rewardStats[rewardKey]
+        if (!entries || typeof entries !== 'object') continue
+        for (const valueKey of Object.keys(entries)) {
+          const reward = Number(valueKey)
+          if (!Number.isFinite(reward) || reward < 0 || reward > 1) {
+            throw new Error(`malformed reward value in ${common.sourceFile} (${evalKey}.${rewardKey}): ${valueKey}`)
+          }
+          const names = entries[valueKey]
+          if (!Array.isArray(names)) {
+            throw new Error(`malformed reward_stats entry in ${common.sourceFile}: ${JSON.stringify(entries[valueKey])}`)
+          }
+          for (const trialName of names) {
+            if (seenTrialNames.has(trialName)) {
+              throw new Error(`duplicate trial "${trialName}" in ${common.sourceFile}`)
+            }
+            seenTrialNames.add(trialName)
+            const taskId = trialName.includes('__') ? trialName.split('__')[0] : trialName
+            notes.push({ type: 'task-id-fallback', source: common.sourceFile, message: `task id for "${trialName}" derived from the trial name (job-level result.json carries no per-trial task identity)` })
+            records.push({
+              ...common,
+              taskId,
+              trialId: trialName,
+              reward,
+              scored: true,
+              status: 'completed',
+              exception: null,
+            })
+          }
+        }
+      }
+    }
+    if (exceptionStats && typeof exceptionStats === 'object') {
+      for (const exceptionKey of Object.keys(exceptionStats)) {
+        const names = exceptionStats[exceptionKey]
+        if (!Array.isArray(names)) continue
+        for (const trialName of names) exceptionsByName.set(trialName, exceptionKey)
+      }
+    }
+  }
+  for (const [trialName, exception] of exceptionsByName) {
+    const record = records.find((entry) => entry.trialId === trialName)
+    if (record) {
+      record.status = 'completed-with-exception'
+      record.exception = exception
+      anomalies.push({ type: 'scored-with-exception', group: common.group, taskId: record.taskId, trialId: trialName, source: common.sourceFile, message: `scored trial has execution exception (${exception}); reward kept` })
+    } else {
+      anomalies.push({ type: 'exception', group: common.group, taskId: trialName.includes('__') ? trialName.split('__')[0] : trialName, trialId: trialName, source: common.sourceFile, message: `trial has an exception and no reward (${exception}); excluded from scored statistics` })
+    }
+  }
+  const stats = parsed.stats
+  if (Number.isFinite(stats.n_cancelled_trials) && stats.n_cancelled_trials > 0) {
+    anomalies.push({ type: 'cancelled-count', group: common.group, source: common.sourceFile, message: `job reports ${stats.n_cancelled_trials} cancelled trial(s); they are not enumerable from this file` })
+  }
+  if (records.length === 0) {
+    anomalies.push({ type: 'empty-result-set', group: common.group, source: common.sourceFile, message: 'no trial records found in this result.json' })
+  }
+  return records
+}
+
+function normalizeTaskId(parsed, common, notes) {
+  if (parsed.task_id?.path && typeof parsed.task_id.path === 'string') {
+    const name = basename(parsed.task_id.path)
+    if (name) return name
+  }
+  if (parsed.task_name && typeof parsed.task_name === 'string' && parsed.task_name.includes('/')) {
+    const segment = parsed.task_name.split('/').pop()
+    if (segment) return segment
+  }
+  if (parsed.trial_name && typeof parsed.trial_name === 'string' && parsed.trial_name.includes('__')) {
+    const fallback = parsed.trial_name.split('__')[0]
+    notes.push({ type: 'task-id-fallback', source: common.sourceFile, message: `task id for "${parsed.trial_name}" derived from the trial name` })
+    return fallback
+  }
+  throw new Error(`cannot derive a task id from ${common.sourceFile} (no task_id.path, task_name, or trial_name)`)
+}
+
+function describeException(info) {
+  if (info === null || info === undefined) return null
+  if (typeof info === 'string') return info.slice(0, 120)
+  if (typeof info === 'object') {
+    return String(info.type ?? info.name ?? info.message ?? JSON.stringify(info).slice(0, 120)).slice(0, 120)
+  }
+  return String(info).slice(0, 120)
+}
+
+// ── Statistics ─────────────────────────────────────────────────────────────────
+
+export function median(values) {
+  if (values.length === 0) return null
+  const sorted = [...values].sort((a, b) => a - b)
+  const middle = Math.floor(sorted.length / 2)
+  if (sorted.length % 2 === 1) return sorted[middle]
+  return (sorted[middle - 1] + sorted[middle]) / 2
+}
+
+function round4(value) {
+  return Number(value.toFixed(MAX_DECIMALS))
+}
+
+export function perTaskStats(records) {
+  const byTask = new Map()
+  for (const record of records) {
+    if (!record.scored) continue
+    if (!byTask.has(record.taskId)) byTask.set(record.taskId, [])
+    byTask.get(record.taskId).push(record.reward)
+  }
+  const tasks = new Map()
+  for (const [taskId, rewards] of byTask) {
+    const sorted = [...rewards].sort((a, b) => a - b)
+    tasks.set(taskId, {
+      taskId,
+      n: sorted.length,
+      mean: round4(sorted.reduce((sum, value) => sum + value, 0) / sorted.length),
+      median: round4(median(sorted)),
+      min: sorted[0],
+      max: sorted[sorted.length - 1],
+      perfect: sorted.filter((value) => value === 1).length,
+    })
+  }
+  return tasks
+}
+
+export function groupStats(records, files, label) {
+  const scored = records.filter((record) => record.scored)
+  const rewards = scored.map((record) => record.reward).sort((a, b) => a - b)
+  const rewardSum = rewards.reduce((sum, value) => sum + value, 0)
+  return {
+    label,
+    files,
+    records: records.length,
+    scored: scored.length,
+    unscored: records.length - scored.length,
+    tasks: perTaskStats(records).size,
+    rewardSum: round4(rewardSum),
+    mean: rewards.length > 0 ? round4(rewardSum / rewards.length) : null,
+    median: median(rewards),
+    perfect: rewards.filter((value) => value === 1).length,
+    min: rewards.length > 0 ? rewards[0] : null,
+    max: rewards.length > 0 ? rewards[rewards.length - 1] : null,
+  }
+}
+
+export function compareGroups(groupA, groupB) {
+  const commonTasks = [...groupA.tasks.keys()].filter((taskId) => groupB.tasks.has(taskId))
+  const missing = []
+  for (const taskId of groupA.tasks.keys()) {
+    if (!groupB.tasks.has(taskId)) missing.push({ taskId, missingIn: groupB.stats.label })
+  }
+  for (const taskId of groupB.tasks.keys()) {
+    if (!groupA.tasks.has(taskId)) missing.push({ taskId, missingIn: groupA.stats.label })
+  }
+  const rows = []
+  for (const taskId of [...commonTasks].sort()) {
+    const a = groupA.tasks.get(taskId)
+    const b = groupB.tasks.get(taskId)
+    rows.push({ taskId, aMedian: a.median, bMedian: b.median, delta: round4(a.median - b.median) })
+  }
+  const deltas = rows.map((row) => row.delta)
+  return {
+    groupA: groupA.stats.label,
+    groupB: groupB.stats.label,
+    commonTaskCount: commonTasks.length,
+    improved: rows.filter((row) => row.delta > 0).length,
+    tied: rows.filter((row) => row.delta === 0).length,
+    regressed: rows.filter((row) => row.delta < 0).length,
+    meanPerTaskDelta: deltas.length > 0 ? round4(deltas.reduce((sum, value) => sum + value, 0) / deltas.length) : null,
+    medianPerTaskDelta: deltas.length > 0 ? round4(median(deltas)) : null,
+    rows,
+    missing,
+  }
+}
+
+// ── Aggregation entry ──────────────────────────────────────────────────────────
+
+export function summarize(groupArgs) {
+  const anomalies = []
+  const notes = []
+  const seenTrialIds = new Map() // trialId -> source file
+  const groupSummaries = []
+  const seenPaths = new Set()
+  for (const group of groupArgs) {
+    const records = []
+    for (const path of group.paths) {
+      if (seenPaths.has(path)) {
+        throw new Error(`duplicate input file listed twice: ${path}`)
+      }
+      seenPaths.add(path)
+      const parsed = loadResultFile(path)
+      const result = normalizeFile(parsed, group.label, path)
+      for (const record of result.records) {
+        if (record.trialId !== null) {
+          if (seenTrialIds.has(record.trialId)) {
+            throw new Error(`duplicate trial "${record.trialId}" loaded twice: ${seenTrialIds.get(record.trialId)} and ${path}`)
+          }
+          seenTrialIds.set(record.trialId, path)
+        }
+        records.push(record)
+      }
+      anomalies.push(...result.anomalies)
+      notes.push(...result.notes)
+    }
+    const tasks = perTaskStats(records)
+    const stats = groupStats(records, group.paths, group.label)
+    if (stats.records === 0) {
+      anomalies.push({ type: 'empty-group', group: group.label, message: `group "${group.label}" produced no trial records` })
+    }
+    groupSummaries.push({ stats, tasks, records })
+  }
+  const comparison = groupSummaries.length === 2
+    ? compareGroups(groupSummaries[0], groupSummaries[1])
+    : null
+  if (comparison) {
+    for (const missing of comparison.missing) {
+      anomalies.push({ type: 'missing-in-group', taskId: missing.taskId, message: `task "${missing.taskId}" missing in ${missing.missingIn}; excluded from paired delta aggregates (never treated as 0)` })
+    }
+  }
+  return { groups: groupSummaries, comparison, anomalies, notes }
+}
+
+// ── Renderers ──────────────────────────────────────────────────────────────────
+
+function fmt(value) {
+  if (value === null || value === undefined) return '—'
+  if (typeof value === 'number') return String(round4(value))
+  return String(value)
+}
+
+export function renderMarkdown(summary) {
+  const lines = []
+  lines.push('# Benchmark Run Summary')
+  lines.push('')
+  lines.push('## Groups')
+  lines.push('')
+  lines.push('| Group | Files | Records | Scored | Tasks | Reward | Mean | Median | Perfect |')
+  lines.push('| --- | --- | --- | --- | --- | --- | --- | --- | --- |')
+  for (const group of summary.groups) {
+    const stats = group.stats
+    lines.push(`| ${stats.label} | ${stats.files.length} | ${stats.records} | ${stats.scored} | ${stats.tasks} | ${fmt(stats.rewardSum)} | ${fmt(stats.mean)} | ${fmt(stats.median)} | ${stats.perfect} |`)
+  }
+  lines.push('')
+  lines.push('## Per-task results')
+  lines.push('')
+  for (const group of summary.groups) {
+    lines.push(`### ${group.stats.label}`)
+    lines.push('')
+    lines.push('| Task | n | Mean | Median | Min | Max | Perfect |')
+    lines.push('| --- | --- | --- | --- | --- | --- | --- |')
+    for (const [taskId, entry] of [...group.tasks].sort(([a], [b]) => a.localeCompare(b))) {
+      lines.push(`| ${taskId} | ${entry.n} | ${fmt(entry.mean)} | ${fmt(entry.median)} | ${fmt(entry.min)} | ${fmt(entry.max)} | ${entry.perfect} |`)
+    }
+    lines.push('')
+  }
+  if (summary.comparison) {
+    const comparison = summary.comparison
+    lines.push('## Paired comparison')
+    lines.push('')
+    lines.push(`delta = ${comparison.groupA} median − ${comparison.groupB} median`)
+    lines.push('')
+    lines.push(`| Task | ${comparison.groupA} median | ${comparison.groupB} median | delta |`)
+    lines.push('| --- | --- | --- | --- |')
+    for (const row of comparison.rows) {
+      lines.push(`| ${row.taskId} | ${fmt(row.aMedian)} | ${fmt(row.bMedian)} | ${fmt(row.delta)} |`)
+    }
+    lines.push('')
+    lines.push(`common tasks: ${comparison.commonTaskCount}; improved: ${comparison.improved}; tied: ${comparison.tied}; regressed: ${comparison.regressed}`)
+    lines.push(`mean per-task delta: ${fmt(comparison.meanPerTaskDelta)}; median per-task delta: ${fmt(comparison.medianPerTaskDelta)}`)
+    lines.push('')
+  }
+  lines.push('## Anomalies')
+  lines.push('')
+  if (summary.anomalies.length === 0) {
+    lines.push('none')
+  } else {
+    for (const anomaly of summary.anomalies) {
+      lines.push(`- [${anomaly.type}] ${anomaly.message}`)
+    }
+  }
+  lines.push('')
+  return lines.join('\n')
+}
+
+export function renderJson(summary) {
+  const groups = {}
+  for (const group of summary.groups) {
+    groups[group.stats.label] = {
+      files: group.stats.files,
+      records: group.stats.records,
+      scored: group.stats.scored,
+      unscored: group.stats.unscored,
+      tasks: group.stats.tasks,
+      rewardSum: group.stats.rewardSum,
+      mean: group.stats.mean,
+      median: group.stats.median,
+      perfect: group.stats.perfect,
+      min: group.stats.min,
+      max: group.stats.max,
+      perTask: Object.fromEntries([...group.tasks].map(([taskId, entry]) => [taskId, entry])),
+    }
+  }
+  return JSON.stringify({
+    groups,
+    comparison: summary.comparison,
+    anomalies: summary.anomalies,
+    notes: summary.notes,
+  }, null, 2)
+}
+
+// ── CLI entry ──────────────────────────────────────────────────────────────────
+
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href
+if (isMain) {
+  try {
+    const { groups, format } = parseGroupArgs(process.argv.slice(2))
+    const summary = summarize(groups)
+    process.stdout.write(`${format === 'json' ? renderJson(summary) : renderMarkdown(summary)}\n`)
+  } catch (error) {
+    console.error(`[summarize-runs] ${error.message}`)
+    process.exit(1)
+  }
+}

--- a/benchmark/scripts/summarize-runs.mjs
+++ b/benchmark/scripts/summarize-runs.mjs
@@ -428,11 +428,10 @@ export function renderMarkdown(summary) {
   lines.push('')
   lines.push('## Groups')
   lines.push('')
-  lines.push('| Group | Files | Records | Scored | Tasks | Reward | Trial mean | Median | Perfect |')
-  lines.push('| --- | --- | --- | --- | --- | --- | --- | --- | --- |')
-  lines.push('')
   lines.push('The "Trial mean" is trial-weighted: every scored trial contributes equally, regardless of how many trials each task has.')
   lines.push('')
+  lines.push('| Group | Files | Records | Scored | Tasks | Reward | Trial mean | Median | Perfect |')
+  lines.push('| --- | --- | --- | --- | --- | --- | --- | --- | --- |')
   for (const group of summary.groups) {
     const stats = group.stats
     lines.push(`| ${escapeLabel(stats.label)} | ${stats.files.length} | ${stats.records} | ${stats.scored} | ${stats.tasks} | ${fmt(stats.rewardSum)} | ${fmt(stats.mean)} | ${fmt(stats.median)} | ${stats.perfect} |`)

--- a/benchmark/scripts/summarize-runs.mjs
+++ b/benchmark/scripts/summarize-runs.mjs
@@ -100,7 +100,7 @@ export function normalizeFile(parsed, label, sourceFile) {
     agent: parsed.agent_info?.name ?? parsed.config?.agent?.name ?? null,
     model: parsed.agent_info?.model_info ?? parsed.config?.agent?.model_name ?? null,
   }
-  if (parsed.verifier_result !== undefined || parsed.verifier_result === null) {
+  if (parsed.verifier_result !== undefined) {
     const records = normalizeTrialLevel(parsed, common, anomalies, notes)
     return { records, anomalies, notes }
   }
@@ -111,23 +111,33 @@ export function normalizeFile(parsed, label, sourceFile) {
   throw new Error(`unsupported Harbor result.json schema: ${sourceFile} (has neither "verifier_result" nor "stats.evals")`)
 }
 
-function extractReward(rewards, sourceFile) {
+function extractReward(rewards, sourceFile, context = '') {
   if (rewards === undefined || rewards === null) return null
   if (typeof rewards !== 'object' || Array.isArray(rewards)) {
     throw new Error(`malformed "verifier_result.rewards" in ${sourceFile}: expected an object`)
   }
   const keys = Object.keys(rewards)
-  if (keys.length === 0) return null
-  const key = keys.includes('reward') ? 'reward' : keys[0]
+  if (keys.length === 0) {
+    throw new Error(`malformed "verifier_result.rewards" in ${sourceFile}${context}: empty rewards object`)
+  }
+  let key
+  if (keys.includes('reward')) {
+    key = 'reward'
+  } else if (keys.length === 1) {
+    key = keys[0]
+  } else {
+    throw new Error(`ambiguous rewards in ${sourceFile}${context}: multiple reward keys (${keys.join(', ')}) and no canonical "reward" key — refusing to guess`)
+  }
   const value = rewards[key]
   if (typeof value !== 'number' || Number.isNaN(value) || value < 0 || value > 1) {
-    throw new Error(`malformed reward in ${sourceFile}: ${JSON.stringify(value)} (must be a number in [0, 1])`)
+    throw new Error(`malformed reward in ${sourceFile}${context}: ${JSON.stringify(value)} (must be a number in [0, 1])`)
   }
   return value
 }
 
 function normalizeTrialLevel(parsed, common, anomalies, notes) {
-  const reward = extractReward(parsed.verifier_result?.rewards, common.sourceFile)
+  const context = ` (trial ${common.trialId ?? common.sourceFile})`
+  const reward = extractReward(parsed.verifier_result?.rewards, common.sourceFile, context)
   const hasException = parsed.exception_info !== null && parsed.exception_info !== undefined
   const taskId = normalizeTaskId(parsed, common, notes)
   const record = {
@@ -154,12 +164,20 @@ function normalizeJobLevel(parsed, common, anomalies, notes) {
   const exceptionsByName = new Map()
   for (const evalKey of Object.keys(parsed.stats.evals)) {
     const evalStats = parsed.stats.evals[evalKey]
-    const rewardStats = evalStats?.reward_stats
-    const exceptionStats = evalStats?.exception_stats
-    if (rewardStats && typeof rewardStats === 'object') {
+    if (evalStats === null || typeof evalStats !== 'object' || Array.isArray(evalStats)) {
+      throw new Error(`malformed stats.evals entry in ${common.sourceFile}: "${evalKey}" is not an object`)
+    }
+    const rewardStats = evalStats.reward_stats
+    const exceptionStats = evalStats.exception_stats
+    if (rewardStats !== undefined && rewardStats !== null) {
+      if (typeof rewardStats !== 'object' || Array.isArray(rewardStats)) {
+        throw new Error(`malformed reward_stats in ${common.sourceFile} (${evalKey}): expected an object`)
+      }
       for (const rewardKey of Object.keys(rewardStats)) {
         const entries = rewardStats[rewardKey]
-        if (!entries || typeof entries !== 'object') continue
+        if (entries === null || typeof entries !== 'object' || Array.isArray(entries)) {
+          throw new Error(`malformed reward_stats entry in ${common.sourceFile} (${evalKey}.${rewardKey}): expected an object mapping reward values to trial names`)
+        }
         for (const valueKey of Object.keys(entries)) {
           const reward = Number(valueKey)
           if (!Number.isFinite(reward) || reward < 0 || reward > 1) {
@@ -167,9 +185,12 @@ function normalizeJobLevel(parsed, common, anomalies, notes) {
           }
           const names = entries[valueKey]
           if (!Array.isArray(names)) {
-            throw new Error(`malformed reward_stats entry in ${common.sourceFile}: ${JSON.stringify(entries[valueKey])}`)
+            throw new Error(`malformed reward_stats entry in ${common.sourceFile} (${evalKey}.${rewardKey}.${valueKey}): expected an array of trial names, got ${JSON.stringify(names)}`)
           }
           for (const trialName of names) {
+            if (typeof trialName !== 'string' || trialName.trim() === '') {
+              throw new Error(`malformed trial name in ${common.sourceFile} (${evalKey}.${rewardKey}.${valueKey}): ${JSON.stringify(trialName)}`)
+            }
             if (seenTrialNames.has(trialName)) {
               throw new Error(`duplicate trial "${trialName}" in ${common.sourceFile}`)
             }
@@ -189,11 +210,21 @@ function normalizeJobLevel(parsed, common, anomalies, notes) {
         }
       }
     }
-    if (exceptionStats && typeof exceptionStats === 'object') {
+    if (exceptionStats !== undefined && exceptionStats !== null) {
+      if (typeof exceptionStats !== 'object' || Array.isArray(exceptionStats)) {
+        throw new Error(`malformed exception_stats in ${common.sourceFile} (${evalKey}): expected an object`)
+      }
       for (const exceptionKey of Object.keys(exceptionStats)) {
         const names = exceptionStats[exceptionKey]
-        if (!Array.isArray(names)) continue
-        for (const trialName of names) exceptionsByName.set(trialName, exceptionKey)
+        if (!Array.isArray(names)) {
+          throw new Error(`malformed exception_stats entry in ${common.sourceFile} (${evalKey}.${exceptionKey}): expected an array of trial names, got ${JSON.stringify(names)}`)
+        }
+        for (const trialName of names) {
+          if (typeof trialName !== 'string' || trialName.trim() === '') {
+            throw new Error(`malformed trial name in ${common.sourceFile} (${evalKey}.${exceptionKey}): ${JSON.stringify(trialName)}`)
+          }
+          exceptionsByName.set(trialName, exceptionKey)
+        }
       }
     }
   }
@@ -293,7 +324,7 @@ export function groupStats(records, files, label) {
     tasks: perTaskStats(records).size,
     rewardSum: round4(rewardSum),
     mean: rewards.length > 0 ? round4(rewardSum / rewards.length) : null,
-    median: median(rewards),
+    median: rewards.length > 0 ? round4(median(rewards)) : null,
     perfect: rewards.filter((value) => value === 1).length,
     min: rewards.length > 0 ? rewards[0] : null,
     max: rewards.length > 0 ? rewards[rewards.length - 1] : null,
@@ -385,23 +416,32 @@ function fmt(value) {
   return String(value)
 }
 
+// Escape a free-form label for a Markdown table cell: pipe characters would
+// split the cell and newlines would break the row.
+function escapeLabel(label) {
+  return String(label).replaceAll('|', '\\|').replaceAll('\n', ' ').replaceAll('\r', '')
+}
+
 export function renderMarkdown(summary) {
   const lines = []
   lines.push('# Benchmark Run Summary')
   lines.push('')
   lines.push('## Groups')
   lines.push('')
-  lines.push('| Group | Files | Records | Scored | Tasks | Reward | Mean | Median | Perfect |')
+  lines.push('| Group | Files | Records | Scored | Tasks | Reward | Trial mean | Median | Perfect |')
   lines.push('| --- | --- | --- | --- | --- | --- | --- | --- | --- |')
+  lines.push('')
+  lines.push('The "Trial mean" is trial-weighted: every scored trial contributes equally, regardless of how many trials each task has.')
+  lines.push('')
   for (const group of summary.groups) {
     const stats = group.stats
-    lines.push(`| ${stats.label} | ${stats.files.length} | ${stats.records} | ${stats.scored} | ${stats.tasks} | ${fmt(stats.rewardSum)} | ${fmt(stats.mean)} | ${fmt(stats.median)} | ${stats.perfect} |`)
+    lines.push(`| ${escapeLabel(stats.label)} | ${stats.files.length} | ${stats.records} | ${stats.scored} | ${stats.tasks} | ${fmt(stats.rewardSum)} | ${fmt(stats.mean)} | ${fmt(stats.median)} | ${stats.perfect} |`)
   }
   lines.push('')
   lines.push('## Per-task results')
   lines.push('')
   for (const group of summary.groups) {
-    lines.push(`### ${group.stats.label}`)
+    lines.push(`### ${escapeLabel(group.stats.label)}`)
     lines.push('')
     lines.push('| Task | n | Mean | Median | Min | Max | Perfect |')
     lines.push('| --- | --- | --- | --- | --- | --- | --- |')
@@ -414,9 +454,9 @@ export function renderMarkdown(summary) {
     const comparison = summary.comparison
     lines.push('## Paired comparison')
     lines.push('')
-    lines.push(`delta = ${comparison.groupA} median − ${comparison.groupB} median`)
+    lines.push(`delta = ${escapeLabel(comparison.groupA)} median − ${escapeLabel(comparison.groupB)} median`)
     lines.push('')
-    lines.push(`| Task | ${comparison.groupA} median | ${comparison.groupB} median | delta |`)
+    lines.push(`| Task | ${escapeLabel(comparison.groupA)} median | ${escapeLabel(comparison.groupB)} median | delta |`)
     lines.push('| --- | --- | --- | --- |')
     for (const row of comparison.rows) {
       lines.push(`| ${row.taskId} | ${fmt(row.aMedian)} | ${fmt(row.bMedian)} | ${fmt(row.delta)} |`)

--- a/benchmark/scripts/summarize-runs.test.mjs
+++ b/benchmark/scripts/summarize-runs.test.mjs
@@ -26,7 +26,7 @@ function trialJson({ id, taskId = 'S1-static-scan', trialName = `${taskId}__abc`
     task_id: { path: `benchmark/tasks/${taskId}` },
     agent_info: { name: 'claude-code', model_info: model },
     config: { agent: { name: 'claude-code', model_name: model } },
-    verifier_result: { rewards: reward === null ? {} : { reward } },
+    verifier_result: reward === null ? null : { rewards: { reward } },
     exception_info: exception,
   }
 }
@@ -320,4 +320,87 @@ test('normalizeFile on a trial-level object yields one record with normalized ta
 
 test('loadResultFile throws for a missing path', () => {
   assert.throws(() => loadResultFile('/tmp/definitely-not-present-xyz.json'), /result file not found/)
+})
+
+test('multiple reward keys without a canonical reward key fail loudly', () => {
+  const root = mkdtempSync(join(tmpdir(), 'sr-'))
+  const file = join(root, 'multi.json')
+  writeFileSync(file, JSON.stringify({ id: 't1', task_name: 'dsh-plugin-upgrade/x', trial_name: 'x__1', task_id: { path: 'benchmark/tasks/X1' }, verifier_result: { rewards: { a: 1, b: 0.5 } }, exception_info: null }))
+  assert.throws(() => summarize([{ label: 'run', paths: [file] }]), /ambiguous rewards.*multiple reward keys \(a, b\) and no canonical "reward" key/)
+  rmSync(root, { recursive: true, force: true })
+})
+
+test('empty rewards object fails loudly', () => {
+  const root = mkdtempSync(join(tmpdir(), 'sr-'))
+  const file = join(root, 'empty.json')
+  writeFileSync(file, JSON.stringify({ id: 't1', task_name: 'dsh-plugin-upgrade/x', trial_name: 'x__1', task_id: { path: 'benchmark/tasks/X1' }, verifier_result: { rewards: {} }, exception_info: null }))
+  assert.throws(() => summarize([{ label: 'run', paths: [file] }]), /empty rewards object/)
+  rmSync(root, { recursive: true, force: true })
+})
+
+test('a single non-canonical numeric reward key is still accepted (kept compatibility)', () => {
+  const root = mkdtempSync(join(tmpdir(), 'sr-'))
+  const file = join(root, 'single.json')
+  writeFileSync(file, JSON.stringify({ id: 't1', task_name: 'dsh-plugin-upgrade/x', trial_name: 'x__1', task_id: { path: 'benchmark/tasks/X1' }, verifier_result: { rewards: { other: 0.7 } }, exception_info: null }))
+  const { groups } = summarize([{ label: 'run', paths: [file] }])
+  rmSync(root, { recursive: true, force: true })
+  assert.equal(groups[0].stats.rewardSum, 0.7)
+})
+
+test('non-object eval entry in job-level stats fails loudly', () => {
+  const root = mkdtempSync(join(tmpdir(), 'sr-'))
+  const file = join(root, 'job.json')
+  writeFileSync(file, JSON.stringify({ id: 'j', stats: { evals: { 'a__b': 'not-an-object' } } }))
+  assert.throws(() => summarize([{ label: 'run', paths: [file] }]), /malformed stats\.evals entry.*not an object/)
+  rmSync(root, { recursive: true, force: true })
+})
+
+test('non-array trial names in reward_stats fail loudly', () => {
+  const root = mkdtempSync(join(tmpdir(), 'sr-'))
+  const file = join(root, 'job.json')
+  writeFileSync(file, JSON.stringify({ id: 'j', stats: { evals: { 'a__b': { reward_stats: { reward: { '1.0': 'not-an-array' } } } } } }))
+  assert.throws(() => summarize([{ label: 'run', paths: [file] }]), /expected an array of trial names/)
+  rmSync(root, { recursive: true, force: true })
+})
+
+test('non-object reward_stats entries fail loudly', () => {
+  const root = mkdtempSync(join(tmpdir(), 'sr-'))
+  const file = join(root, 'job.json')
+  writeFileSync(file, JSON.stringify({ id: 'j', stats: { evals: { 'a__b': { reward_stats: { reward: 'not-an-object' } } } } }))
+  assert.throws(() => summarize([{ label: 'run', paths: [file] }]), /malformed reward_stats entry.*expected an object mapping reward values to trial names/)
+  rmSync(root, { recursive: true, force: true })
+})
+
+test('non-object exception_stats fail loudly', () => {
+  const root = mkdtempSync(join(tmpdir(), 'sr-'))
+  const file = join(root, 'job.json')
+  writeFileSync(file, JSON.stringify({ id: 'j', stats: { evals: { 'a__b': { reward_stats: { reward: { '1.0': ['x__1'] } }, exception_stats: 'bad' } } } }))
+  assert.throws(() => summarize([{ label: 'run', paths: [file] }]), /malformed exception_stats.*expected an object/)
+  rmSync(root, { recursive: true, force: true })
+})
+
+test('non-array exception_stats names fail loudly', () => {
+  const root = mkdtempSync(join(tmpdir(), 'sr-'))
+  const file = join(root, 'job.json')
+  writeFileSync(file, JSON.stringify({ id: 'j', stats: { evals: { 'a__b': { reward_stats: { reward: { '1.0': ['x__1'] } }, exception_stats: { E: 'not-an-array' } } } } }))
+  assert.throws(() => summarize([{ label: 'run', paths: [file] }]), /malformed exception_stats entry.*expected an array of trial names/)
+  rmSync(root, { recursive: true, force: true })
+})
+
+test('non-string trial names fail loudly', () => {
+  const root = mkdtempSync(join(tmpdir(), 'sr-'))
+  const file = join(root, 'job.json')
+  writeFileSync(file, JSON.stringify({ id: 'j', stats: { evals: { 'a__b': { reward_stats: { reward: { '1.0': [42] } } } } } }))
+  assert.throws(() => summarize([{ label: 'run', paths: [file] }]), /malformed trial name/)
+  rmSync(root, { recursive: true, force: true })
+})
+
+test('group labels with pipes are escaped in Markdown tables', () => {
+  const root = mkdtempSync(join(tmpdir(), 'sr-'))
+  const f1 = writeTrial(root, 'a1.json', trialJson({ id: 'a1', taskId: 'S1-static-scan', trialName: 'S1-static-scan__a1', reward: 1 }))
+  const summary = summarize([{ label: 'run|with pipe\nsecond line', paths: [f1] }])
+  const md = renderMarkdown(summary)
+  rmSync(root, { recursive: true, force: true })
+  assert.match(md, /run\\\|with pipe second line/)
+  assert.doesNotMatch(md, /second line\n\|/)
 })

--- a/benchmark/scripts/summarize-runs.test.mjs
+++ b/benchmark/scripts/summarize-runs.test.mjs
@@ -1,0 +1,323 @@
+// benchmark/scripts/summarize-runs.test.mjs
+//
+// Pure-function tests for the Harbor run aggregator. No Docker, no Harbor, no
+// network: synthetic trial-level and job-level result.json objects are written
+// into mkdtemp directories and fed through the same functions the CLI uses.
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  parseGroupArgs,
+  summarize,
+  renderMarkdown,
+  renderJson,
+  median,
+  normalizeFile,
+  loadResultFile,
+} from './summarize-runs.mjs'
+
+function trialJson({ id, taskId = 'S1-static-scan', trialName = `${taskId}__abc`, reward = 1, exception = null, model = null } = {}) {
+  return {
+    id,
+    task_name: `dsh-plugin-upgrade/${taskId.toLowerCase()}`,
+    trial_name: trialName,
+    task_id: { path: `benchmark/tasks/${taskId}` },
+    agent_info: { name: 'claude-code', model_info: model },
+    config: { agent: { name: 'claude-code', model_name: model } },
+    verifier_result: { rewards: reward === null ? {} : { reward } },
+    exception_info: exception,
+  }
+}
+
+function jobJson({ rewards = {}, exceptions = {}, cancelled = 0 } = {}) {
+  return {
+    id: 'job-id-1',
+    stats: {
+      n_completed_trials: 0,
+      n_cancelled_trials: cancelled,
+      evals: {
+        'claude-code__adhoc': {
+          reward_stats: { reward: rewards },
+          exception_stats: exceptions,
+        },
+      },
+    },
+  }
+}
+
+function writeTrial(root, name, json) {
+  const file = join(root, name)
+  writeFileSync(file, JSON.stringify(json))
+  return file
+}
+
+test('single result / single group summarizes correctly', () => {
+  const root = mkdtempSync(join(tmpdir(), 'sr-'))
+  const file = writeTrial(root, 'a.json', trialJson({ id: 't1', reward: 0.8 }))
+  const { groups, anomalies } = summarize([{ label: 'run', paths: [file] }])
+  rmSync(root, { recursive: true, force: true })
+  assert.equal(groups.length, 1)
+  assert.equal(groups[0].stats.records, 1)
+  assert.equal(groups[0].stats.scored, 1)
+  assert.equal(groups[0].stats.tasks, 1)
+  assert.equal(groups[0].stats.rewardSum, 0.8)
+  assert.equal(groups[0].stats.mean, 0.8)
+  assert.equal(groups[0].stats.median, 0.8)
+  assert.equal(groups[0].stats.perfect, 0)
+  assert.equal(anomalies.length, 0)
+})
+
+test('two result files merge into one group', () => {
+  const root = mkdtempSync(join(tmpdir(), 'sr-'))
+  const f1 = writeTrial(root, 'a.json', trialJson({ id: 't1', taskId: 'S1-static-scan', reward: 1 }))
+  const f2 = writeTrial(root, 'b.json', trialJson({ id: 't2', taskId: 'S2-negative-scan', reward: 0.5 }))
+  const { groups } = summarize([{ label: 'run', paths: [f1, f2] }])
+  rmSync(root, { recursive: true, force: true })
+  assert.equal(groups[0].stats.records, 2)
+  assert.equal(groups[0].stats.tasks, 2)
+  assert.equal(groups[0].stats.rewardSum, 1.5)
+})
+
+test('same task 3 runs aggregates with a correct median', () => {
+  const root = mkdtempSync(join(tmpdir(), 'sr-'))
+  const f1 = writeTrial(root, 'a.json', trialJson({ id: 't1', taskId: 'S1-static-scan', trialName: 'S1-static-scan__r1', reward: 0.4 }))
+  const f2 = writeTrial(root, 'b.json', trialJson({ id: 't2', taskId: 'S1-static-scan', trialName: 'S1-static-scan__r2', reward: 1 }))
+  const f3 = writeTrial(root, 'c.json', trialJson({ id: 't3', taskId: 'S1-static-scan', trialName: 'S1-static-scan__r3', reward: 0.7 }))
+  const { groups } = summarize([{ label: 'run', paths: [f1, f2, f3] }])
+  rmSync(root, { recursive: true, force: true })
+  const entry = groups[0].tasks.get('S1-static-scan')
+  assert.equal(entry.n, 3)
+  assert.equal(entry.median, 0.7)
+  assert.equal(entry.mean, 0.7)
+  assert.equal(entry.min, 0.4)
+  assert.equal(entry.max, 1)
+  assert.equal(entry.perfect, 1)
+})
+
+test('even-length median averages the two middle values', () => {
+  assert.equal(median([1, 2, 3, 4]), 2.5)
+  assert.equal(median([0.2, 0.8]), 0.5)
+  assert.equal(median([1]), 1)
+  assert.equal(median([]), null)
+})
+
+test('reward 0 is scored, not treated as missing', () => {
+  const root = mkdtempSync(join(tmpdir(), 'sr-'))
+  const file = writeTrial(root, 'a.json', trialJson({ id: 't1', reward: 0 }))
+  const { groups, anomalies } = summarize([{ label: 'run', paths: [file] }])
+  rmSync(root, { recursive: true, force: true })
+  assert.equal(groups[0].stats.scored, 1)
+  assert.equal(groups[0].stats.mean, 0)
+  assert.equal(anomalies.length, 0)
+})
+
+test('perfect trials are counted', () => {
+  const root = mkdtempSync(join(tmpdir(), 'sr-'))
+  const f1 = writeTrial(root, 'a.json', trialJson({ id: 't1', taskId: 'S1-static-scan', trialName: 'S1-static-scan__r1', reward: 1 }))
+  const f2 = writeTrial(root, 'b.json', trialJson({ id: 't2', taskId: 'S1-static-scan', trialName: 'S1-static-scan__r2', reward: 1 }))
+  const f3 = writeTrial(root, 'c.json', trialJson({ id: 't3', taskId: 'S2-negative-scan', trialName: 'S2-negative-scan__r1', reward: 0.5 }))
+  const { groups } = summarize([{ label: 'run', paths: [f1, f2, f3] }])
+  rmSync(root, { recursive: true, force: true })
+  assert.equal(groups[0].stats.perfect, 2)
+})
+
+test('no-reward trial is an anomaly and never scored as 0', () => {
+  const root = mkdtempSync(join(tmpdir(), 'sr-'))
+  const f1 = writeTrial(root, 'a.json', trialJson({ id: 't1', taskId: 'S1-static-scan', trialName: 'S1-static-scan__r1', reward: 1 }))
+  const f2 = writeTrial(root, 'b.json', trialJson({ id: 't2', taskId: 'S2-negative-scan', trialName: 'S2-negative-scan__r1', reward: null }))
+  const { groups, anomalies } = summarize([{ label: 'run', paths: [f1, f2] }])
+  rmSync(root, { recursive: true, force: true })
+  assert.equal(groups[0].stats.scored, 1)
+  assert.equal(groups[0].stats.unscored, 1)
+  assert.equal(groups[0].stats.mean, 1)
+  assert.equal(groups[0].tasks.size, 1)
+  assert.ok(anomalies.some((entry) => entry.type === 'no-reward'))
+})
+
+test('scored trial with an execution exception keeps its reward and is flagged', () => {
+  const root = mkdtempSync(join(tmpdir(), 'sr-'))
+  const file = writeTrial(root, 'a.json', trialJson({ id: 't1', reward: 1, exception: { type: 'AgentTimeoutError' } }))
+  const { groups, anomalies } = summarize([{ label: 'run', paths: [file] }])
+  rmSync(root, { recursive: true, force: true })
+  assert.equal(groups[0].stats.scored, 1)
+  assert.equal(groups[0].stats.rewardSum, 1)
+  assert.ok(anomalies.some((entry) => entry.type === 'scored-with-exception' && entry.message.includes('reward kept')))
+})
+
+test('reward below 0 fails loudly', () => {
+  const root = mkdtempSync(join(tmpdir(), 'sr-'))
+  const file = writeTrial(root, 'a.json', trialJson({ id: 't1', reward: -0.1 }))
+  assert.throws(() => summarize([{ label: 'run', paths: [file] }]), /malformed reward/)
+  rmSync(root, { recursive: true, force: true })
+})
+
+test('reward above 1 fails loudly', () => {
+  const root = mkdtempSync(join(tmpdir(), 'sr-'))
+  const file = writeTrial(root, 'a.json', trialJson({ id: 't1', reward: 1.2 }))
+  assert.throws(() => summarize([{ label: 'run', paths: [file] }]), /malformed reward/)
+  rmSync(root, { recursive: true, force: true })
+})
+
+test('malformed JSON fails with an actionable message', () => {
+  const root = mkdtempSync(join(tmpdir(), 'sr-'))
+  const file = join(root, 'broken.json')
+  writeFileSync(file, '{not json')
+  assert.throws(() => summarize([{ label: 'run', paths: [file] }]), /not valid JSON/)
+  rmSync(root, { recursive: true, force: true })
+})
+
+test('unsupported schema fails with an actionable message', () => {
+  const root = mkdtempSync(join(tmpdir(), 'sr-'))
+  const file = join(root, 'other.json')
+  writeFileSync(file, JSON.stringify({ some: 'random shape' }))
+  assert.throws(() => summarize([{ label: 'run', paths: [file] }]), /unsupported Harbor result\.json schema/)
+  rmSync(root, { recursive: true, force: true })
+})
+
+test('the same input file listed twice is a hard error', () => {
+  const root = mkdtempSync(join(tmpdir(), 'sr-'))
+  const file = writeTrial(root, 'a.json', trialJson({ id: 't1' }))
+  assert.throws(
+    () => summarize([{ label: 'run', paths: [file, file] }]),
+    /duplicate input file listed twice/,
+  )
+  rmSync(root, { recursive: true, force: true })
+})
+
+test('the same trial id loaded from two different files is a hard error', () => {
+  const root = mkdtempSync(join(tmpdir(), 'sr-'))
+  const f1 = writeTrial(root, 'a.json', trialJson({ id: 'same-id' }))
+  const f2 = writeTrial(root, 'b.json', trialJson({ id: 'same-id' }))
+  assert.throws(() => summarize([{ label: 'run', paths: [f1, f2] }]), /duplicate trial "same-id" loaded twice/)
+  rmSync(root, { recursive: true, force: true })
+})
+
+test('two groups produce a paired comparison with deltas', () => {
+  const root = mkdtempSync(join(tmpdir(), 'sr-'))
+  const files = {
+    a1: writeTrial(root, 'a1.json', trialJson({ id: 'a1', taskId: 'S1-static-scan', trialName: 'S1-static-scan__a1', reward: 1 })),
+    a2: writeTrial(root, 'a2.json', trialJson({ id: 'a2', taskId: 'S2-negative-scan', trialName: 'S2-negative-scan__a1', reward: 0.4 })),
+    b1: writeTrial(root, 'b1.json', trialJson({ id: 'b1', taskId: 'S1-static-scan', trialName: 'S1-static-scan__b1', reward: 0.6 })),
+    b2: writeTrial(root, 'b2.json', trialJson({ id: 'b2', taskId: 'S2-negative-scan', trialName: 'S2-negative-scan__b1', reward: 0.4 })),
+  }
+  const { comparison } = summarize([
+    { label: 'with-skill', paths: [files.a1, files.a2] },
+    { label: 'no-skill', paths: [files.b1, files.b2] },
+  ])
+  rmSync(root, { recursive: true, force: true })
+  assert.equal(comparison.commonTaskCount, 2)
+  const s1 = comparison.rows.find((row) => row.taskId === 'S1-static-scan')
+  assert.equal(s1.delta, 0.4)
+  assert.equal(comparison.improved, 1)
+  assert.equal(comparison.tied, 1)
+  assert.equal(comparison.regressed, 0)
+})
+
+test('a task present in only one group is excluded from deltas and listed as an anomaly', () => {
+  const root = mkdtempSync(join(tmpdir(), 'sr-'))
+  const f1 = writeTrial(root, 'a1.json', trialJson({ id: 'a1', taskId: 'S1-static-scan', trialName: 'S1-static-scan__a1', reward: 1 }))
+  const f2 = writeTrial(root, 'a2.json', trialJson({ id: 'a2', taskId: 'S2-negative-scan', trialName: 'S2-negative-scan__a1', reward: 0.5 }))
+  const f3 = writeTrial(root, 'b1.json', trialJson({ id: 'b1', taskId: 'S1-static-scan', trialName: 'S1-static-scan__b1', reward: 0.6 }))
+  const { comparison, anomalies } = summarize([
+    { label: 'with-skill', paths: [f1, f2] },
+    { label: 'no-skill', paths: [f3] },
+  ])
+  rmSync(root, { recursive: true, force: true })
+  assert.equal(comparison.commonTaskCount, 1)
+  assert.ok(comparison.missing.some((entry) => entry.taskId === 'S2-negative-scan' && entry.missingIn === 'no-skill'))
+  assert.ok(anomalies.some((entry) => entry.type === 'missing-in-group' && entry.taskId === 'S2-negative-scan'))
+  assert.equal(comparison.rows.length, 1)
+})
+
+test('improvement/tie/regression counts are computed from deltas', () => {
+  const root = mkdtempSync(join(tmpdir(), 'sr-'))
+  const mk = (id, task, reward) => writeTrial(root, `${id}.json`, trialJson({ id, taskId: task, trialName: `${task}__${id}`, reward }))
+  const a = [mk('a1', 'T1', 0.8), mk('a2', 'T2', 0.5), mk('a3', 'T3', 0.2)]
+  const b = [mk('b1', 'T1', 0.4), mk('b2', 'T2', 0.5), mk('b3', 'T3', 0.9)]
+  const { comparison } = summarize([
+    { label: 'A', paths: a },
+    { label: 'B', paths: b },
+  ])
+  rmSync(root, { recursive: true, force: true })
+  assert.equal(comparison.improved, 1)
+  assert.equal(comparison.tied, 1)
+  assert.equal(comparison.regressed, 1)
+})
+
+test('JSON output is deterministic and contains raw numbers', () => {
+  const root = mkdtempSync(join(tmpdir(), 'sr-'))
+  const f1 = writeTrial(root, 'a1.json', trialJson({ id: 'a1', taskId: 'S1-static-scan', trialName: 'S1-static-scan__a1', reward: 1 }))
+  const f2 = writeTrial(root, 'a2.json', trialJson({ id: 'a2', taskId: 'S2-negative-scan', trialName: 'S2-negative-scan__a1', reward: 0.4 }))
+  const summary = summarize([{ label: 'run', paths: [f1, f2] }])
+  const first = renderJson(summary)
+  const second = renderJson(summary)
+  rmSync(root, { recursive: true, force: true })
+  assert.equal(first, second)
+  const parsed = JSON.parse(first)
+  assert.equal(parsed.groups.run.mean, 0.7)
+  assert.equal(typeof parsed.groups.run.median, 'number')
+  assert.deepEqual(parsed.anomalies, [])
+})
+
+test('Markdown output is deterministic and lists the anomalies section', () => {
+  const root = mkdtempSync(join(tmpdir(), 'sr-'))
+  const f1 = writeTrial(root, 'a1.json', trialJson({ id: 'a1', taskId: 'S1-static-scan', trialName: 'S1-static-scan__a1', reward: 1 }))
+  const f2 = writeTrial(root, 'a2.json', trialJson({ id: 'a2', taskId: 'S2-negative-scan', trialName: 'S2-negative-scan__a1', reward: null }))
+  const summary = summarize([{ label: 'run', paths: [f1, f2] }])
+  const first = renderMarkdown(summary)
+  const second = renderMarkdown(summary)
+  rmSync(root, { recursive: true, force: true })
+  assert.equal(first, second)
+  assert.match(first, /# Benchmark Run Summary/)
+  assert.match(first, /## Anomalies/)
+  assert.match(first, /\[no-reward\]/)
+})
+
+test('no groups at all is a hard error', () => {
+  assert.throws(() => parseGroupArgs([]), /no --group given/)
+})
+
+test('job-level result.json expands into per-trial records from reward_stats', () => {
+  const root = mkdtempSync(join(tmpdir(), 'sr-'))
+  const file = join(root, 'job.json')
+  writeFileSync(file, JSON.stringify(jobJson({ rewards: { '1.0': ['S1-static-scan__r1', 'S2-negative-scan__r1'], '0.5': ['S3-snapshot-migration__r1'] } })))
+  const { groups, notes } = summarize([{ label: 'run', paths: [file] }])
+  rmSync(root, { recursive: true, force: true })
+  assert.equal(groups[0].stats.records, 3)
+  assert.equal(groups[0].stats.scored, 3)
+  assert.equal(groups[0].stats.rewardSum, 2.5)
+  assert.ok(notes.some((entry) => entry.type === 'task-id-fallback'))
+})
+
+test('job-level cancelled trial count is reported as an anomaly', () => {
+  const root = mkdtempSync(join(tmpdir(), 'sr-'))
+  const file = join(root, 'job.json')
+  writeFileSync(file, JSON.stringify(jobJson({ rewards: { '1.0': ['S1-static-scan__r1'] }, cancelled: 2 })))
+  const { anomalies } = summarize([{ label: 'run', paths: [file] }])
+  rmSync(root, { recursive: true, force: true })
+  assert.ok(anomalies.some((entry) => entry.type === 'cancelled-count' && entry.message.includes('2')))
+})
+
+test('job-level exception without a reward is an anomaly', () => {
+  const root = mkdtempSync(join(tmpdir(), 'sr-'))
+  const file = join(root, 'job.json')
+  writeFileSync(file, JSON.stringify(jobJson({ rewards: { '1.0': ['S1-static-scan__r1'] }, exceptions: { AgentTimeoutError: ['S2-negative-scan__r1'] } })))
+  const { anomalies, groups } = summarize([{ label: 'run', paths: [file] }])
+  rmSync(root, { recursive: true, force: true })
+  assert.equal(groups[0].stats.scored, 1)
+  assert.ok(anomalies.some((entry) => entry.type === 'exception' && entry.message.includes('AgentTimeoutError')))
+})
+
+test('normalizeFile on a trial-level object yields one record with normalized task id', () => {
+  const parsed = trialJson({ id: 't1', taskId: 'H11-remote-result-boundary-trap' })
+  const result = normalizeFile(parsed, 'run', '/tmp/example.json')
+  assert.equal(result.records.length, 1)
+  assert.equal(result.records[0].taskId, 'H11-remote-result-boundary-trap')
+  assert.equal(result.records[0].scored, true)
+})
+
+test('loadResultFile throws for a missing path', () => {
+  assert.throws(() => loadResultFile('/tmp/definitely-not-present-xyz.json'), /result file not found/)
+})

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "test": "npm run validate && npm run test:release && npm run test:audit && npm run test:dsh:cases",
-    "validate": "node scripts/validate.mjs && node scripts/validate-manifests.mjs && node benchmark/scripts/validate-task-registry.mjs && node benchmark/scripts/validate-execution-contract.mjs && node --test benchmark/scripts/validate-task-registry.test.mjs && node benchmark/scripts/validate-evaluation-snapshots.mjs && node --test benchmark/scripts/validate-evaluation-snapshots.test.mjs && node benchmark/scripts/validate-checkpoints.mjs && node --test benchmark/scripts/validate-checkpoints.test.mjs && node benchmark/scripts/validate-task-toml.mjs && node --test benchmark/scripts/validate-task-toml.test.mjs && npm run test:h11-judge && node --test benchmark/tasks/H12-remote-result-boundary-trap/tests/parse-sections.test.mjs && node skills/plugin-upgrade/scripts/verify-runtime.check.mjs && npm run test:smoke",
+    "validate": "node scripts/validate.mjs && node scripts/validate-manifests.mjs && node benchmark/scripts/validate-task-registry.mjs && node benchmark/scripts/validate-execution-contract.mjs && node --test benchmark/scripts/validate-task-registry.test.mjs && node benchmark/scripts/validate-evaluation-snapshots.mjs && node --test benchmark/scripts/validate-evaluation-snapshots.test.mjs && node benchmark/scripts/validate-checkpoints.mjs && node --test benchmark/scripts/validate-checkpoints.test.mjs && node benchmark/scripts/validate-task-toml.mjs && node --test benchmark/scripts/validate-task-toml.test.mjs && npm run test:h11-judge && node --test benchmark/tasks/H12-remote-result-boundary-trap/tests/parse-sections.test.mjs && node --test benchmark/scripts/summarize-runs.test.mjs && node skills/plugin-upgrade/scripts/verify-runtime.check.mjs && npm run test:smoke",
     "validate:skills": "node scripts/validate.mjs",
     "validate:manifests": "node scripts/validate-manifests.mjs",
     "validate:benchmark-registry": "node benchmark/scripts/validate-task-registry.mjs",
@@ -14,6 +14,7 @@
     "validate:benchmark-checkpoints": "node benchmark/scripts/validate-checkpoints.mjs",
     "validate:benchmark-toml": "node benchmark/scripts/validate-task-toml.mjs",
     "test:h11-judge": "node --test benchmark/tasks/H11-dual-cohort-rpc/tests/judge-utils.test.mjs",
+    "test:benchmark-summary": "node --test benchmark/scripts/summarize-runs.test.mjs",
     "validate:naming": "node skills/plugin-write/scripts/validate-names.check.mjs",
     "validate:registry": "node skills/plugin-write/scripts/query-registry.check.mjs",
     "verify:runtime": "node skills/plugin-upgrade/scripts/verify-runtime.check.mjs",


### PR DESCRIPTION
## Summary

Add a deterministic Harbor `result.json` aggregator for benchmark experiments.

It computes scored-trial and per-task statistics directly from trial rewards
instead of relying on Harbor's built-in aggregate mean, which can be misleading
when a job contains stopped/unscored trials or when one benchmark task is run in
a separate job.

The tool supports repeated runs per task, two-group paired comparison, Markdown
and JSON output, and explicit anomaly reporting.

## Why

The existing 2026-09-01 benchmark situation showed exactly this failure mode:
a stopped trial existed in the main result and one task ran separately, so
Harbor's built-in mean did not equal the intended benchmark task-set mean.

## Behavior

- repeated trials aggregate by task (n / mean / median / min / max / perfect)
- per-task median for the paired comparison (group A − group B)
- no-reward trials excluded from scores but reported as anomalies, never scored as 0
- a scored trial that also records an execution exception keeps its reward and is flagged
- missing paired tasks are never treated as zero
- duplicate inputs, malformed rewards, and unsupported schemas are hard errors
- accepts both trial-level and job-level `result.json` shapes

## Verification

- unit tests: 35/35 pass (no Docker / Harbor / network; includes ambiguous-reward and malformed job-level regression cases)
- `npm test`: green (the aggregator tests are wired into the standard validate chain)
- `node benchmark/scripts/validate-task-registry.mjs`: OK (23 tasks)
- registry self-tests 15/15; `validate-execution-contract.mjs`: 23 tasks
- `node scripts/validate.mjs` / `validate-manifests.mjs`: pass
- `git diff --check`: pass
- real-result smoke: three real oracle `result.json` files (H5 / H6 / H11) →
  reward sum 3, mean 1, median 1, perfect 3; a real job-level `result.json`
  expands correctly
- the 2026-09-01 18-task source files are not present on this machine, so the
  15.15/18 reproduction was not run

## Review fixes

- ambiguous reward objects (multiple keys without a canonical `reward` key) now hard-error with the offending keys instead of silently picking the first; empty reward objects and malformed values hard-error too; a single non-canonical numeric key keeps working
- malformed job-level structures (non-object eval entries, non-object/non-array `reward_stats`/`exception_stats` entries, non-string trial names) now fail loudly instead of being silently dropped
- nits: removed the dead `verifier_result` condition, consistent 4-decimal rounding for group medians, Markdown label escaping for `|`/newlines, and the top-level mean is now labeled "Trial mean" with an explicit trial-weighted note
- the cross-group duplicate trial-ID policy is intentionally unchanged

## Scope

Only:

- `benchmark/scripts/summarize-runs.mjs` + unit tests
- package.json test wiring
- a "Summarizing Harbor runs" section in `benchmark/README.md`

No task, skill, or paper changes.
