### PR TITLE
fix(benchmark): H7 task.toml 非法转义导致整题被 Harbor 静默丢弃（23 题实际只跑 22 题）

### DIFF
--- a/benchmark/tasks/H7-locale-trap/task.toml
+++ b/benchmark/tasks/H7-locale-trap/task.toml
@@ -3,7 +3,7 @@ schema_version = "1.4"
 [task]
 name = "dsh-plugin-upgrade/h7-locale-trap"
 version = "1.1.0"
-description = "A web plugin anchors host UI by display text (/session\s*log/i) which breaks silently once the host copy is localized: migrate the anchor to a stable data-slot and assert the injection rendered"
+description = "A web plugin anchors host UI by display text (/session\\s*log/i) which breaks silently once the host copy is localized: migrate the anchor to a stable data-slot and assert the injection rendered"
 keywords = ["dsh", "plugin-migration", "locale", "web-client", "harbor"]
 
 [metadata]


### PR DESCRIPTION
## 问题

`benchmark/tasks/H7-locale-trap/task.toml` 第 6 行 description 里的正则 `/session\s*log/i` 含未转义的反斜杠，是非法 TOML：

```
tomllib: Unescaped '\' in a string (at line 6, column 72)
```

Harbor 解析失败后会**静默**把 H7 从数据集里丢掉：`harbor run -p benchmark/tasks` 实际只调度 22/23 题（job result 里 `n_total_trials = 66` 而不是 69），单独 `-p benchmark/tasks/H7-locale-trap` 则直接报 "Either datasets or tasks must be provided"。

## 修复

把 `\s` 转义为 `\\s`，一行改动。

## 验证

- `python3 -c "import tomllib; tomllib.load(open('benchmark/tasks/H7-locale-trap/task.toml','rb'))"` 解析通过；
- `harbor run -p benchmark/tasks/H7-locale-trap -a oracle`（Harbor 0.22.0）reward 1.0；
- `node benchmark/scripts/validate-execution-contract.mjs` 仍然 23/23 通过（它是逐文件读的，不受 TOML 解析影响，所以之前没兜住这个问题——后续可以考虑在 validate 脚本里加一个 TOML 解析检查，我可以另提 PR）。

在跑 #102 的 v4f 全量评测时发现（两个 job 的 `n_total_trials` 都是 66）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
