### PR TITLE
docs(paper): add William Jin as co-author

### DIFF
--- a/paper/latex/acl_latex.tex
+++ b/paper/latex/acl_latex.tex
@@ -74,7 +74,11 @@
   \And
   Minjie Chen \\
   PetroChina Southwest Oil \& Gasfield Company \\
-  \texttt{auturnncrow@gmail.com} \\}
+  \texttt{auturnncrow@gmail.com} \\
+  \And
+  William Jin \\
+  Independent Researcher \\
+  \texttt{williamjinq@gmail.com} \\}
 
 \begin{document}
 \maketitle


### PR DESCRIPTION
## Summary

Adds an author entry to the ACL author block in `paper/latex/acl_latex.tex`, following the maintainer's request that contributors submit their names.

- **William Jin** — Independent Researcher — `williamjinq@gmail.com`

Contribution context:

- #105 — fixed the H7 `task.toml` escape bug that made Harbor silently drop the task (the 23-task benchmark was actually running 22).
- #110 — first real 23-task / 3-run-median paired evaluation report (terminus-2 + deepseek-v4-flash), including the cost dimension proposed in #102.
- #111 — `task.toml` TOML string-syntax validator (follow-up from the #105 review).

Single file, five added lines, no other change. Appended after the current last entry (#117); if #118 lands first I will rebase onto it.

Note: the document currently builds with `\usepackage[review]{acl}`, which replaces the author block with "Anonymous ACL submission". This entry only renders once the option is switched to `final` or `preprint`.

## Scope Checklist

- [x] I checked existing Issues and PRs for overlap and coordinated any related work.
- [ ] For version-specific work, I used exact DSH tags or commit hashes, not `latest` or inferred versions. — not applicable.
- [ ] I cited fixed first-party sources for version-specific claims. — not applicable.
- [ ] For migration or card work, I listed the affected touchpoints (`#1`-`#7`) and complete card IDs. — not applicable.
- [ ] I kept Host, Web Client, and ordinary Cordis plugin faces distinct. — not applicable.
- [ ] For benchmark result or validation-report PRs, the report states the consumed tokens and the total run duration per round. — not applicable.

## Verification

```text
node scripts/validate.mjs
node scripts/validate-manifests.mjs
git diff --check
```

All pass. Brace nesting of `\author{}` unchanged; the closing `}` moves to the new final entry, same as #117.

Unverified boundaries: not compiled with `pdflatex` locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)