### PR TITLE
docs(benchmark): add Terra skill-effectiveness results

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -45,47 +45,76 @@ honestly instead of quietly fixing it and pretending nothing happened).
 
 ## Benchmark results
 
-On 2026-09-01, Codex ran the then-current 19-task snapshot with
-`openai/gpt-5.6-luna` at `xhigh` reasoning effort in two configurations: with
-`skills/plugin-upgrade`, and with no skill supplied by Harbor. The selected
-single-run results are shown below. `M5-token-auth-smoke` and `H8-fire-drill` were
-added later and therefore have no scores in these reports.
+On 2026-09-01, Codex ran the benchmark at `xhigh` reasoning effort with
+`openai/gpt-5.6-terra` on a 22-task snapshot and with
+`openai/gpt-5.6-luna` on the earlier 19-task snapshot. Terra was tested both
+with `skills/plugin-upgrade` and with Harbor-injected and Codex-native skills
+fully disabled. Luna was tested with `skills/plugin-upgrade` and with no skill
+supplied by Harbor, although native Codex skills remained available in the
+latter condition. These rows belong to the same benchmark family but are not a
+direct model comparison: `S8-release-routing-trap`, `M5-token-auth-smoke`, and
+`H8-fire-drill` were added after the Luna snapshot, while
+`H10-browser-activation-trap` was added after the Terra runs.
 
-| Configuration | Scope | reward | mean | perfect tasks | Detailed report |
-|---|---:|---:|---:|---:|---|
-| With `skills/plugin-upgrade` | 19-task 2026-09-01 snapshot | 15.95/19 | 0.8395 | 13 | [18-task batch](results/validation-report-2026-09-01-codex-gpt-5.6-luna-other-18.md) · [real-repository task](results/validation-report-2026-09-01.md) |
-| No Harbor-injected skill | 19-task 2026-09-01 snapshot | 13.09/19 | 0.6889 | 10 | [18-task batch](results/validation-report-2026-09-01-codex-gpt-5.6-luna-other-18-no-injected-skill.md) · [real-repository task](results/validation-report-2026-09-01-h8-dsh-web-alpha2-no-skill.md) |
+| Model | Skill condition | Scope | reward | mean | perfect tasks | Summed job duration | Tokens (input / cache / output) | Cost | Detailed report |
+|---|---|---|---:|---:|---:|---:|---:|---:|---|
+| `openai/gpt-5.6-terra` | With `skills/plugin-upgrade` | 22-task 2026-09-01 snapshot; 21 rewarded + 1 verifier error | 16.75/21 scored; 16.75/22 conservative | 0.7976 scored; 0.7614 conservative | 13 | 2h33m58.860s | 54,094,444 / 51,131,904 / 355,256 | $20.4145 | [22-task report](results/validation-report-2026-09-01-codex-gpt-5.6-terra-all-22.md) |
+| `openai/gpt-5.6-terra` | Literal zero skill | 22-task 2026-09-01 snapshot; 21 rewarded + 1 verifier error | 14.93/21 scored; 14.93/22 conservative | 0.7110 scored; 0.6786 conservative | 10 | 2h51m32s | 46,824,114 / 44,432,640 / 283,652 | $17.0733 | [22-task literal-no-skill report](results/validation-report-2026-09-01-codex-gpt-5.6-terra-all-22-literal-no-skill.md) |
+| `openai/gpt-5.6-luna` | With `skills/plugin-upgrade` | 19-task 2026-09-01 snapshot | 15.95/19 | 0.8395 | 13 | 1h38m30.556s | 57,118,102 / 54,630,656 / 332,161 | $1.9887 | [18-task batch](results/validation-report-2026-09-01-codex-gpt-5.6-luna-other-18.md) · [real-repository task](results/validation-report-2026-09-01.md) |
+| `openai/gpt-5.6-luna` | No Harbor-injected skill† | 19-task 2026-09-01 snapshot | 13.09/19 | 0.6889 | 10 | 1h49m25.650s | 36,761,760 / 34,515,712 / 244,223 | $1.4326 | [18-task batch](results/validation-report-2026-09-01-codex-gpt-5.6-luna-other-18-no-injected-skill.md) · [real-repository task](results/validation-report-2026-09-01-h8-dsh-web-alpha2-no-skill.md) |
 
-Per-task comparison (`delta = with-skill - no-Harbor-skill`):
+Duration is the sum of the Harbor job durations represented in each report;
+concurrent jobs therefore remain additive rather than being collapsed into an
+elapsed wall-clock window. Token cells are ordered as input / cache / output.
+Cache tokens are a subset of input tokens and must not be added to input when
+calculating total consumption. Costs are the Harbor-recorded USD totals. The
+Luna resource totals were recovered from the persisted historical
+`result.json` artifacts underlying the linked reports. The Terra literal
+zero-skill row uses the exact retained result-file totals; its report notes
+that the provider's absolute billing total is higher because Harbor erased the
+first H8 agent attempt when retrying it.
 
-| Task | with skill | no Harbor-injected skill | delta |
-|---|---:|---:|---:|
-| S1-static-scan | 1.00 | 0.67 | +0.33 |
-| S2-negative-scan | 1.00 | 0.60 | +0.40 |
-| S3-snapshot-migration | 1.00 | 0.00 | +1.00 |
-| H4-tsbuildinfo-trap | 1.00 | 0.30 | +0.70 |
-| M1-host-migration | 1.00 | 1.00 | 0.00 |
-| H1-plane-trap | 1.00 | 1.00 | 0.00 |
-| H2-baseline-trap | 1.00 | 1.00† | 0.00 |
-| H3-client-plane | 1.00 | 1.00† | 0.00 |
-| H5-runtime-export-drift | 1.00 | 1.00 | 0.00 |
-| H9-dsh-web-alpha2 | 0.80 | 0.67 | +0.13 |
-| S4-legacy-client-imports | 1.00 | 1.00 | 0.00 |
-| S5-negative-naming | 0.75 | 0.50 | +0.25 |
-| H6-remote-error-trap | 0.00 | 0.00 | 0.00 |
-| S6-corridor-net-state | 0.25 | 0.25 | 0.00 |
-| S7-unpublished-cohort | 0.25 | 0.10 | +0.15 |
-| M2-optional-dep-trap | 1.00 | 1.00 | 0.00 |
-| M3-session-projection | 1.00 | 1.00 | 0.00 |
-| M4-peer-prerelease-range | 1.00 | 1.00 | 0.00 |
-| H7-locale-trap | 0.90 | 1.00 | -0.10 |
+Per-task skill comparison (`delta = with-skill - corresponding no-skill
+condition`; `—` means the task was absent or no verifier reward existed):
 
