### PR TITLE
docs(paper): add Puzhao Zhang as co-author

### DIFF
--- a/paper/latex/acl_latex.tex
+++ b/paper/latex/acl_latex.tex
@@ -59,7 +59,11 @@
 
 \author{Beiming Liu \\
   Tsinghua University \\
-  \texttt{lbm21@tsinghua.org.cn} \\}
+  \texttt{lbm21@tsinghua.org.cn} \\
+  \And
+  Puzhao Zhang \\
+  Dalian Neusoft University of Information \\
+  \texttt{3026418933@qq.com} \\}
 
 \begin{document}
 \maketitle


### PR DESCRIPTION
## Summary

Adds a second author entry to the ACL author block in `paper/latex/acl_latex.tex`, following the maintainer's request that contributors submit their names.

- **Puzhao Zhang** — Dalian Neusoft University of Information — `3026418933@qq.com`

Contribution context: the Claude Code + Opus 5 paired benchmark run claimed in #100, whose interim report landed in #112.

Single file, five added lines, no other change.

Note: the document currently builds with `\usepackage[review]{acl}`, and `acl.sty` replaces the author block with "Anonymous ACL submission" under that option. This entry therefore only renders once the option is switched to `final` or `preprint` — the source is correct either way.

## Scope Checklist

- [x] I checked existing Issues and PRs for overlap and coordinated any related work.
- [ ] For version-specific work, I used exact DSH tags or commit hashes, not `latest` or inferred versions. — not applicable.
- [ ] I cited fixed first-party sources for version-specific claims. — not applicable.
- [ ] For migration or card work, I listed the affected touchpoints (`#1`-`#7`) and complete card IDs. — not applicable.
- [ ] I kept Host, Web Client, and ordinary Cordis plugin faces distinct. — not applicable.
- [ ] For benchmark result or validation-report PRs, the report states the consumed tokens and the total run duration per round. — not applicable, no result content in this PR.

## Verification

Commands run:

```text
node scripts/validate.mjs
node scripts/validate-manifests.mjs
git diff --check
```

All pass. The author block's brace nesting is unchanged — the closing `\}` simply moves to the new final entry, which is the standard two-author form in the ACL template (`\And` between institutions).

Additional checks:

- [x] I reviewed the complete diff and `git diff --check`.
- [ ] I ran the focused tests or example checks for the changed behavior. — see below.

Unverified boundaries: no LaTeX toolchain on this machine, so the document was **not** compiled. The change is confined to the `\author{}` block and follows the template's documented multi-author form, but a maintainer with `pdflatex` should confirm the title block typesets as expected.

## Review Notes

- Name order follows the ACL convention of given name before family name (张普曌 → Puzhao Zhang).
- The institution's official English name is "Dalian Neusoft University of Information" (per the university's own site), despite 学院 normally rendering as "Institute" or "College".
- Happy to switch the contact address to an institutional one, or to move this to Acknowledgments instead of the byline, if that better matches your intent.
