### PR TITLE
fix(planner): skip dependency residue and macOS dataless files

### DIFF
--- a/skills/plugin-upgrade/scripts/README.md
+++ b/skills/plugin-upgrade/scripts/README.md
@@ -37,7 +37,7 @@ node skills/plugin-upgrade/scripts/plan-migration.mjs ... --touchpoints 1,5
 ## What it does
 
 1. reads `pre-flight-patterns.json`;
-2. scans code and config files (`.ts .tsx .js .jsx .mjs .cjs .json .yml .yaml .toml`, plus lockfiles/Dockerfile/Makefile) while skipping Markdown, `.git`, dependencies, generated output, sensitive filenames and files larger than 1 MiB;
+2. scans code and config files (`.ts .tsx .js .jsx .mjs .cjs .json .yml .yaml .toml`, plus lockfiles/Dockerfile/Makefile) while skipping Markdown, `.git`, dependencies (including `.node_modules-delete-pending` cleanup residue), generated output, sensitive filenames and files larger than 1 MiB; on macOS it reports and skips `dataless` cloud placeholders instead of implicitly downloading them;
    hits are ranked `src/` code first, other code next, config last, then capped at `--max-hits` (default 20); the touchpoint table reports shown/total;
 3. reports path, line number and pattern number only—never the matching source line;
 4. resolves an exact `from → to` path through card-set frontmatter;
@@ -58,6 +58,7 @@ node skills/plugin-upgrade/scripts/plan-migration.mjs ... --touchpoints 1,5
 This is an intentionally conservative heuristic:
 
 - zero hits do not prove public-contract-only coupling;
+- skipped large or macOS `dataless` files leave the plan incomplete until those files are made available and the scan is rerun;
 - card sets are curated, not complete API diffs;
 - it does not parse TypeScript data flow or dynamic imports;
 - it does not install dependencies, contact registries, edit files or run plugin code;

--- a/skills/plugin-upgrade/scripts/plan-migration.check.mjs
+++ b/skills/plugin-upgrade/scripts/plan-migration.check.mjs
@@ -1,11 +1,11 @@
 import assert from 'node:assert/strict'
 import { createHash } from 'node:crypto'