-The observed with-skill uplift is **+2.86 reward points across 19 tasks**, or
-**+0.1505 mean reward**. Seven tasks improved, eleven tied, and one (H7) was
-0.10 lower. The largest gains were S3 (+1.00), H4 (+0.70), S2 (+0.40), and S1
-(+0.33). H6 remained at 0 in both configurations, while the real-repository
-task (run as H8 and now numbered H9) improved from 0.67 to 0.80 but did not
-complete the full runtime validation in either run.
+| Task | Luna with skill | Luna no Harbor skill | Luna delta | Terra with skill | Terra literal zero skill | Terra delta |
+|---|---:|---:|---:|---:|---:|---:|
+| S1-static-scan | 1.00 | 0.67 | +0.33 | 1.00 | 0.83 | +0.17 |
+| S2-negative-scan | 1.00 | 0.60 | +0.40 | 1.00 | 0.60 | +0.40 |
+| S3-snapshot-migration | 1.00 | 0.00 | +1.00 | 1.00 | 0.20 | +0.80 |
+| H4-tsbuildinfo-trap | 1.00 | 0.30 | +0.70 | 1.00 | 0.30 | +0.70 |
+| M1-host-migration | 1.00 | 1.00 | 0.00 | 1.00 | 1.00 | 0.00 |
+| H1-plane-trap | 1.00 | 1.00 | 0.00 | 1.00 | 1.00 | 0.00 |
+| H2-baseline-trap | 1.00 | 1.00† | 0.00 | 1.00 | 1.00 | 0.00 |
+| H3-client-plane | 1.00 | 1.00† | 0.00 | 1.00 | 1.00 | 0.00 |
+| H5-runtime-export-drift | 1.00 | 1.00 | 0.00 | 0.20 | 1.00 | -0.80 |
+| M5-token-auth-smoke | — | — | — | 0.60 | 0.60 | 0.00 |
+| H8-fire-drill | — | — | — | error | error | — |
+| H9-dsh-web-alpha2 | 0.80 | 0.67 | +0.13 | 0.80 | 0.50 | +0.30 |
+| H10-browser-activation-trap | — | — | — | — | — | — |
+| S4-legacy-client-imports | 1.00 | 1.00 | 0.00 | 1.00 | 1.00 | 0.00 |
+| S5-negative-naming | 0.75 | 0.50 | +0.25 | 0.75 | 0.50 | +0.25 |
+| H6-remote-error-trap | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| S6-corridor-net-state | 0.25 | 0.25 | 0.00 | 0.25 | 0.25 | 0.00 |
+| S7-unpublished-cohort | 0.25 | 0.10 | +0.15 | 0.25 | 0.25 | 0.00 |
+| S8-release-routing-trap | — | — | — | 1.00 | 1.00 | 0.00 |
+| M2-optional-dep-trap | 1.00 | 1.00 | 0.00 | 1.00 | 1.00 | 0.00 |
+| M3-session-projection | 1.00 | 1.00 | 0.00 | 1.00 | 1.00 | 0.00 |
+| M4-peer-prerelease-range | 1.00 | 1.00 | 0.00 | 1.00 | 1.00 | 0.00 |
+| H7-locale-trap | 0.90 | 1.00 | -0.10 | 0.90 | 0.90 | 0.00 |
+
+For Luna, the observed with-skill uplift is **+2.86 reward points across 19
+tasks**, or **+0.1505 mean reward**. Seven tasks improved, eleven tied, and one
+(H7) was 0.10 lower. The largest gains were S3 (+1.00), H4 (+0.70), S2 (+0.40),
+and S1 (+0.33). H6 remained at 0 in both configurations, while the
+real-repository task (run as H8 and now numbered H9) improved from 0.67 to 0.80
+but did not complete the full runtime validation in either run.
+
+For Terra, the observed with-skill uplift is **+1.82 reward points across the
+21 tasks with verifier rewards**, or **+0.0867 mean reward**. Six tasks
+improved, fourteen tied, and one (H5) was 0.80 lower. The largest gains were S3
+(+0.80), H4 (+0.70), S2 (+0.40), and H9 (+0.30). H8 produced no verifier
+reward in either Terra condition and is excluded from this delta.
 
 These numbers are evidence from one selected attempt per task and condition,
 not the three-run median recommended below. They also have these protocol

