### PR TITLE
feat(benchmark): add immutable evaluation snapshots

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -22,7 +22,11 @@ jobs:
         node-version: [22, 24]
     runs-on: ubuntu-latest
     steps:
+      # Full history is required: the evaluation snapshot validator resolves
+      # snapshot-pinned benchmark/skill commits via local git objects.
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -148,11 +148,12 @@ it is alive.
   switch to a cloud sandbox such as Daytona with `--env`).
 - Harbor CLI: `uv tool install harbor` or `pip install harbor`.
 - A model API key for the agent (e.g. `ANTHROPIC_API_KEY`, depending on the agent you use).
-- For formal/reproducible runs, pin an evaluation snapshot under
-  [`benchmark/snapshots/`](snapshots/README.md) instead of describing the object
-  as "the current benchmark".
 
 ## How to run
+
+For formal/reproducible runs, pin an evaluation snapshot under
+[`benchmark/snapshots/`](snapshots/README.md) instead of describing the object
+as "the current benchmark".
 
 ```sh
 # oracle self-check (no API cost): the reference answer must score a perfect 1.0

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -148,6 +148,9 @@ it is alive.
   switch to a cloud sandbox such as Daytona with `--env`).
 - Harbor CLI: `uv tool install harbor` or `pip install harbor`.
 - A model API key for the agent (e.g. `ANTHROPIC_API_KEY`, depending on the agent you use).
+- For formal/reproducible runs, pin an evaluation snapshot under
+  [`benchmark/snapshots/`](snapshots/README.md) instead of describing the object
+  as "the current benchmark".
 
 ## How to run
 

--- a/benchmark/scripts/validate-evaluation-snapshots.mjs
+++ b/benchmark/scripts/validate-evaluation-snapshots.mjs
@@ -1,0 +1,210 @@
+// benchmark/scripts/validate-evaluation-snapshots.mjs
+//
+// Validates every benchmark/snapshots/*.json (except schema.json) as an immutable
+// evaluation snapshot. A snapshot pins an exact benchmark commit, an explicit
+// frozen task list, an exact skill commit/path, and the run protocol — and it is
+// checked against the REFERENCED commits via local git objects, never against the
+// current living benchmark inventory. Adding tasks to main therefore never
+// invalidates an existing snapshot.
+//
+// Network is never used: if a referenced commit is not present in the local
+// clone, the validator fails with an actionable "fetch the referenced commit"
+// message instead of fetching anything.
+import { execFileSync } from 'node:child_process'
+import { readdirSync, readFileSync } from 'node:fs'
+import { basename, dirname, join, relative, resolve } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+export const SNAPSHOT_ID_RE = /^[0-9]{4}-[0-9]{2}-[0-9]{2}-[a-z0-9]+(?:-[a-z0-9]+)*$/
+export const DATE_RE = /^[0-9]{4}-[0-9]{2}-[0-9]{2}$/
+export const FULL_SHA_RE = /^[0-9a-f]{40}$/
+export const TASK_ID_RE = /^[A-Z][A-Za-z0-9]+(?:-[A-Za-z0-9]+)*$/
+export const SUPPORTED_AGGREGATIONS = ['per-task-median']
+export const REPOSITORY = 'oh-my-dsh/dsh-plugin-upgrade-skill'
+
+const PREFIX = '[evaluation-snapshot]'
+
+// ── git plumbing (local only, never fetches) ──────────────────────────────────
+
+export function gitCatFileExists(repoRoot, spec) {
+  try {
+    execFileSync('git', ['-C', repoRoot, 'cat-file', '-e', spec], { stdio: 'ignore' })
+    return true
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      throw new Error('git executable not found; evaluation snapshots must be validated inside a git clone')
+    }
+    return false
+  }
+}
+
+export function gitCommitResolvable(repoRoot, sha) {
+  return gitCatFileExists(repoRoot, `${sha}^{commit}`)
+}
+
+// ── per-snapshot validation ───────────────────────────────────────────────────
+
+export function validateSnapshot(parsed, filePath, repoRoot) {
+  const failures = []
+  const fail = (reason) => failures.push(`${PREFIX} ${filePath}: ${reason}`)
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    fail('snapshot must be a JSON object')
+    return failures
+  }
+
+  // Shape checks (no git required).
+  if (parsed.schemaVersion !== 1) fail(`schemaVersion must be 1, got ${JSON.stringify(parsed.schemaVersion)}`)
+  if (typeof parsed.id !== 'string' || !SNAPSHOT_ID_RE.test(parsed.id)) {
+    fail(`id must match YYYY-MM-DD-<lowercase-kebab-slug>, got ${JSON.stringify(parsed.id)}`)
+  } else {
+    if (basename(filePath) !== `${parsed.id}.json`) fail(`filename must be "${parsed.id}.json", got "${basename(filePath)}"`)
+  }
+  if (typeof parsed.createdAt !== 'string' || !DATE_RE.test(parsed.createdAt)) {
+    fail(`createdAt must be YYYY-MM-DD, got ${JSON.stringify(parsed.createdAt)}`)
+  } else if (typeof parsed.id === 'string' && parsed.id.slice(0, 10) !== parsed.createdAt) {
+    fail(`createdAt (${parsed.createdAt}) must match the date prefix of id (${parsed.id.slice(0, 10)})`)
+  }
+  if (parsed.repository !== REPOSITORY) fail(`repository must be "${REPOSITORY}", got ${JSON.stringify(parsed.repository)}`)
+
+  const benchmark = parsed.benchmark
+  const skill = parsed.skill
+  const protocol = parsed.protocol
+  if (benchmark === null || typeof benchmark !== 'object' || Array.isArray(benchmark)) fail('benchmark must be an object')
+  if (skill === null || typeof skill !== 'object' || Array.isArray(skill)) fail('skill must be an object')
+  if (protocol === null || typeof protocol !== 'object' || Array.isArray(protocol)) fail('protocol must be an object')
+
+  let benchmarkSha = null
+  let skillSha = null
+  let skillPath = null
+  if (benchmark && typeof benchmark === 'object') {
+    if (typeof benchmark.commit !== 'string' || !FULL_SHA_RE.test(benchmark.commit)) {
+      fail(`benchmark.commit must be a full 40-char lowercase hex SHA, got ${JSON.stringify(benchmark.commit)}`)
+    } else {
+      benchmarkSha = benchmark.commit
+    }
+    const tasks = benchmark.tasks
+    if (!Array.isArray(tasks) || tasks.length === 0) {
+      fail('benchmark.tasks must be a non-empty array of task IDs')
+    } else {
+      if (typeof benchmark.taskCount !== 'number' || !Number.isInteger(benchmark.taskCount)) {
+        fail(`benchmark.taskCount must be an integer, got ${JSON.stringify(benchmark.taskCount)}`)
+      } else if (benchmark.taskCount !== tasks.length) {
+        fail(`benchmark.taskCount (${benchmark.taskCount}) must equal tasks.length (${tasks.length})`)
+      }
+      const seen = new Set()
+      for (const task of tasks) {
+        if (typeof task !== 'string' || !TASK_ID_RE.test(task)) {
+          fail(`invalid task ID: ${JSON.stringify(task)} (expected e.g. "S1-static-scan")`)
+        } else if (seen.has(task)) {
+          fail(`duplicate task ID in the frozen list: ${task}`)
+        }
+        if (typeof task === 'string') seen.add(task)
+      }
+    }
+  }
+  if (skill && typeof skill === 'object') {
+    if (typeof skill.commit !== 'string' || !FULL_SHA_RE.test(skill.commit)) {
+      fail(`skill.commit must be a full 40-char lowercase hex SHA, got ${JSON.stringify(skill.commit)}`)
+    } else {
+      skillSha = skill.commit
+    }
+    if (typeof skill.path !== 'string' || skill.path.trim() === '') {
+      fail(`skill.path must be a non-empty path, got ${JSON.stringify(skill.path)}`)
+    } else {
+      skillPath = skill.path
+    }
+  }
+  if (protocol && typeof protocol === 'object') {
+    if (typeof protocol.runsPerTask !== 'number' || !Number.isInteger(protocol.runsPerTask) || protocol.runsPerTask < 1) {
+      fail(`protocol.runsPerTask must be an integer >= 1, got ${JSON.stringify(protocol.runsPerTask)}`)
+    }
+    if (!SUPPORTED_AGGREGATIONS.includes(protocol.aggregation)) {
+      fail(`protocol.aggregation must be one of [${SUPPORTED_AGGREGATIONS.join(', ')}], got ${JSON.stringify(protocol.aggregation)}`)
+    }
+    if (!Array.isArray(protocol.conditions) || protocol.conditions.length === 0) {
+      fail('protocol.conditions must be a non-empty array')
+    } else {
+      const seenConditions = new Set()
+      for (const condition of protocol.conditions) {
+        if (typeof condition !== 'string' || condition.trim() === '') {
+          fail(`invalid condition: ${JSON.stringify(condition)}`)
+        } else if (seenConditions.has(condition)) {
+          fail(`duplicate condition: ${condition}`)
+        }
+        if (typeof condition === 'string') seenConditions.add(condition)
+      }
+    }
+  }
+  if (parsed.notes !== undefined && (!Array.isArray(parsed.notes) || parsed.notes.some((note) => typeof note !== 'string'))) {
+    fail('notes must be an array of strings when present')
+  }
+
+  // Git checks: everything below resolves against the REFERENCED commits, so a
+  // snapshot stays valid while the living benchmark grows.
+  if (benchmarkSha) {
+    if (!gitCommitResolvable(repoRoot, benchmarkSha)) {
+      fail(`cannot resolve benchmark commit ${benchmarkSha} in the local clone — fetch the referenced commit before validating`)
+    } else if (benchmark && Array.isArray(benchmark.tasks) && benchmark.tasks.every((task) => typeof task === 'string' && TASK_ID_RE.test(task))) {
+      for (const task of benchmark.tasks) {
+        for (const required of ['task.toml', 'instruction.md']) {
+          if (!gitCatFileExists(repoRoot, `${benchmarkSha}:benchmark/tasks/${task}/${required}`)) {
+            fail(`task "${task}" has no ${required} at benchmark commit ${benchmarkSha}`)
+          }
+        }
+      }
+    }
+  }
+  if (skillSha && skillPath) {
+    if (!gitCommitResolvable(repoRoot, skillSha)) {
+      fail(`cannot resolve skill commit ${skillSha} in the local clone — fetch the referenced commit before validating`)
+    } else if (!gitCatFileExists(repoRoot, `${skillSha}:${skillPath}/SKILL.md`)) {
+      fail(`skill path "${skillPath}" has no SKILL.md at skill commit ${skillSha}`)
+    }
+  }
+
+  return failures
+}
+
+// ── directory-level validation ────────────────────────────────────────────────
+
+export function validateSnapshots(snapshotsDir, repoRoot) {
+  const failures = []
+  let count = 0
+  let entries
+  try {
+    entries = readdirSync(snapshotsDir)
+  } catch {
+    failures.push(`${PREFIX} snapshots directory not found: ${snapshotsDir}`)
+    return { ok: false, failures, count }
+  }
+  for (const entry of entries.sort()) {
+    if (!entry.endsWith('.json') || entry === 'schema.json') continue
+    const filePath = join(snapshotsDir, entry)
+    let parsed
+    try {
+      parsed = JSON.parse(readFileSync(filePath, 'utf8'))
+    } catch (error) {
+      failures.push(`${PREFIX} ${filePath}: not valid JSON (${error.message})`)
+      continue
+    }
+    count += 1
+    failures.push(...validateSnapshot(parsed, filePath, repoRoot))
+  }
+  if (count === 0) failures.push(`${PREFIX} no snapshot manifests found under ${snapshotsDir}`)
+  return { ok: failures.length === 0, failures, count }
+}
+
+// ── CLI ───────────────────────────────────────────────────────────────────────
+
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href
+if (isMain) {
+  const repoRoot = resolve(dirname(dirname(dirname(fileURLToPath(import.meta.url)))))
+  const snapshotsDir = join(repoRoot, 'benchmark', 'snapshots')
+  const result = validateSnapshots(snapshotsDir, repoRoot)
+  if (result.ok) {
+    console.log(`${PREFIX} OK: ${result.count} snapshot(s) valid`)
+    process.exit(0)
+  }
+  for (const failure of result.failures) console.log(failure)
+  process.exit(1)
+}

--- a/benchmark/scripts/validate-evaluation-snapshots.mjs
+++ b/benchmark/scripts/validate-evaluation-snapshots.mjs
@@ -11,9 +11,9 @@
 // clone, the validator fails with an actionable "fetch the referenced commit"
 // message instead of fetching anything.
 import { execFileSync } from 'node:child_process'
-import { readdirSync, readFileSync } from 'node:fs'
+import { readdirSync, readFileSync, realpathSync } from 'node:fs'
 import { basename, dirname, join, relative, resolve } from 'node:path'
-import { fileURLToPath, pathToFileURL } from 'node:url'
+import { fileURLToPath } from 'node:url'
 
 export const SNAPSHOT_ID_RE = /^[0-9]{4}-[0-9]{2}-[0-9]{2}-[a-z0-9]+(?:-[a-z0-9]+)*$/
 export const DATE_RE = /^[0-9]{4}-[0-9]{2}-[0-9]{2}$/
@@ -196,7 +196,13 @@ export function validateSnapshots(snapshotsDir, repoRoot) {
 
 // ── CLI ───────────────────────────────────────────────────────────────────────
 
-const isMain = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href
+const isMain = (() => {
+  try {
+    return realpathSync(process.argv[1] ?? '') === realpathSync(fileURLToPath(import.meta.url))
+  } catch {
+    return false
+  }
+})()
 if (isMain) {
   const repoRoot = resolve(dirname(dirname(dirname(fileURLToPath(import.meta.url)))))
   const snapshotsDir = join(repoRoot, 'benchmark', 'snapshots')

--- a/benchmark/scripts/validate-evaluation-snapshots.test.mjs
+++ b/benchmark/scripts/validate-evaluation-snapshots.test.mjs
@@ -1,0 +1,295 @@
+// benchmark/scripts/validate-evaluation-snapshots.test.mjs
+//
+// Tests for the evaluation snapshot validator. Each test builds a minimal
+// synthetic git repository in mkdtemp (no network, no GitHub): commit A pins the
+// snapshot, commit B adds another task. The key invariant is that a snapshot
+// pinned to commit A stays valid while the working tree sits at a later commit B.
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { validateSnapshot, validateSnapshots } from './validate-evaluation-snapshots.mjs'
+
+function initRepo() {
+  const root = mkdtempSync(join(tmpdir(), 'snap-test-'))
+  execFileSync('git', ['init', '-q'], { cwd: root })
+  execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: root })
+  execFileSync('git', ['config', 'user.name', 'Test'], { cwd: root })
+  return root
+}
+
+function write(root, rel, content = 'placeholder') {
+  mkdirSync(dirname(join(root, rel)), { recursive: true })
+  writeFileSync(join(root, rel), content)
+}
+
+function commitAll(root, message) {
+  execFileSync('git', ['add', '-A'], { cwd: root })
+  execFileSync('git', ['commit', '-q', '-m', message], { cwd: root })
+  return execFileSync('git', ['rev-parse', 'HEAD'], { cwd: root, encoding: 'utf8' }).trim()
+}
+
+function writeTask(root, id) {
+  write(root, `benchmark/tasks/${id}/task.toml`)
+  write(root, `benchmark/tasks/${id}/instruction.md`)
+}
+
+function writeSkill(root, path = 'skills/plugin-upgrade') {
+  write(root, `${path}/SKILL.md`)
+}
+
+// Repository with commit A (T1-alpha, T2-beta, skill) and commit B (adds T3-gamma).
+function buildRepo({ withSkill = true, t2Instruction = true } = {}) {
+  const root = initRepo()
+  writeTask(root, 'T1-alpha')
+  writeTask(root, 'T2-beta')
+  if (!t2Instruction) {
+    execFileSync('rm', ['-f', join(root, 'benchmark/tasks/T2-beta/instruction.md')], { cwd: root })
+  }
+  if (withSkill) writeSkill(root)
+  const commitA = commitAll(root, 'A')
+  writeTask(root, 'T3-gamma')
+  const commitB = commitAll(root, 'B')
+  return { root, commitA, commitB }
+}
+
+function manifest(commitA, commitB = commitA, overrides = {}) {
+  return {
+    schemaVersion: 1,
+    id: '2026-09-01-test-a',
+    createdAt: '2026-09-01',
+    repository: 'oh-my-dsh/dsh-plugin-upgrade-skill',
+    benchmark: { commit: commitA, taskCount: 2, tasks: ['T1-alpha', 'T2-beta'] },
+    skill: { commit: commitB, path: 'skills/plugin-upgrade' },
+    protocol: { runsPerTask: 3, aggregation: 'per-task-median', conditions: ['with-skill', 'no-harbor-injected-skill'] },
+    notes: ['synthetic test snapshot'],
+    ...overrides,
+  }
+}
+
+function writeSnapshot(root, json, name = '2026-09-01-test-a.json') {
+  write(root, `benchmark/snapshots/${name}`, JSON.stringify(json, null, 2))
+}
+
+function failures(root, json, name) {
+  writeSnapshot(root, json, name)
+  return validateSnapshots(join(root, 'benchmark', 'snapshots'), root).failures.join('\n')
+}
+
+function cleanup(root) {
+  rmSync(root, { recursive: true, force: true })
+}
+
+test('valid snapshot passes', () => {
+  const { root, commitA } = buildRepo()
+  const result = validateSnapshot(manifest(commitA), '/fake/2026-09-01-test-a.json', root)
+  cleanup(root)
+  assert.deepEqual(result, [])
+})
+
+test('invalid JSON fails', () => {
+  const { root, commitA } = buildRepo()
+  mkdirSync(join(root, 'benchmark', 'snapshots'), { recursive: true })
+  writeFileSync(join(root, 'benchmark', 'snapshots', 'broken.json'), '{not valid json')
+  const result = validateSnapshots(join(root, 'benchmark', 'snapshots'), root)
+  cleanup(root)
+  void commitA
+  assert.match(result.failures.join('\n'), /not valid JSON/)
+})
+
+test('filename/id mismatch fails', () => {
+  const { root, commitA } = buildRepo()
+  const out = failures(root, manifest(commitA), '2026-09-01-other.json')
+  cleanup(root)
+  assert.match(out, /filename must be "2026-09-01-test-a\.json"/)
+})
+
+test('malformed createdAt fails', () => {
+  const { root, commitA } = buildRepo()
+  const out = failures(root, manifest(commitA, commitA, { createdAt: 'not-a-date' }))
+  cleanup(root)
+  assert.match(out, /createdAt must be YYYY-MM-DD/)
+})
+
+test('createdAt not matching the id date prefix fails', () => {
+  const { root, commitA } = buildRepo()
+  const out = failures(root, manifest(commitA, commitA, { createdAt: '2026-08-31' }))
+  cleanup(root)
+  assert.match(out, /must match the date prefix of id/)
+})
+
+test('short benchmark SHA fails', () => {
+  const { root, commitA } = buildRepo()
+  const out = failures(root, manifest(commitA, commitA, { benchmark: { commit: commitA.slice(0, 8), taskCount: 2, tasks: ['T1-alpha', 'T2-beta'] } }))
+  cleanup(root)
+  assert.match(out, /benchmark\.commit must be a full 40-char lowercase hex SHA/)
+})
+
+test('short skill SHA fails', () => {
+  const { root, commitA } = buildRepo()
+  const out = failures(root, manifest(commitA, commitA, { skill: { commit: commitA.slice(0, 8), path: 'skills/plugin-upgrade' } }))
+  cleanup(root)
+  assert.match(out, /skill\.commit must be a full 40-char lowercase hex SHA/)
+})
+
+test('taskCount mismatch fails', () => {
+  const { root, commitA } = buildRepo()
+  const out = failures(root, manifest(commitA, commitA, { benchmark: { commit: commitA, taskCount: 3, tasks: ['T1-alpha', 'T2-beta'] } }))
+  cleanup(root)
+  assert.match(out, /taskCount \(3\) must equal tasks\.length \(2\)/)
+})
+
+test('duplicate task IDs fail', () => {
+  const { root, commitA } = buildRepo()
+  const out = failures(root, manifest(commitA, commitA, { benchmark: { commit: commitA, taskCount: 2, tasks: ['T1-alpha', 'T1-alpha'] } }))
+  cleanup(root)
+  assert.match(out, /duplicate task ID/)
+})
+
+test('invalid task ID format fails', () => {
+  const { root, commitA } = buildRepo()
+  const out = failures(root, manifest(commitA, commitA, { benchmark: { commit: commitA, taskCount: 2, tasks: ['T1-alpha', 'bad task id'] } }))
+  cleanup(root)
+  assert.match(out, /invalid task ID/)
+})
+
+test('task missing at the snapshot commit fails', () => {
+  const { root, commitA } = buildRepo()
+  const out = failures(root, manifest(commitA, commitA, { benchmark: { commit: commitA, taskCount: 2, tasks: ['T1-alpha', 'T9-ghost'] } }))
+  cleanup(root)
+  assert.match(out, /task "T9-ghost" has no task\.toml at benchmark commit/)
+})
+
+test('task without instruction.md at the snapshot commit fails', () => {
+  const { root, commitA } = buildRepo({ t2Instruction: false })
+  const out = failures(root, manifest(commitA))
+  cleanup(root)
+  assert.match(out, /task "T2-beta" has no instruction\.md at benchmark commit/)
+})
+
+test('missing skill path at the skill commit fails', () => {
+  const { root, commitA } = buildRepo()
+  const out = failures(root, manifest(commitA, commitA, { skill: { commit: commitA, path: 'skills/plugin-write' } }))
+  cleanup(root)
+  assert.match(out, /skill path "skills\/plugin-write" has no SKILL\.md at skill commit/)
+})
+
+test('skill missing entirely at the skill commit fails', () => {
+  const { root, commitA } = buildRepo({ withSkill: false })
+  const out = failures(root, manifest(commitA))
+  cleanup(root)
+  assert.match(out, /skill path "skills\/plugin-upgrade" has no SKILL\.md at skill commit/)
+})
+
+test('unresolvable benchmark commit gives an actionable fetch message', () => {
+  const { root, commitA } = buildRepo()
+  const bogus = '0'.repeat(40)
+  const out = failures(root, manifest(bogus))
+  cleanup(root)
+  void commitA
+  assert.match(out, /cannot resolve benchmark commit 0{40} in the local clone — fetch the referenced commit before validating/)
+})
+
+test('unresolvable skill commit gives an actionable fetch message', () => {
+  const { root, commitA } = buildRepo()
+  const out = failures(root, manifest(commitA, '1'.repeat(40)))
+  cleanup(root)
+  assert.match(out, /cannot resolve skill commit 1{40} in the local clone/)
+})
+
+test('invalid runsPerTask fails', () => {
+  const { root, commitA } = buildRepo()
+  for (const bad of [0, -1, 1.5, '3']) {
+    const out = failures(root, manifest(commitA, commitA, { protocol: { runsPerTask: bad, aggregation: 'per-task-median', conditions: ['with-skill'] } }))
+    assert.match(out, /runsPerTask must be an integer >= 1/)
+  }
+  cleanup(root)
+})
+
+test('empty conditions fail', () => {
+  const { root, commitA } = buildRepo()
+  const out = failures(root, manifest(commitA, commitA, { protocol: { runsPerTask: 3, aggregation: 'per-task-median', conditions: [] } }))
+  cleanup(root)
+  assert.match(out, /conditions must be a non-empty array/)
+})
+
+test('duplicate conditions fail', () => {
+  const { root, commitA } = buildRepo()
+  const out = failures(root, manifest(commitA, commitA, { protocol: { runsPerTask: 3, aggregation: 'per-task-median', conditions: ['with-skill', 'with-skill'] } }))
+  cleanup(root)
+  assert.match(out, /duplicate condition: with-skill/)
+})
+
+test('unsupported aggregation fails', () => {
+  const { root, commitA } = buildRepo()
+  const out = failures(root, manifest(commitA, commitA, { protocol: { runsPerTask: 3, aggregation: 'mean', conditions: ['with-skill'] } }))
+  cleanup(root)
+  assert.match(out, /aggregation must be one of \[per-task-median\]/)
+})
+
+test('non-string notes fail', () => {
+  const { root, commitA } = buildRepo()
+  const out = failures(root, manifest(commitA, commitA, { notes: [42] }))
+  cleanup(root)
+  assert.match(out, /notes must be an array of strings/)
+})
+
+test('wrong repository fails', () => {
+  const { root, commitA } = buildRepo()
+  const out = failures(root, manifest(commitA, commitA, { repository: 'someone-else/repo' }))
+  cleanup(root)
+  assert.match(out, /repository must be "oh-my-dsh\/dsh-plugin-upgrade-skill"/)
+})
+
+test('KEY: a snapshot pinned to commit A stays valid while the working tree sits at a later commit B', () => {
+  const { root, commitA, commitB } = buildRepo()
+  const snapshot = manifest(commitA)
+  writeSnapshot(root, snapshot)
+  const result = validateSnapshots(join(root, 'benchmark', 'snapshots'), root)
+  cleanup(root)
+  void commitB
+  assert.equal(result.ok, true, result.failures.join('\n'))
+  assert.equal(result.count, 1)
+})
+
+test('KEY: a task that only exists at the later commit fails when the snapshot points to the earlier commit', () => {
+  const { root, commitA, commitB } = buildRepo()
+  const snapshot = manifest(commitA, commitA, { benchmark: { commit: commitA, taskCount: 3, tasks: ['T1-alpha', 'T2-beta', 'T3-gamma'] } })
+  writeSnapshot(root, snapshot)
+  const result = validateSnapshots(join(root, 'benchmark', 'snapshots'), root)
+  cleanup(root)
+  void commitB
+  assert.equal(result.ok, false)
+  assert.match(result.failures.join('\n'), /task "T3-gamma" has no task\.toml at benchmark commit/)
+})
+
+test('a snapshot pinned to the later commit passes and includes the new task', () => {
+  const { root, commitB } = buildRepo()
+  const snapshot = manifest(commitB, commitB, { benchmark: { commit: commitB, taskCount: 3, tasks: ['T1-alpha', 'T2-beta', 'T3-gamma'] } })
+  writeSnapshot(root, snapshot)
+  const result = validateSnapshots(join(root, 'benchmark', 'snapshots'), root)
+  cleanup(root)
+  assert.equal(result.ok, true, result.failures.join('\n'))
+})
+
+test('a snapshot against a non-commit object id fails as unresolved', () => {
+  const { root } = buildRepo()
+  const treeSha = execFileSync('git', ['rev-parse', 'HEAD^{tree}'], { cwd: root, encoding: 'utf8' }).trim()
+  const snapshot = manifest(treeSha)
+  writeSnapshot(root, snapshot)
+  const result = validateSnapshots(join(root, 'benchmark', 'snapshots'), root)
+  cleanup(root)
+  assert.equal(result.ok, false)
+  assert.match(result.failures.join('\n'), /cannot resolve benchmark commit/)
+})
+
+test('snapshots directory without any manifests fails', () => {
+  const { root } = buildRepo()
+  mkdirSync(join(root, 'benchmark', 'snapshots'), { recursive: true })
+  const result = validateSnapshots(join(root, 'benchmark', 'snapshots'), root)
+  cleanup(root)
+  assert.equal(result.ok, false)
+  assert.match(result.failures.join('\n'), /no snapshot manifests found/)
+})

--- a/benchmark/scripts/validate-evaluation-snapshots.test.mjs
+++ b/benchmark/scripts/validate-evaluation-snapshots.test.mjs
@@ -46,7 +46,7 @@ function buildRepo({ withSkill = true, t2Instruction = true } = {}) {
   writeTask(root, 'T1-alpha')
   writeTask(root, 'T2-beta')
   if (!t2Instruction) {
-    execFileSync('rm', ['-f', join(root, 'benchmark/tasks/T2-beta/instruction.md')], { cwd: root })
+    rmSync(join(root, 'benchmark/tasks/T2-beta/instruction.md'), { force: true })
   }
   if (withSkill) writeSkill(root)
   const commitA = commitAll(root, 'A')

--- a/benchmark/snapshots/2026-09-01-main-23.json
+++ b/benchmark/snapshots/2026-09-01-main-23.json
@@ -4,7 +4,7 @@
   "createdAt": "2026-09-01",
   "repository": "oh-my-dsh/dsh-plugin-upgrade-skill",
   "benchmark": {
-    "commit": "2de49059ec3178e23ea644cd78e7d20575b74745",
+    "commit": "472e5eae93d165906ddb8cc3861bb529f9b22c3e",
     "taskCount": 23,
     "tasks": [
       "S1-static-scan",
@@ -33,7 +33,7 @@
     ]
   },
   "skill": {
-    "commit": "2de49059ec3178e23ea644cd78e7d20575b74745",
+    "commit": "472e5eae93d165906ddb8cc3861bb529f9b22c3e",
     "path": "skills/plugin-upgrade"
   },
   "protocol": {
@@ -46,6 +46,7 @@
   },
   "notes": [
     "Current 23-task main evaluation snapshot. Infrastructure/current-evaluation anchor, not retroactive metadata for earlier runs.",
-    "The 2026-09-01 19-task paired run predates snapshot recording; its exact repository and skill commits were not recorded, so it is intentionally not reconstructed here."
+    "The 2026-09-01 19-task paired run predates snapshot recording; its exact repository and skill commits were not recorded, so it is intentionally not reconstructed here.",
+    "Pinned to the first post-#105 main commit: H7's task.toml escape bug (which made Harbor silently drop H7) is fixed in this anchor."
   ]
 }

--- a/benchmark/snapshots/2026-09-01-main-23.json
+++ b/benchmark/snapshots/2026-09-01-main-23.json
@@ -1,0 +1,51 @@
+{
+  "schemaVersion": 1,
+  "id": "2026-09-01-main-23",
+  "createdAt": "2026-09-01",
+  "repository": "oh-my-dsh/dsh-plugin-upgrade-skill",
+  "benchmark": {
+    "commit": "2de49059ec3178e23ea644cd78e7d20575b74745",
+    "taskCount": 23,
+    "tasks": [
+      "S1-static-scan",
+      "S2-negative-scan",
+      "S3-snapshot-migration",
+      "H4-tsbuildinfo-trap",
+      "M1-host-migration",
+      "H1-plane-trap",
+      "H2-baseline-trap",
+      "H3-client-plane",
+      "H5-runtime-export-drift",
+      "M5-token-auth-smoke",
+      "H8-fire-drill",
+      "H9-dsh-web-alpha2",
+      "S4-legacy-client-imports",
+      "S5-negative-naming",
+      "H6-remote-error-trap",
+      "S6-corridor-net-state",
+      "S7-unpublished-cohort",
+      "S8-release-routing-trap",
+      "M2-optional-dep-trap",
+      "M3-session-projection",
+      "M4-peer-prerelease-range",
+      "H7-locale-trap",
+      "H10-browser-activation-trap"
+    ]
+  },
+  "skill": {
+    "commit": "2de49059ec3178e23ea644cd78e7d20575b74745",
+    "path": "skills/plugin-upgrade"
+  },
+  "protocol": {
+    "runsPerTask": 3,
+    "aggregation": "per-task-median",
+    "conditions": [
+      "with-skill",
+      "no-harbor-injected-skill"
+    ]
+  },
+  "notes": [
+    "Current 23-task main evaluation snapshot. Infrastructure/current-evaluation anchor, not retroactive metadata for earlier runs.",
+    "The 2026-09-01 19-task paired run predates snapshot recording; its exact repository and skill commits were not recorded, so it is intentionally not reconstructed here."
+  ]
+}

--- a/benchmark/snapshots/README.md
+++ b/benchmark/snapshots/README.md
@@ -52,3 +52,6 @@ network.
   earlier runs: the 2026-09-01 19-task paired run predates snapshot recording
   and its exact repository/skill commits were not recorded in the validation
   reports, so it cannot be reconstructed faithfully.
+- The anchor is the first post-#105 commit (`472e5ea…`): the H7 `task.toml`
+  escape bug (which made Harbor silently drop H7) is fixed in the pinned tree,
+  so all 23 tasks in the frozen list are actually runnable.

--- a/benchmark/snapshots/README.md
+++ b/benchmark/snapshots/README.md
@@ -1,0 +1,54 @@
+# Benchmark evaluation snapshots
+
+The benchmark under `benchmark/tasks/` is a **living benchmark**: tasks are added
+over time, and main has already moved through 18 / 19 / 22 / 23-task states.
+Formal experiments must not describe their object as "the current benchmark" —
+they must pin an **immutable evaluation snapshot**.
+
+A snapshot pins:
+
+- the exact benchmark commit (full 40-char git SHA);
+- the explicit, frozen task ID list (not just a count);
+- the exact skill commit and path (recorded separately from the benchmark
+  commit, so a frozen benchmark can later be paired with an updated skill for
+  before/after comparisons);
+- the run protocol (`runsPerTask`, `aggregation`, `conditions`);
+- the creation date and free-form notes.
+
+Snapshots are immutable historical experiment inputs: adding tasks to main does
+not mutate an existing snapshot, and validators check the snapshot against the
+referenced commits (via local git objects) — not against the current living
+inventory.
+
+## Validating
+
+```sh
+node benchmark/scripts/validate-evaluation-snapshots.mjs
+```
+
+This verifies every `benchmark/snapshots/*.json` (except `schema.json`):
+manifest shape, filename/id consistency, full-SHA contract, and — using
+`git cat-file` against the local clone only — that the referenced commits exist
+and that every snapshot task (with its `task.toml` and `instruction.md`) and the
+referenced skill path exist at their commits. If a referenced commit is not
+present in the local clone, the validator fails with an actionable message
+("fetch the referenced commit before validating"); it never fetches from the
+network.
+
+## Creating a new snapshot
+
+1. Decide the frozen point: `git rev-parse <ref>` for the benchmark commit, and
+   (separately) the skill commit you want to evaluate.
+2. Copy `schema.json` as a starting point, fill in the full SHAs and the
+   explicit task list (`git ls-tree --name-only <commit>:benchmark/tasks/`).
+3. Name the file exactly `benchmark/snapshots/<id>.json` where `<id>` is
+   `YYYY-MM-DD-<slug>` matching `createdAt`.
+4. Run the validator.
+
+## Notes
+
+- `2026-09-01-main-23.json` pins the current 23-task main. It is an
+  infrastructure/current-evaluation snapshot, **not** retroactive metadata for
+  earlier runs: the 2026-09-01 19-task paired run predates snapshot recording
+  and its exact repository/skill commits were not recorded in the validation
+  reports, so it cannot be reconstructed faithfully.

--- a/benchmark/snapshots/schema.json
+++ b/benchmark/snapshots/schema.json
@@ -1,0 +1,29 @@
+{
+  "$comment": "Documentation contract for benchmark/snapshots/*.json. The validator (benchmark/scripts/validate-evaluation-snapshots.mjs) enforces this shape; no JSON-Schema tooling is used.",
+  "schemaVersion": 1,
+  "id": "<YYYY-MM-DD>-<slug>",
+  "createdAt": "<YYYY-MM-DD>",
+  "repository": "oh-my-dsh/dsh-plugin-upgrade-skill",
+  "benchmark": {
+    "commit": "<full 40-char lowercase hex git SHA>",
+    "taskCount": 23,
+    "tasks": [
+      "S1-static-scan"
+    ]
+  },
+  "skill": {
+    "commit": "<full 40-char lowercase hex git SHA>",
+    "path": "skills/plugin-upgrade"
+  },
+  "protocol": {
+    "runsPerTask": 3,
+    "aggregation": "per-task-median",
+    "conditions": [
+      "with-skill",
+      "no-harbor-injected-skill"
+    ]
+  },
+  "notes": [
+    "<optional strings>"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -4,10 +4,12 @@
   "type": "module",
   "scripts": {
     "test": "npm run validate",
-    "validate": "node scripts/validate.mjs && node scripts/validate-manifests.mjs && node benchmark/scripts/validate-task-registry.mjs && node --test benchmark/scripts/validate-task-registry.test.mjs && node skills/plugin-upgrade/scripts/verify-runtime.check.mjs && npm run test:smoke",
+    "validate": "node scripts/validate.mjs && node scripts/validate-manifests.mjs && node benchmark/scripts/validate-task-registry.mjs && node --test benchmark/scripts/validate-task-registry.test.mjs && node benchmark/scripts/validate-evaluation-snapshots.mjs && node --test benchmark/scripts/validate-evaluation-snapshots.test.mjs && node skills/plugin-upgrade/scripts/verify-runtime.check.mjs && npm run test:smoke",
     "validate:skills": "node scripts/validate.mjs",
     "validate:manifests": "node scripts/validate-manifests.mjs",
     "validate:benchmark-registry": "node benchmark/scripts/validate-task-registry.mjs",
+    "validate:benchmark-snapshots": "node benchmark/scripts/validate-evaluation-snapshots.mjs",
+    "test:benchmark-snapshots": "node --test benchmark/scripts/validate-evaluation-snapshots.test.mjs",
     "validate:naming": "node skills/plugin-write/scripts/validate-names.check.mjs",
     "validate:registry": "node skills/plugin-write/scripts/query-registry.check.mjs",
     "verify:runtime": "node skills/plugin-upgrade/scripts/verify-runtime.check.mjs",


### PR DESCRIPTION
## Summary

Add machine-readable benchmark evaluation snapshots that pin:

- exact benchmark commit (full 40-char git SHA)
- explicit frozen task ID list
- exact skill commit / path
- run count, aggregation policy, and evaluation conditions

Snapshots are validated against the **referenced git commits** (via local
`git cat-file` only — never the network), not against the current living
benchmark inventory.

## Why

The benchmark has already grown across 18 / 19 / 22 / 23-task states, and the
2026-09-01 paired run could only be described as a "then-current 19-task
snapshot" without a machine-readable record of what that meant. Historical
experiments must remain reproducible after new tasks land, so formal runs need
an immutable experiment definition.

## Key invariant

A snapshot created at commit A remains valid after commit B adds more tasks.
This is enforced by resolving every snapshot task at the pinned benchmark
commit and the skill path at the pinned skill commit — and covered by dedicated
regression tests (snapshot at A passes in a B checkout; a task that only exists
at B fails when the snapshot points at A).

## Historical snapshot

The exact 2026-09-01 19-task run's repository/skill commits were not recorded
in the validation reports (only the 19 task IDs are recoverable from the README
table), so this PR does **not** fabricate a retroactive snapshot. The first
manifest `2026-09-01-main-23.json` pins the current 23-task main as an
infrastructure/current-evaluation anchor, and the snapshots README documents
why the historical run cannot be reconstructed faithfully.

## Verification

- validator self-tests: 27/27 (synthetic git repos in mkdtemp; no network)
- `node benchmark/scripts/validate-evaluation-snapshots.mjs`: OK, 1 snapshot valid (pinned to `472e5ea…`)
- `npm test`: green (snapshot validator + tests wired into the validate chain)
- `node benchmark/scripts/validate-task-registry.mjs`: OK (23 tasks); registry tests 17/17
- `node benchmark/scripts/validate-execution-contract.mjs`: 23 tasks
- `node scripts/validate.mjs` / `validate-manifests.mjs`: pass
- `git diff --check`: pass
- CI: the validate workflow now uses a full-history checkout (`fetch-depth: 0`) because the snapshot validator resolves pinned commits via local git objects, which a shallow clone cannot provide

## Scope

Only:

- `benchmark/snapshots/` (schema.json, README.md, `2026-09-01-main-23.json`)
- `benchmark/scripts/validate-evaluation-snapshots.mjs` + unit tests
- package.json test wiring
- a one-paragraph link in `benchmark/README.md`

No tasks, skills, benchmark results, aggregation (#98), or paper content changed.