-import { mkdtemp, mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises'
+import { chmod, mkdtemp, mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { pathToFileURL } from 'node:url'
 import { resolve } from 'node:path'
-import { buildMigrationPlan, renderMarkdown } from './plan-migration.mjs'
+import { buildMigrationPlan, partitionDatalessFiles, renderMarkdown } from './plan-migration.mjs'
 
 async function snapshot(root) {
   const rows = []
@@ -25,25 +25,43 @@ async function snapshot(root) {
 
 export async function runMigrationPlannerChecks() {
   const root = await mkdtemp(join(tmpdir(), 'dsh-plan-'))
+  const dependencyResidue = join(root, '.node_modules-delete-pending')
   try {
+    const partition = await partitionDatalessFiles(['/local.ts', '/offline.ts'], {
+      platform: 'darwin',
+      readFlags: async () => ['-', 'archived,compressed,dataless'],
+    })
+    assert.deepEqual(partition, { localFiles: ['/local.ts'], datalessFiles: ['/offline.ts'] })
+
     await mkdir(join(root, 'src'), { recursive: true })
     await mkdir(join(root, 'scripts'), { recursive: true })
+    await mkdir(dependencyResidue, { recursive: true })
     await writeFile(join(root, 'cordis.patch.yml'), '- name: ordinary-composition\n  config: {}\n')
     await writeFile(join(root, 'src', 'plugin.ts'), "import type { ClientContext } from '@deepseek-ai/dsh-client-runtime/client'\nconst proxy = ctx.get('apiProxy')\nctx.useSession((session) => session?.nodes)\n")
     await writeFile(join(root, 'src', 'channel.ts'), "createServer(() => {}).listen(3000, '127.0.0.1') // /api/private\n")
     await writeFile(join(root, 'scripts', 'run.mjs'), "import { spawn } from 'node:child_process'\nspawn('dsh', ['--profile', 'headless'])\n")
     await writeFile(join(root, '.env'), 'APIProxy=secret-must-not-leak\n')
+    await writeFile(join(dependencyResidue, 'stale-plugin.ts'), "const proxy = ctx.get('apiProxy')\n")
 
     const before = await snapshot(root)
-    const plan = await buildMigrationPlan({
-      root,
-      from: 'dsh-v0.1.1-rc.2',
-      to: 'dsh-v0.1.2-alpha.2',
-      maxHits: 5,
-    })
+    await chmod(dependencyResidue, 0o000)
+    let plan
+    try {
+      plan = await buildMigrationPlan({
+        root,
+        from: 'dsh-v0.1.1-rc.2',
+        to: 'dsh-v0.1.2-alpha.2',
+        maxHits: 5,
+      })
+    } finally {
+      await chmod(dependencyResidue, 0o700)
+    }
     const after = await snapshot(root)
     assert.deepEqual(after, before, 'Planner must not modify the target repository')
     assert.equal(plan.readOnly, true)
+    assert.equal(plan.scan.scannedFiles, 4, 'Planner must skip dependency cleanup residue')
+    assert.deepEqual(plan.scan.skippedDatalessFiles, [])
+    assert(!plan.scan.touchpoints.some((entry) => entry.hits.some((hit) => hit.file.startsWith('.node_modules-delete-pending/'))))
     assert.equal(plan.corridor.length, 2)
     assert.deepEqual(
       plan.scan.touchpoints.filter((entry) => entry.detected).map((entry) => entry.id),
@@ -64,6 +82,13 @@ export async function runMigrationPlannerChecks() {
     assert(!markdown.includes('secret-must-not-leak'))
     assert(!markdown.includes("ctx.get('apiProxy')"), 'Planner output must not print matched source lines')
 
+    const datalessMarkdown = renderMarkdown({
+      ...plan,
+      scan: { ...plan.scan, skippedDatalessFiles: ['offline/plugin.ts'] },
+    })
+    assert(datalessMarkdown.includes('Skipped macOS dataless files'))
+    assert(datalessMarkdown.includes('Hydrate them and rerun before making a compatibility claim.'))
+
     const gap = await buildMigrationPlan({
       root,
       from: 'dsh-v0.1.2-alpha.2',
@@ -71,6 +96,26 @@ export async function runMigrationPlannerChecks() {
     })
     assert.equal(gap.gaps.length, 1)
     assert.equal(gap.cards.applicable.length, 0)
+
+    if (process.platform !== 'win32' && process.getuid?.() !== 0) {
+      const unreadableSource = join(root, 'protected-source')
+      await mkdir(unreadableSource)
+      await writeFile(join(unreadableSource, 'plugin.ts'), "ctx.get('apiProxy')\n")
+      await chmod(unreadableSource, 0o000)
+      try {
+        await assert.rejects(
+          buildMigrationPlan({
+            root,
+            from: 'dsh-v0.1.1-rc.2',
+            to: 'dsh-v0.1.2-alpha.2',
+          }),
+          /EACCES|permission denied/i,
+          'Planner must still fail when an ordinary source directory is unreadable',
+        )
+      } finally {
+        await chmod(unreadableSource, 0o700)
+      }
+    }
   } finally {
     await rm(root, { recursive: true, force: true })
   }

--- a/skills/plugin-upgrade/scripts/plan-migration.mjs
+++ b/skills/plugin-upgrade/scripts/plan-migration.mjs
@@ -1,19 +1,32 @@
 #!/usr/bin/env node
+import { execFile } from 'node:child_process'
 import { existsSync } from 'node:fs'
 import { readFile, readdir, stat } from 'node:fs/promises'
 import { basename, dirname, extname, join, relative, resolve } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
+import { promisify } from 'node:util'
 
 // This script lives inside the skill so installers that copy only skills/<name>/ still ship it.
 const skillRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 const referencesRoot = join(skillRoot, 'references')
-const ignoredDirectories = new Set(['.git', 'node_modules', 'vendor', 'lib', 'dist', 'build', 'coverage'])
+const ignoredDirectories = new Set([
+  '.git',
+  '.node_modules-delete-pending',
+  'node_modules',
+  'vendor',
+  'lib',
+  'dist',
+  'build',
+  'coverage',
+])
 const sensitiveNames = new Set(['.env', '.npmrc', '.yarnrc', '.pypirc', 'credentials.json'])
 // Markdown is deliberately not scanned: prose about a touchpoint is not a touchpoint.
 const allowedExtensions = new Set(['.cjs', '.js', '.jsx', '.json', '.mjs', '.toml', '.ts', '.tsx', '.yaml', '.yml'])
 const codeExtensions = new Set(['.cjs', '.js', '.jsx', '.mjs', '.ts', '.tsx'])
 const alwaysReadNames = new Set(['Dockerfile', 'Makefile', 'pnpm-lock.yaml', 'package-lock.json', 'yarn.lock', 'bun.lock', 'bun.lockb'])
 const maxFileBytes = 1024 * 1024
+const execFileAsync = promisify(execFile)
+const darwinStatBatchSize = 256
 
 function relativePath(root, file) {
   return relative(root, file).replaceAll('\\', '/')
@@ -33,6 +46,38 @@ function parseFrontmatter(text, file) {
     meta[match[1]] = /^\d+$/.test(value) ? Number(value) : value
   }
   return { meta, body: normalized.slice(end + 5) }
+}
+
+async function readDarwinFileFlags(files) {
+  const flags = []
+  for (let index = 0; index < files.length; index += darwinStatBatchSize) {
+    const batch = files.slice(index, index + darwinStatBatchSize)
+    const { stdout } = await execFileAsync('/usr/bin/stat', ['-f', '%Sf', ...batch], {
+      encoding: 'utf8',
+      maxBuffer: 1024 * 1024,
+    })
+    const rows = stdout.replace(/\n$/, '').split('\n')
+    if (rows.length !== batch.length) throw new Error('macOS stat returned an unexpected file count')
+    flags.push(...rows)
+  }
+  return flags
+}
+
+export async function partitionDatalessFiles(
+  files,
+  { platform = process.platform, readFlags = readDarwinFileFlags } = {},
+) {
+  if (platform !== 'darwin' || files.length === 0) return { localFiles: files, datalessFiles: [] }
+  const flags = await readFlags(files)
+  if (flags.length !== files.length) throw new Error('macOS stat flags do not match the candidate file count')
+  const localFiles = []
+  const datalessFiles = []
+  for (let index = 0; index < files.length; index += 1) {
+    const flagSet = new Set(flags[index].split(','))
+    if (flagSet.has('dataless')) datalessFiles.push(files[index])
+    else localFiles.push(files[index])
+  }
+  return { localFiles, datalessFiles }
 }
 
 async function walkReadableFiles(root) {
@@ -62,7 +107,12 @@ async function walkReadableFiles(root) {
   await visit(root)
   files.sort()
   skippedLargeFiles.sort()
-  return { files, skippedLargeFiles }
+  const { localFiles, datalessFiles } = await partitionDatalessFiles(files)
+  return {
+    files: localFiles,
+    skippedLargeFiles,
+    skippedDatalessFiles: datalessFiles.map((file) => relativePath(root, file)),
+  }
 }
 
 function matchingLine(text, source) {
@@ -80,7 +130,7 @@ export async function scanRepository(targetRoot, { maxHits = 20, manualTouchpoin
   if (!existsSync(root)) throw new Error(`target root does not exist: ${root}`)
   const patternFile = join(referencesRoot, 'pre-flight-patterns.json')
   const patternData = JSON.parse(await readFile(patternFile, 'utf8'))
-  const { files, skippedLargeFiles } = await walkReadableFiles(root)
+  const { files, skippedLargeFiles, skippedDatalessFiles } = await walkReadableFiles(root)
   const texts = new Map()
   for (const file of files) texts.set(file, await readFile(file, 'utf8'))
 
@@ -116,6 +166,7 @@ export async function scanRepository(targetRoot, { maxHits = 20, manualTouchpoin
     root,
     scannedFiles: files.length,
     skippedLargeFiles,
+    skippedDatalessFiles,
     touchpoints,
   }
 }
@@ -236,6 +287,15 @@ export function renderMarkdown(plan) {
   if (plan.gaps.length) lines.push('', '## Unsupported corridor gaps', '', ...plan.gaps.map((gap) => `- ${gap}`))
   if (plan.scan.skippedLargeFiles.length) {
     lines.push('', '## Skipped large files', '', ...plan.scan.skippedLargeFiles.map((file) => `- \`${file}\``))
+  }
+  if (plan.scan.skippedDatalessFiles.length) {
+    lines.push(
+      '',
+      '## Skipped macOS dataless files',
+      '',
+      '- These files are not stored locally. Hydrate them and rerun before making a compatibility claim.',
+      ...plan.scan.skippedDatalessFiles.map((file) => `- \`${file}\``),
+    )
   }
   return `${lines.join('\n')}\n`
 }


### PR DESCRIPTION
## Summary

Keep the read-only migration planner usable on real plugin checkouts with two kinds of local filesystem residue:

- ignore the known `.node_modules-delete-pending` dependency cleanup directory;
- on macOS, inspect file flags before reading and report APFS/iCloud `dataless` placeholders instead of implicitly hydrating them or blocking the scan.

The report now makes the evidence boundary explicit: skipped cloud files must be hydrated and the planner rerun before making a compatibility claim. Ordinary unreadable source directories still fail closed.

### Reproduction and candidate evidence

Baseline `1b885148f39b303986e0c7dd5eaabce3e56c7e91`:

- `dsh-goal-quiescence` failed with `EACCES` while traversing `.node_modules-delete-pending`;
- `dsh-plan-lattice` blocked while reading a macOS `dataless` source file.

Candidate `05948cb`:

- `dsh-goal-quiescence`: 7 files scanned, touchpoints #2/#5, full rc.2 -> alpha.4 corridor, no gaps;
- `dsh-plan-lattice`: 292 files scanned, touchpoints #2-#7, full rc.2 -> alpha.4 corridor, no gaps; `src/router-model.ts` reported as skipped and remained `dataless` before and after the scan.

## Scope Checklist

- [x] I checked existing Issues and PRs for overlap and coordinated any related work.
- [x] N/A: this changes planner filesystem handling and makes no version-specific DSH claim.
- [x] N/A: no version card or API source claim changes.
- [x] N/A: no migration card or touchpoint definition changes.
- [x] Host, Web Client, and ordinary Cordis plugin classification is unchanged.
- [x] N/A: this is not a benchmark result or validation-report PR.

## Verification

Commands run:

```text
node skills/plugin-upgrade/scripts/plan-migration.check.mjs
node scripts/validate.mjs
node scripts/validate-manifests.mjs
npm test
python quick_validate.py skills/plugin-upgrade
git diff HEAD^ --check
trufflehog filesystem <three changed files>
```

Additional checks:

- [x] I ran the focused regression, including dependency residue, dataless classification/reporting, and the ordinary unreadable-source counterexample.
- [x] I reviewed the complete diff and `git diff --check`.
- [x] I ran the planner against the two real plugin repositories described above.
- [x] TruffleHog 3.97.1 found 0 verified, unverified, or unknown secrets in the changed files.

Unverified boundaries:

- Linux and Windows were not run directly; the non-Darwin path is covered by the focused check.
- `npm run test:dsh` was not run because the local Docker/Colima daemon was unavailable. This change does not alter DSH runtime fixtures, version cards, or plugin runtime behavior.

## Review Notes

The macOS path batches `/usr/bin/stat -f %Sf` calls before reading candidate files. A missing or unexpected stat result fails the scan rather than silently treating a file as local. Skipped paths are rendered in Markdown and JSON, while source contents remain redacted.