--- a/benchmark/results/validation-report-2026-09-01-codex-gpt-5.6-terra-all-22-literal-no-skill.md
+++ b/benchmark/results/validation-report-2026-09-01-codex-gpt-5.6-terra-all-22-literal-no-skill.md
@@ -1,0 +1,316 @@
+# benchmark task validation report · 2026-09-01
+
+End-to-end validation of all 22 tasks under `benchmark/tasks`, with Codex and
+`openai/gpt-5.6-terra`, with both Harbor-injected and Codex-native skills
+disabled: **all 22 tasks received a complete model attempt, 21 produced
+verifier rewards, and H8 ended in `VerifierTimeoutError`. The 21 accepted
+rewards total 14.93/21 with a mean of 0.7110 (verifier score 1493/2100). If
+the unscored H8 exception is conservatively counted as zero, the full-cohort
+diagnostic is 14.93/22 with a mean of 0.6786 (1493/2200).**
+
+This is a **literal zero-skill result**. No Harbor `--skill` argument was
+supplied; every selected job and trial records no injected skill; Codex was
+started with `skills.include_instructions=false` and
+`skills.bundled.enabled=false`. Audit of all 22 selected trajectories found
+zero `<skills_instructions>` blocks, zero concrete skill-path hits, and no
+skill-file read. Seven trials used a generic repository-discovery command
+whose filename glob mentioned `SKILL.md`, but none found or opened one.
+
+## Environment
+
+- Harbor CLI 0.22.0
+- Docker Desktop 29.7.2 (macOS, local provider)
+- Agent: Codex 0.152.0, model `openai/gpt-5.6-terra`
+- Harbor-injected skill: none (`--skill` omitted; trial configuration has no
+  skill)
+- Codex-native system skills: catalog and instructions disabled with
+  `skills.include_instructions=false` and `skills.bundled.enabled=false`
+- Reasoning effort: `xhigh`
+- Main-batch concurrency: 4 trials / 4 agent phases
+- Agent setup timeout multiplier: `4.0`
+- Agent/verifier timeout multiplier: `2.0`
+- H8 supplemental verifier timeout multiplier: `4.0`
+- Main retry policy: at most one retry for every exception other than
+  `AgentTimeoutError`; the main result records two retries
+- H9 closed-book protocol: task-declared `no-network` plus runner-level
+  `web_search=disabled`
+- The user explicitly requested Codex, this model, no skill, and every task,
+  authorizing the benchmark sources to be sent to OpenAI for this run;
+  `chatgpt.com` was allowed for model connectivity.
+
+## How to reproduce
+
+The primary selected job used a temporary loadable copy of the 22-task
+dataset because the checked-in H7 metadata is invalid TOML. No `--skill`
+argument was supplied:
+
+```sh
+harbor run \
+  -p /private/tmp/dsh-plugin-upgrade-terra-noskill-tasks-20260901-v1/tasks \
+  -a codex \
+  -m openai/gpt-5.6-terra \
+  --ak reasoning_effort=xhigh \
+  --ak 'config={"skills":{"include_instructions":false,"bundled":{"enabled":false}}}' \
+  --ae CODEX_FORCE_AUTH_JSON=true \
+  --allow-agent-host chatgpt.com \
+  --n-concurrent 4 \
+  --n-concurrent-agents 4 \
+  --max-retries 1 \
+  --retry-exclude AgentTimeoutError \
+  --agent-setup-timeout-multiplier 4 \
+  --agent-timeout-multiplier 2 \
+  --verifier-timeout-multiplier 2 \
+  --jobs-dir /private/tmp/dsh-plugin-upgrade-terra-noskill-20260901 \
+  --job-name codex-terra-literal-no-skills-all-22-setup4-20260901 \
+  -y
+```
+
+H7's temporary copy changed only the description regex from
+`/session\s*log/i` to the valid TOML spelling `/session\\s*log/i`. Task
+instructions, fixture, tests, verifier, and every other task were byte-for-byte
+unchanged.
+
+H8's agent phase completed in the primary job, but its verifier exceeded the
+1200-second effective timeout. It was rerun alone with the same task, model,
+reasoning effort, zero-skill configuration, and a 2400-second verifier timeout:
+
+```sh
+harbor run \
+  -p /private/tmp/dsh-plugin-upgrade-terra-noskill-tasks-20260901-v1/tasks/H8-fire-drill \
+  -a codex \
+  -m openai/gpt-5.6-terra \
+  --ak reasoning_effort=xhigh \
+  --ak 'config={"skills":{"include_instructions":false,"bundled":{"enabled":false}}}' \
+  --ae CODEX_FORCE_AUTH_JSON=true \
+  --allow-agent-host chatgpt.com \
+  --n-concurrent 1 \
+  --n-concurrent-agents 1 \
+  --max-retries 0 \
+  --agent-setup-timeout-multiplier 4 \
+  --agent-timeout-multiplier 2 \
+  --verifier-timeout-multiplier 4 \
+  --jobs-dir /private/tmp/dsh-plugin-upgrade-terra-noskill-h8-supplement-20260901 \
+  --job-name codex-terra-h8-literal-no-skills-vtimeout4-20260901 \
+  -y
+```
+
+The main-batch H9 produced 0.70, but that run did not explicitly disable
+provider-side search. Its trajectory used only local `exec` calls and did not
+actually invoke search, but it is not accepted as auditable closed-book proof.
+H9 was therefore rerun through its checked-in closed-book wrapper, whose final
+argument pins `web_search=disabled`; the compliant 0.50 reward replaces 0.70:
+
+```sh
+benchmark/tasks/H9-dsh-web-alpha2/run-codex-closed-book.sh \
+  -m openai/gpt-5.6-terra \
+  --ak reasoning_effort=xhigh \
+  --ak 'config={"skills":{"include_instructions":false,"bundled":{"enabled":false}}}' \
+  --ae CODEX_FORCE_AUTH_JSON=true \
+  --allow-agent-host chatgpt.com \
+  --n-concurrent 1 \
+  --n-concurrent-agents 1 \
+  --max-retries 1 \
+  --retry-exclude AgentTimeoutError \
+  --agent-setup-timeout-multiplier 4 \
+  --agent-timeout-multiplier 2 \
+  --verifier-timeout-multiplier 2 \
+  --jobs-dir /private/tmp/dsh-plugin-upgrade-terra-noskill-h9-closed-book-20260901 \
+  --job-name codex-terra-h9-literal-no-skills-closed-book-v2-20260901 \
+  -y
+```
+
+Task sources and candidate fixtures were isolated in Docker. The host
+workspace was not an agent write target, and its pre-existing untracked report
+was preserved.
+
+## Results summary
+
+| Task | reward | verifier | Key result |
+|---|---:|---:|---|
+| `H1-plane-trap` | 1.0 | 100/100 | Injected host-plane `llm`, installed successfully, and cold-booted with no pending plugin |
+| `H2-baseline-trap` | 1.0 | 100/100 | Preserved and correctly attributed the pre-existing failing test; cold boot activated |
+| `H3-client-plane` | 1.0 | 100/100 | Added the top-level Web client declaration and appeared in `__DSH_BOOT__.entries` |
+| `H4-tsbuildinfo-trap` | 0.3 | 30/100 | Found the stale artifact and clean/rebuild path, but omitted the explicit no-source-change conclusion and hit the nonexistent-reference trap |
+| `H5-runtime-export-drift` | 1.0 | 100/100 | Aligned the settings cohort, packed and installed a tarball, and cold-booted without export or pending failures |
+| `H6-remote-error-trap` | 0.0 | 0/100 | Kept the fixture read-only but omitted all four graded Remote error-flow migration requirements |
+| `H7-locale-trap` | 0.9 | 90/100 | Replaced display-text matching with a stable `data-slot` and reached the browser roster, but omitted the separate explicit render assertion |
+| `H8-fire-drill` | error | — | Agent completed all four acts and its token/Cookie smoke, but the sealed verifier timed out at 1200 seconds and again at 2400 seconds |
+| `H9-dsh-web-alpha2` | 0.5 | 50/100 | Closed-book run aligned 248 SDK/Cordis declarations and several contracts, but scored 0/13 settings migrations and stayed below the runtime-gate threshold |
+| `M1-host-migration` | 1.0 | 100/100 | Installed the fixture and reached the host application layer without pending entries |
+| `M2-optional-dep-trap` | 1.0 | 100/100 | Moved the unconditionally imported package to `dependencies`; cold boot activated |
+| `M3-session-projection` | 1.0 | 100/100 | Corrected profile composition while retaining `dsh-tool-todo`; cold boot activated |
+| `M4-peer-prerelease-range` | 1.0 | 100/100 | Rewrote peer/dev bounds to `^0.1.2-alpha.2`; install and cold boot passed |
+| `M5-token-auth-smoke` | 0.6 | 60/100 | Token/Cookie smoke returned 401 then 200, but raw `webServer.register` remained and triggered the cap |
+| `S1-static-scan` | 0.83 | 83/100 | Kept the fixture read-only and found five required cards, but missed A1-08 |
+| `S2-negative-scan` | 0.6 | 60/100 | Covered zero-hit uncertainty and the need for real verification, but did not map the positive APIProxy hit to A1-01 |
+| `S3-snapshot-migration` | 0.2 | 20/100 | Identified the legacy projection but missed the lifecycle seat, Cordis type import, slots registration, and A1-03 |
+| `S4-legacy-client-imports` | 1.0 | 100/100 | Kept the fixture read-only and mapped A1-25, A1-26, A1-27, and A1-30 |
+| `S5-negative-naming` | 0.5 | 50/100 | Correctly handled the shared `events` channel and unknown state, but omitted the `greet` judgment and misclassified the services warning |
+| `S6-corridor-net-state` | 0.25 | 25/100 | Cited both corridor cards but missed the deletion conclusion, producer semantics, and `Session.append` gap |
+| `S7-unpublished-cohort` | 0.25 | 25/100 | Gave two legal install paths but missed registry proof, caret semantics, and exit/package-manager discipline |
+| `S8-release-routing-trap` | 1.0 | 100/100 | Diagnosed mirror tag lag and forward incompatibility, chose the rc-compatible release, and prescribed mirror synchronization |
+
+Distribution:
+
+| reward | count |
+|---:|---:|
+| 1.0 | 10 |
+| 0.9 | 1 |
+| 0.83 | 1 |
+| 0.6 | 2 |
+| 0.5 | 2 |
+| 0.3 | 1 |
+| 0.25 | 2 |
+| 0.2 | 1 |
+| 0.0 | 1 |
+| verifier error / no reward | 1 |
+
+The primary raw result is:
+
+`/private/tmp/dsh-plugin-upgrade-terra-noskill-20260901/codex-terra-literal-no-skills-all-22-setup4-20260901/result.json`
+
+The selected supplemental results are:
+
+- H8 verifier retry:
+  `/private/tmp/dsh-plugin-upgrade-terra-noskill-h8-supplement-20260901/codex-terra-h8-literal-no-skills-vtimeout4-20260901/result.json`
+- H9 literal-zero-skill closed-book rerun:
+  `/private/tmp/dsh-plugin-upgrade-terra-noskill-h9-closed-book-20260901/codex-terra-h9-literal-no-skills-closed-book-v2-20260901/result.json`
+
+The primary result's built-in mean (`0.6877`) is not the selected benchmark
+mean: it conservatively treats H8 as zero and includes the non-auditable H9
+pre-run at 0.70. Replacing H9's 0.70 with the compliant 0.50 leaves 14.93
+reward across the 21 tasks with verifier output. H8 remains an execution
+exception; no semantic score is inferred from its candidate artifacts.
+
+## What the verifier confirmed
+
+- Ten tasks received full verifier credit. Eight were hands-on migrations
+  (`H1`, `H2`, `H3`, `H5`, `M1`, `M2`, `M3`, and `M4`); S4 and S8 were
+  complete read-only assessments.
+- H1, H2, H5, M1, M2, M3, and M4 passed isolated DSH install/cold-start
+  checks. H3 and H7 also passed real Web roster checks through
+  `__DSH_BOOT__.entries`.
+- H5 was verified from a packed tarball rather than a workspace link, so local
+  resolution could not hide the runtime-export drift.
+- M5's sealed token smoke confirmed 401 without a Cookie and 200 after token
+  exchange, while separately detecting that the plugin retained the raw route.
+- H9's selected run was closed-book at both layers: the task container used
+  `no-network`, and the runner disabled provider-side web search. It aligned
+  248 direct SDK/Cordis declarations, migrated the npm cohort/lock/workflow
+  partially, excluded incompatible external plugins, handled the qualified
+  task-board gateway code, and passed the inject/aggregate script regression.
+- The read-only fixtures remained unchanged for H4, H6, and S1-S8. H2's
+  pre-existing failing test also remained untouched.
+- All 22 selected trajectories identify the agent as `codex` and the model as
+  `openai/gpt-5.6-terra`. None contains a `<skills_instructions>` system block
+  or a concrete skill path. Generic `SKILL.md` discovery globs occurred in
+  seven trajectories but returned no skill file and led to no skill read.
+
+## Time and token accounting
+
+| Run | Scope | Wall time | Input tokens | Cached input | Output tokens | Estimated cost |
+|---|---|---:|---:|---:|---:|---:|
+| Primary selected job | 21 retained scored trajectories plus the main H8 attempt/retry lifecycle | 1h32m48s | 28,568,074 | 26,872,064 | 194,364 | $11.0988 |
+| H8 supplement | H8 agent rerun plus 2400-second verifier timeout | 48m21s | 2,819,813 | 2,658,304 | 17,294 | $1.0622 |
+| H9 closed-book v2 | Selected H9 replacement | 30m23s | 15,436,227 | 14,902,272 | 71,994 | $4.9123 |
+| Retained result-file total | Three rows above | 2h51m32s | 46,824,114 | 44,432,640 | 283,652 | $17.0733 |
+
+The retained result-file total is execution accounting, not the selected
+22-answer comparison set: it includes the discarded main-batch H9 trajectory
+(16,074,892 input, 15,548,416 cached, 56,092 output, $4.8357). Removing that
+discarded trajectory gives the selected 22 trajectories:
+
+- input tokens: **30,749,222**
+- cached input tokens: **28,884,224**
+- output tokens: **227,560**
+- estimated cost: **$12.2376**
+
+The preliminary main setup-only attempt ran for 7m41s and made no model call.
+The first H9 closed-book setup attempt ran for 1m58s and also made no model
+call; Codex installation failed because `@openai/codex-linux-arm64` was
+missing. From the preliminary main start at 14:26:51 through the final H9
+result at 17:36:46, end-to-end elapsed time was **3h09m55s**.
+
+One accounting limitation remains: the primary H8 agent completed before its
+1200-second verifier timeout, but Harbor's automatic retry replaced that
+trial directory and its trajectory. The main result's final token counters no
+longer include that first H8 agent call. Therefore $17.0733 is the exact total
+retained by Harbor's result files, not a claim about the provider's absolute
+billing total; actual consumption is higher by the erased first H8 attempt.
+
+## Issues found
+
+1. **H8 has no official verifier reward.** Both agent runs completed the
+   migration, isolated Web profile, cold boot, token/Cookie exchange, 401/200
+   `/ping` smoke, version bumps, and release checklist. The verifier still
+   timed out at both 1200 and 2400 seconds. `judge.mjs` calls
+   `readAgentText('/app/agent-output', TASK)`, whose helper recursively walks
+   every directory and synchronously reads all `.md`, `.txt`, `.json`,
+   `.jsonl`, and `.log` files. Terra placed its full DSH profile under
+   `/app/agent-output/H8-fire-drill/dsh-home`, so the judge traversed the
+   profile and its `node_modules` before scoring.
+2. **H9 stopped at 50/100.** The selected closed-book candidate changed 57
+   paths, including two paths outside the compatibility surface. The verifier
+   awarded dependency, cohort, aggregate, external-plugin, and task-board
+   points, but found none of the 13 settings-service seam migrations and found
+   git-graph still depending on a removed transitive type edge. Static score
+   stayed below 80, so the heavy real install/cold-start gate was skipped.
+3. **H4 accepted the trap's false premise (30/100).** It correctly identified
+   stale build output and recommended clean/rebuild, but failed to conclude
+   explicitly that source needed no changes and claimed a nonexistent
+   reference repair, triggering the cap.
+4. **H6 omitted the Remote error migration (0/100).** Its report did not cover
+   namespaced error codes, cancel propagation, internal/unknown-code handling,
+   or removal of silent error swallowing.
+5. **M5 preserved the raw route (60/100).** Authentication behavior passed the
+   real token/Cookie smoke, but `webServer.register` remained instead of
+   moving the channel to the host's unified authenticated surface.
+6. **H7 and S1-S3/S5-S7 were semantically incomplete.** H7 omitted a separate
+   render assertion. S1 missed A1-08; S2 omitted the A1-01 positive mapping;
+   S3 supplied only one of five required migration points. S5 omitted the
+   official `greet` judgment and mishandled a warning. S6 did not fold the
+   corridor into the required deletion/net-state conclusion. S7 omitted
+   registry verification, caret semantics, and exit/package-manager discipline.
+
+## Preliminary run anomalies
+
+The checked-in H7 metadata cannot be parsed by Harbor because the TOML basic
+string at line 6 contains the unescaped sequence `\s`. Python `tomllib`
+reports `Unescaped '\\' in a string (at line 6, column 72)`. Harbor silently
+omitted H7 when pointed at the checked-in task root. Only a temporary metadata
+copy was made loadable; the repository task was not changed.
+
+The first all-task job used Harbor's default setup timeout. Four concurrent
+trials reached `AgentSetupTimeoutError` before model execution; the job was
+stopped after 7m41s with no token usage and restarted with
+`--agent-setup-timeout-multiplier 4`.
+
+The primary H8 agent completed, but the 1200-second verifier timeout triggered
+Harbor's automatic retry. The retry entered setup and was cancelled after the
+first candidate had already proved that more verifier time was needed. The
+standalone H8 run disabled retries and raised the verifier budget to 2400
+seconds; it timed out again with empty verifier stdout.
+
+The first strict H9 rerun failed during Codex setup after 1m58s because npm's
+global install omitted `@openai/codex-linux-arm64`. It made no model call. An
+identical retry installed successfully and produced the selected 0.50 reward.
+
+## Conclusion
+
+**The Codex + `gpt-5.6-terra` literal-zero-skill benchmark completed model
+execution for all 22 tasks.** Twenty-one tasks have verifier rewards totaling
+14.93/21, mean 0.7110, with ten perfect tasks. H8 has a completed candidate
+but no official score because the sealed verifier timed out twice; counting
+that exception as zero gives the diagnostic full-cohort mean 0.6786.
+
+Unlike the Luna no-injected-skill reference run, this execution also disabled
+Codex's native system-skill catalog and skill instructions. All 22 selected
+trajectories passed the literal no-skill audit. The strongest results were the
+hands-on install/cold-start migrations plus S4 and S8; the main semantic gaps
+were H6, H4, H9's settings-service migration, and the incomplete static
+assessments.
+
+The host task fixtures and benchmark implementation were not modified. This
+report is the only workspace file added for the Terra literal-zero-skill
+result; the pre-existing untracked skill-injected Terra report remains
+untouched.

