### PR TITLE
docs(paper): add Minjie Chen as co-author

### DIFF
--- a/paper/latex/acl_latex.tex
+++ b/paper/latex/acl_latex.tex
@@ -63,7 +63,11 @@
   \And
   Puzhao Zhang \\
   Dalian Neusoft University of Information \\
-  \texttt{3026418933@qq.com} \\}
+  \texttt{3026418933@qq.com} \\
+  \And
+  Minjie Chen \\
+  PetroChina Southwest Oil \& Gasfield Company \\
+  \texttt{auturnncrow@gmail.com} \\}
 
 \begin{document}
 \maketitle


### PR DESCRIPTION
## Summary

Adds a third author entry to the ACL author block in `paper/latex/acl_latex.tex`, following the maintainer's request that contributors submit their names.

- **Minjie Chen** — PetroChina Southwest Oil & Gasfield Company — `auturnncrow@gmail.com`

Contribution context: the M5/H8 container tasks (#86), the declarative checkpoint grading model borrowed from DeepSWE (#99), the alpha.2→alpha.3 no-op corridor record (#97), the 17-plugin batch migration runbook with the browserless token-auth smoke recipe (#67), the alpha.4 Windows fleet verification record + DeepSWE-style reward export (#121), and the community discussion on generalizing the checkpoint-grading form (issue 120).

Single file, five added lines plus the closing brace moved to the new final entry, no other change. Appended after the current last entry (Puzhao Zhang, added in #117).

Note: the document currently builds with `\usepackage[review]{acl}`, and `acl.sty` replaces the author block with "Anonymous ACL submission" under that option. This entry therefore only renders once the option is switched to `final` or `preprint` — the source is correct either way.

## Scope Checklist

- [x] I checked existing Issues and PRs for overlap and coordinated any related work.
- [ ] For version-specific work, I used exact DSH tags or commit hashes, not `latest` or inferred versions. — not applicable.
- [ ] I cited fixed first-party sources for version-specific claims. — not applicable.
- [ ] For migration or card work, I listed the affected touchpoints (`#1`-`#7`) and complete card IDs. — not applicable.
- [ ] I kept Host, Web Client, and ordinary Cordis plugin faces distinct. — not applicable.
- [ ] For benchmark result or validation-report PRs, the report states the consumed tokens and the total run duration per round. — not applicable, no result content in this PR.

## Verification

Commands run:

```text
node scripts/validate.mjs
node scripts/validate-manifests.mjs
git diff --check
```

All pass. The author block's brace nesting is unchanged — the closing `\}` simply moves to the new final entry, which is the standard multi-author form in the ACL template (`\And` between institutions).

Additional checks:

- [x] I reviewed the complete diff and `git diff --check`.
- [ ] I ran the focused tests or example checks for the changed behavior. — see below.

Unverified boundaries: no LaTeX toolchain on this machine, so the document was **not** compiled. The change is confined to the `\author{}` block and follows the template's documented multi-author form, but a maintainer with `pdflatex` should confirm the title block typesets as expected.

## Review Notes

- Name order follows the ACL convention of given name before family name (陈旻杰 → Minjie Chen).
- The institution name "PetroChina Southwest Oil & Gasfield Company" is the wording provided by the author; happy to switch to the company's official English name if it differs.
- The contact address is used verbatim as provided; happy to switch to an institutional address, or to move this to Acknowledgments instead of the byline, if that better matches your intent.
