### PR TITLE
fix(plugin-upgrade): broaden migration diagnosis activation

### DIFF
--- a/skills/plugin-upgrade/SKILL.md
+++ b/skills/plugin-upgrade/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: plugin-upgrade
-description: Inspect or upgrade installed DSH (DeepSeek Harness) plugins, or adapt plugin source to a newer DSH host version. Inspection stays read-only; show a plan and obtain confirmation before any configuration, dependency, or source write.
+description: Use for DSH plugin compatibility, migration, upgrade, regression, or post-upgrade diagnosis, including read-only review of already-migrated plugin source and version-boundary, API, dependency, activation, or runtime compatibility problems. Inspection and diagnosis stay read-only; show a plan and obtain confirmation before any configuration, dependency, or source write.
 ---
 
 English | [简体中文](SKILL.zh-CN.md)


### PR DESCRIPTION
## Why

A frozen H11 calibration exposed an activation gap:
the skill was available/injected but was not opened in any of three with-skill trials.

The existing description clearly covers inspection, upgrade, and active source migration, but is less explicit about read-only review of an already-completed migration or post-upgrade compatibility diagnosis.

## Change

Broaden only the frontmatter description to cover those task classes.

## Experimental boundary

This intentionally does NOT add H11-specific RemoteResult knowledge, benchmark answers, reference cards, or body changes.

A follow-up frozen-benchmark rerun will test whether this metadata-only intervention changes actual skill-read rate and task performance.

## Scope

- one skill frontmatter description
- no benchmark
- no references
- no paper
- no H11 answer leakage