--- a/benchmark/results/validation-report-2026-09-01-codex-gpt-5.6-terra-all-22.md
+++ b/benchmark/results/validation-report-2026-09-01-codex-gpt-5.6-terra-all-22.md
@@ -1,0 +1,278 @@
+# benchmark task validation report · 2026-09-01
+
+End-to-end validation of all 22 tasks under `benchmark/tasks`, with Codex and
+`openai/gpt-5.6-terra`, using the Harbor-injected
+`skills/plugin-upgrade` skill: **all 22 tasks were attempted, 21 produced
+verifier rewards, and H8 ended in `VerifierTimeoutError` twice. The 21 accepted
+rewards total 16.75/21 with a mean of 0.7976 (verifier score 1675/2100). If the
+unscored H8 exception is conservatively counted as zero, the full-cohort result
+is 16.75/22 with a mean of 0.7614 (1675/2200).**
+
+This is a skill-injected result. Every selected Harbor job and trial lock
+records `skills/plugin-upgrade`, and a trajectory command audit confirmed that
+every selected task explicitly opened
+`/root/.agents/skills/plugin-upgrade/SKILL.md`. H7 required a temporary
+metadata-only TOML correction before Harbor could load it. H9 was rerun under
+its required closed-book protocol; its earlier main-batch reward was discarded.
+
+## Environment
+
+- Harbor CLI 0.22.0
+- Docker Desktop 29.7.2 (macOS, local provider)
+- Agent: Codex 0.152.0, model `openai/gpt-5.6-terra`
+- Harbor-injected skill: `skills/plugin-upgrade`
+- Reasoning effort: `xhigh`
+- Main-batch concurrency: 4 trials / 4 agent phases
+- Agent setup timeout multiplier: `5.0`
+- Agent/verifier timeout multiplier: `2.0`
+- Main retry policy: at most one retry for `NetworkConnectionError`; the
+  selected main job recorded no retries
+- H8 verifier retry multiplier: `4.0`
+- H9 agent protocol: task-declared `no-network` plus
+  `web_search=disabled`; only `chatgpt.com` was allowed for model connectivity
+- The user explicitly requested Codex, this model, this skill, and every task,
+  authorizing the benchmark sources to be sent to OpenAI for execution.
+
+The stock Harbor Codex bootstrap first timed out while provisioning Node in
+four trial containers, before any model call. The selected jobs therefore used
+the temporary adapter `/private/tmp/harbor_codex_node24_fast.py`, which
+subclasses Harbor's Codex agent and changes only setup: it uses the Node 24
+already present in the task image and installs `@openai/codex@latest` with npm.
+Agent execution, model settings, task images, mounted skill, and verifiers were
+otherwise unchanged. An install-only preflight completed before the selected
+jobs were started.
+
+Before execution, both benchmark metadata checks passed:
+
+```text
+Execution-contract validation OK: 22 tasks use BENCHMARK-AUTH-v1
+[task-registry] OK: 22 tasks, README/scoring registry consistent
+```
+
+## How to reproduce
+
+The primary selected job used the following Harbor configuration:
+
+```sh
+PYTHONPATH=/private/tmp uvx --from harbor harbor run \
+  -p benchmark/tasks \
+  -x '*h9-dsh-web-alpha2*' \
+  -a harbor_codex_node24_fast:CodexNode24Fast \
+  -m openai/gpt-5.6-terra \
+  --skill ./skills/plugin-upgrade \
+  --ak reasoning_effort=xhigh \
+  --ae CODEX_FORCE_AUTH_JSON=true \
+  --allow-agent-host chatgpt.com \
+  --artifact /app/fixture \
+  --artifact /app/agent-output \
+  --n-concurrent 4 \
+  --n-concurrent-agents 4 \
+  --max-retries 1 \
+  --retry-include NetworkConnectionError \
+  --agent-setup-timeout-multiplier 5 \
+  --agent-timeout-multiplier 2 \
+  --verifier-timeout-multiplier 2 \
+  --jobs-dir /private/tmp/dsh-plugin-upgrade-terra-all22-20260901 \
+  --job-name codex-plugin-upgrade-terra-main21-rerun1-20260901 \
+  -y
+```
+
+The main dataset loaded 21 tasks. H7 was silently omitted because the
+checked-in `task.toml` contains the invalid TOML escape `\s` in its description.
+H7 was copied to a temporary directory, and the description alone was changed
+from `/session\s*log/i` to `/session\\s*log/i`; task instructions, fixture,
+tests, and verifier were unchanged. The corrected temporary copy was then run
+with the same agent, model, injected skill, reasoning effort, connectivity, and
+timeout multipliers.
+
+The lowercase H9 exclusion pattern did not match Harbor's uppercase task
+directory, so the main batch also ran H9 and produced 0.53. That run was not
+accepted because it did not explicitly disable Codex web search. H9 was rerun
+alone from the checked-in task with the same model and skill plus
+`--ak web_search=disabled`; the task's `no-network` agent mode remained active.
+The compliant closed-book reward of 0.8 replaces the discarded 0.53.
+
+H8's agent phase completed in the primary job, but the verifier exceeded its
+1200-second effective timeout. A standalone retry used the same task, model,
+skill, and agent output with a 2400-second verifier timeout; it timed out again.
+Neither H8 attempt produced a verifier reward, so no score is inferred from the
+candidate files or the agent's own smoke report.
+
+Task sources and candidate fixtures were isolated in Docker. The host
+workspace was not an agent write target, and it was clean before this report
+was added.
+
+## Results summary
+
+| Task | reward | verifier | Key result |
+|---|---:|---:|---|
+| `H1-plane-trap` | 1.0 | 100/100 | Injected host-plane `llm`, installed successfully, and cold-booted with no pending plugin |
+| `H2-baseline-trap` | 1.0 | 100/100 | Preserved and correctly attributed the pre-existing failing test; cold boot activated |
+| `H3-client-plane` | 1.0 | 100/100 | Added the top-level Web client declaration and appeared in `__DSH_BOOT__.entries` |
+| `H4-tsbuildinfo-trap` | 1.0 | 100/100 | Identified the stale build artifact, prescribed clean/rebuild, and correctly concluded source needed no change |
+| `H5-runtime-export-drift` | 0.2 | 20/100 | Packed install and cold boot passed, but a `settingsNamespace` compatibility shim triggered the 20-point cap |
+| `H6-remote-error-trap` | 0.0 | 0/100 | Kept the fixture read-only but omitted all four required Remote error-flow migration conclusions |
+| `H7-locale-trap` | 0.9 | 90/100 | Replaced display-text matching with a stable `data-slot` and reached the browser roster, but omitted the explicit render assertion |
+| `H8-fire-drill` | error | — | Agent completed the migration and its own token smoke, but the sealed verifier timed out at 1200 seconds and again at 2400 seconds |
+| `H9-dsh-web-alpha2` | 0.8 | 80/100 | Migrated the real dsh-web surface, but out-of-scope changes and a lockfile-integrity failure capped the result |
+| `M1-host-migration` | 1.0 | 100/100 | Installed the fixture and reached the host application layer without pending entries |
+| `M2-optional-dep-trap` | 1.0 | 100/100 | Moved the unconditionally imported package to `dependencies`; cold boot activated |
+| `M3-session-projection` | 1.0 | 100/100 | Corrected profile composition while retaining `dsh-tool-todo`; cold boot activated |
+| `M4-peer-prerelease-range` | 1.0 | 100/100 | Rewrote peer/dev bounds to `^0.1.2-alpha.2`; install and cold boot passed |
+| `M5-token-auth-smoke` | 0.6 | 60/100 | Token/Cookie smoke returned 401 then 200, but raw `webServer.register` remained and triggered the cap |
+| `S1-static-scan` | 1.0 | 100/100 | Kept the fixture read-only and identified all six required corridor cards |
+| `S2-negative-scan` | 1.0 | 100/100 | Mapped the positive APIProxy hit, handled zero-hit uncertainty, and required real verification |
+| `S3-snapshot-migration` | 1.0 | 100/100 | Produced the complete read-only snapshot-migration assessment across all five required points |
+| `S4-legacy-client-imports` | 1.0 | 100/100 | Kept the fixture read-only and mapped A1-25, A1-26, A1-27, and A1-30 |
+| `S5-negative-naming` | 0.75 | 75/100 | Correctly handled warning, informational, and unknown states, but omitted the official `greet` judgment |
+| `S6-corridor-net-state` | 0.25 | 25/100 | Cited both corridor cards but missed the deletion conclusion, producer semantics, and `Session.append` gap |
+| `S7-unpublished-cohort` | 0.25 | 25/100 | Gave two legal install paths but missed registry proof, exit/package-manager discipline, and caret prerelease semantics |
+| `S8-release-routing-trap` | 1.0 | 100/100 | Diagnosed mirror tag lag and forward incompatibility, chose the rc-compatible release, and prescribed mirror synchronization |
+
+Distribution:
+
+| reward | count |
+|---:|---:|
+| 1.0 | 13 |
+| 0.9 | 1 |
+| 0.8 | 1 |
+| 0.75 | 1 |
+| 0.6 | 1 |
+| 0.25 | 2 |
+| 0.2 | 1 |
+| 0.0 | 1 |
+| verifier error / no reward | 1 |
+
+The primary raw result is the uncommitted local artifact
+`/private/tmp/dsh-plugin-upgrade-terra-all22-20260901/codex-plugin-upgrade-terra-main21-rerun1-20260901/result.json`.
+The selected supplemental results are:
+
+- H7:
+  `/private/tmp/dsh-plugin-upgrade-terra-all22-20260901/codex-plugin-upgrade-terra-h7-runnable-20260901/result.json`
+- H8 verifier retry:
+  `/private/tmp/dsh-plugin-upgrade-terra-all22-20260901/codex-plugin-upgrade-terra-h8-verifier-retry1-20260901/result.json`
+- H9 closed-book rerun:
+  `/private/tmp/dsh-plugin-upgrade-terra-all22-20260901/codex-plugin-upgrade-terra-h9-closed-book-20260901/result.json`
+
+The primary result's built-in mean (`0.7419`) is not the selected 22-task
+aggregate: it includes the noncompliant H9 pre-run at 0.53, treats H8's
+verifier exception as zero, and omits the separately loaded H7. Starting from
+the primary reward sum, replacing H9's 0.53 with 0.8 and adding H7's 0.9 yields
+the selected reward sum of 16.75. That is `16.75 / 21 = 0.7976` across tasks
+with verifier rewards, or `16.75 / 22 = 0.7614` under conservative full-cohort
+accounting.
+
+## Execution time and token usage
+
+The following timestamps are Harbor job-level local timestamps in
+Asia/Shanghai. Durations are wall-clock durations for each job. Harbor reports
+cache tokens as a subset of input tokens, so the cache column must not be added
+to the input column when calculating total consumption.
+
+| Job | Started | Finished | Duration | Input tokens | Cache tokens | Output tokens | Cost |
+|---|---|---|---:|---:|---:|---:|---:|
+| Primary 21-task batch | 2026-09-01 14:37:40.620 | 2026-09-01 15:48:04.121 | 1h10m23.501s | 31,056,703 | 28,881,152 | 265,046 | $13.3079 |
+| H7 metadata-corrected run | 2026-09-01 15:49:36.667 | 2026-09-01 15:55:48.484 | 6m11.816s | 824,863 | 732,160 | 12,633 | $0.4834 |
+| H8 verifier retry | 2026-09-01 15:49:51.681 | 2026-09-01 16:38:14.140 | 48m22.458s | 2,410,459 | 2,276,864 | 17,618 | $0.9340 |
+| H9 compliant closed-book run | 2026-09-01 16:04:57.185 | 2026-09-01 16:33:58.270 | 29m01.085s | 19,802,419 | 19,241,728 | 59,959 | $5.6892 |
+| **Recorded job totals** | — | — | **2h33m58.860s** | **54,094,444** | **51,131,904** | **355,256** | **$20.4145** |
+
+The summed job duration is not elapsed end-to-end time because H7, H8, and
+H9 overlapped. The selected model-bearing jobs occupied a 2h00m33.520s window,
+from 14:37:40.620 to 16:38:14.140. Including the first preliminary setup job's
+14:27:17.125 start, the complete observed benchmark window was 2h10m57.015s.
+
+The primary row includes the discarded 0.53 H9 pre-run and the first H8
+attempt. The H8 retry row is the second H8 attempt, so the recorded totals are
+actual compute consumption rather than only the tokens associated with
+accepted rewards. The initial stock-bootstrap batch has no finish timestamp in
+its aborted result and made no model calls. The install-only preflight ran from
+14:35:22.583 to 14:37:00.352 (1m37.769s) and also consumed no model tokens or
+model cost.
+
+## What the verifier confirmed
+
+- Thirteen tasks received full verifier credit. Six were hands-on migrations
+  (`H1`, `H3`, `M1`, `M2`, `M3`, and `M4`); H2 correctly attributed its
+  pre-existing baseline failure and H4 correctly diagnosed an artifact-only
+  repair; S1-S4 and S8 were complete read-only assessments.
+- H1, H2, H5, M1, M2, M3, and M4 passed isolated DSH install/cold-start
+  checks. H3 and H7 also passed real Web roster checks through
+  `__DSH_BOOT__.entries`.
+- H5 was verified from a packed tarball rather than a workspace link, exposing
+  the compatibility shim even though install and cold start succeeded.
+- M5's sealed token smoke confirmed 401 without a Cookie and 200 after token
+  exchange, while separately detecting that the plugin retained the raw route.
+- The read-only fixtures remained unchanged for H4, H6, and S1-S8. H2's
+  pre-existing failing test also remained untouched.
+- H9 scored every settings migration point (13/13), aligned 214 direct
+  SDK/Cordis declarations, preserved the qualified task-board gateway handling,
+  and passed the upstream inject/aggregate regression check.
+- All selected job/trial locks contain the injected skill, and all selected
+  trajectories explicitly read its `SKILL.md`; there is no no-skill ambiguity
+  in this result.
+
+## Issues found
+
+1. **H8 has no official result.** Both agent phases completed, and the retry's
+   own smoke evidence reports a 303 token exchange followed by 401/200 route
+   behavior. The sealed verifier nevertheless timed out at both 1200 and 2400
+   seconds. Static inspection also shows the candidate retained raw
+   `webServer.register` and omitted `rpc.handle('/ping')`; these are evidence,
+   not a substitute for the missing verifier reward.
+2. **H9 stopped at 80/100.** The candidate changed eight paths outside the
+   compatibility surface, including git-graph tests and aggregate/mount/link
+   scripts, triggering a 90-point cap. Its `pnpm-lock.yaml` also left roughly
+   60 alpha.2 entries without `integrity`, so the sealed real install/cold-start
+   gate rejected the candidate and imposed the final 80-point cap. The
+   git-graph package still depended on a removed transitive type edge.
+3. **H5 used a compatibility shim (20/100).** Its package cohort, packed
+   tarball install, and cold boot all passed, but defining `settingsNamespace`
+   in `src/index.ts` bypassed the target host contract and triggered the task's
+   hard cap.
+4. **H6 omitted the Remote error migration (0/100).** The report did not cover
+   namespaced error codes, cancel propagation, internal/unknown-code handling,
+   or removal of silent error swallowing.
+5. **M5 preserved the raw route (60/100).** Authentication behavior passed the
+   real token/Cookie smoke, but `webServer.register` remained instead of moving
+   the channel to the host's unified authenticated surface.
+6. **H7 and S5-S7 were semantically incomplete.** H7 omitted a separate render
+   assertion. S5 omitted the official short-name validity of `greet`. S6 did
+   not collapse the corridor into the required deletion/net-state conclusion.
+   S7 omitted registry verification, caret prerelease behavior, and explicit
+   exit/package-manager discipline.
+
+## Run anomalies
+
+The checked-in H7 metadata cannot be parsed by Harbor because the TOML basic
+string at line 6 contains the unescaped sequence `\s`. Python `tomllib` reports
+`Unescaped '\\' in a string (at line 6, column 72)`. Harbor silently omitted H7
+from the dataset. Only a temporary copy was made loadable for this benchmark;
+the repository task was not changed.
+
+The intended H9 exclusion used a lowercase glob against an uppercase directory
+name, so Harbor included H9 in the primary batch. Because that run lacked the
+explicit `web_search=disabled` flag required for an auditable closed-book
+result, its 0.53 reward is retained only as raw execution history. The
+standalone 0.8 H9 run is the selected result.
+
+The stock Codex install path caused four preliminary
+`AgentSetupTimeoutError`s. Reusing the task images' existing Node 24 through the
+temporary setup-only adapter eliminated that bootstrap bottleneck. The
+selected main and supplemental jobs had no agent setup failure and no retry.
+
+## Conclusion
+
+**The Codex + `gpt-5.6-terra` benchmark with the injected
+`skills/plugin-upgrade` skill attempted every one of the 22 registered tasks.**
+Twenty-one tasks produced accepted verifier rewards totaling 16.75, with 13
+perfect tasks and a rewarded-task mean of 0.7976. Counting H8's missing reward
+as zero gives a conservative full-cohort mean of 0.7614.
+
+The strongest results were the complete static assessments and the focused
+install/cold-start migrations. The main correctness gaps were H6's absent
+Remote error analysis, H5/M5's use of compatibility or raw-route shortcuts,
+and H9's lockfile-integrity and scope discipline. H8 remains unresolved at the
+verifier layer after two bounded attempts and must not be reported as a scored
+completion. The host worktree stayed clean throughout benchmark execution;
+this report is the only workspace file added for this result.


