### PR TITLE
docs(benchmark): require token usage and run duration in submitted result reports

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,6 +9,7 @@ Describe the single logical change and link the related Issue, card, or version 
 - [ ] I cited fixed first-party sources for version-specific claims.
 - [ ] For migration or card work, I listed the affected touchpoints (`#1`-`#7`) and complete card IDs.
 - [ ] I kept Host, Web Client, and ordinary Cordis plugin faces distinct.
+- [ ] For benchmark result or validation-report PRs, the report states the consumed tokens and the total run duration per round (as recorded by Harbor's trial outputs).
 
 ## Verification
 

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -242,6 +242,12 @@ environment, and it does not leak migration answers to either round.
 All validation and result reports live in [`results/`](results/). When opening a PR
 that adds a benchmark result or validation report, put the file there.
 
+Every submitted report must state the **consumed tokens** and the **total run
+duration** of each round, next to the scores — e.g. the input/output/reasoning
+token sums and the summed job duration as recorded in Harbor's trial outputs
+(`result.json`). Cost figures are recommended but optional. Scores without these
+numbers cannot be compared across models or against later runs.
+
 - `results/validation-report-2026-08-30.md`: the skill-effectiveness validation report (v1
   era). The manual `dsh-verify` container reproduction in its section 6 has been
   replaced by the self-contained environment — each task image is now built with the

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -243,9 +243,9 @@ All validation and result reports live in [`results/`](results/). When opening a
 that adds a benchmark result or validation report, put the file there.
 
 Every submitted report must state the **consumed tokens** and the **total run
-duration** of each round, next to the scores — e.g. the input/output/reasoning
+duration** of each round, next to the scores — e.g. the input/output (cache)
 token sums and the summed job duration as recorded in Harbor's trial outputs
-(`result.json`). Cost figures are recommended but optional. Scores without these
+(`result.json`, fields `n_input_tokens` / `n_cache_tokens` / `n_output_tokens`). Cost figures are recommended but optional. Scores without these
 numbers cannot be compared across models or against later runs.
 
 - `results/validation-report-2026-08-30.md`: the skill-effectiveness validation report (v1


### PR DESCRIPTION
## Summary

Require every benchmark result / validation report submitted to `benchmark/results/` to state the consumed tokens and total run duration per round, next to the scores. Format follows the already-merged Terra reports (input/output/reasoning token sums + summed job duration from Harbor trial outputs).

## Changes

- `benchmark/README.md`: add the requirement to the `results/` section.
- `.github/PULL_REQUEST_TEMPLATE.md`: add a Scope Checklist item for report PRs.

Note: the already-merged Luna reports predate this requirement and lack these numbers; a follow-up can backfill them if the raw Harbor artifacts are still available.

## Verification

```text
node scripts/validate.mjs
node benchmark/scripts/validate-task-registry.mjs
```

Both pass.

## Review Notes

No token/duration numbers were invented for existing reports — the requirement applies to future submissions.