### PR DESCRIPTION
## Summary

- Add end-to-end Codex `openai/gpt-5.6-terra` reports for the 22-task 2026-09-01 snapshot with `skills/plugin-upgrade` and with literal zero skill.
- Consolidate Terra and Luna scores, duration, input/cache/output tokens, and cost in one benchmark summary table.
- Extend the per-task table with Terra with-skill/no-skill scores and deltas, while preserving verifier errors and cohort gaps as missing results.

Related issue: none.

## Scope Checklist

- [x] I checked existing Issues and PRs for overlap; no open Terra benchmark result work was found.
- [x] The version-specific benchmark provenance remains pinned by the checked-in task fixtures and reports.
- [x] The reports distinguish observed verifier/runtime evidence from conservative diagnostics and unverified boundaries.
- [x] Not applicable: this PR does not change migration cards or touchpoint IDs.
- [x] Not applicable: this PR does not change Host, Web Client, or ordinary Cordis plugin recipes.

## Verification

Commands run:

```text
npm test
node benchmark/scripts/validate-execution-contract.mjs
git diff --check origin/main...HEAD
```

Additional checks:

- [x] The 23-task README/scoring registry and its 17 validator tests pass.
- [x] All README report links resolve to files under `benchmark/results/`.
- [x] Per-task rows recalculate to Luna 15.95 vs 13.09 and Terra 16.75 vs 14.93.
- [x] I reviewed the complete diff and `git diff --check` passes.

Unverified boundaries (providers, browsers, operating systems, credentials, or product entry points):

- H8 produced `VerifierTimeoutError` in both Terra conditions, so no reward is inferred.
- H10 was added after the Terra runs and is shown as not covered.
- These are selected single attempts, not the recommended three-run median.
- The Terra literal-zero-skill retained result total excludes the first H8 agent attempt erased by Harbor during retry, so absolute provider billing is higher than the retained `$17.0733` total.

## Review Notes

- Terra covers a 22-task snapshot and Luna covers an earlier 19-task snapshot; the README explicitly avoids treating them as a direct model comparison.
- Luna's no-Harbor-skill condition retained native Codex skills, whereas Terra's literal-zero-skill run disabled both injected and native skills.
- The branch was rebased onto `origin/main` after the validation-report migration to `benchmark/results/` and the addition of H10.
- Acknowledgements: none.
