### PR TITLE
docs(cards): add v0.1.1-rc.1 corridor (rc.8→rc.1, 9 draft cards)

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -8,7 +8,7 @@
 
 ## What's in this repo
 
-- **45 upgrade cards** — each records one real pitfall: what breaks, why, how to fix it, and which version the information comes from. Ordered by version, from 0.1.1 all the way to 0.1.2-alpha.4 (alpha.2→alpha.3 has no plugin-facing changes: 0 cards; alpha.3→alpha.4 has 6).
+- **57 upgrade cards** — each records one real pitfall: what breaks, why, how to fix it, and which version the information comes from. Ordered by version, from 0.1.0-rc.8 all the way to 0.1.2-rc.1 (alpha.2→alpha.3 and alpha.5→rc.1 have no plugin-facing changes: 0 cards; alpha.3→alpha.4 has 6; rc.8→rc.1 carries 9 draft cards).
 - **12 general-purpose countermeasures** — some problems have nothing to do with the version (back up first, run old and new side by side, what to do when startup hangs). These live in one checklist.
 - **8 skills** — one unified workflow selects and coordinates stages, while the other seven check upgrades, write plugins, test plugins, release plugins, diff two dsh versions, debug runtime failures, and integrate heavy dependencies into lightweight plugins.
 - **26 exam questions (benchmark)** — tests whether an AI with our skill actually knows how to upgrade a plugin. Every question is auto-graded; one reproduces the real dsh-web v0.3.8 → v0.3.9 migration.
@@ -123,13 +123,16 @@ Upgrade the dsh-ads plugin to dsh-v0.1.2-alpha.2
 
 | Version range | Status | Cards | Notes |
 | --- | --- | --- | --- |
+| 0.1.0-rc.8 → 0.1.1-rc.1 | 📝 Draft | [v0.1.1-rc.1.md](skills/plugin-upgrade/references/v0.1.1-rc.1.md) | 9 draft cards (vlln plugin migrations: repository mechanism removal, strict inject, 0812 service renames, etc.; corridor is the closest published-tag alignment for the internal 0810–0812 snapshot window, pending upstream review) |
 | 0.1.1-rc.1 → 0.1.1-rc.2 | ✅ Done | [v0.1.1-rc.2.md](skills/plugin-upgrade/references/v0.1.1-rc.2.md) | 3 cards |
 | 0.1.1-rc.2 → 0.1.2-alpha.1 | ✅ Done | [v0.1.2-alpha.1.md](skills/plugin-upgrade/references/v0.1.2-alpha.1.md) | 28 cards |
 | 0.1.2-alpha.1 → 0.1.2-alpha.2 | ✅ Done | [v0.1.2-alpha.2.md](skills/plugin-upgrade/references/v0.1.2-alpha.2.md) | 8 cards |
 | 0.1.2-alpha.2 → 0.1.2-alpha.3 | ✅ Done | [v0.1.2-alpha.3.md](skills/plugin-upgrade/references/v0.1.2-alpha.3.md) | 0 cards (no plugin-facing changes; carries the verification record) |
 | 0.1.2-alpha.3 → 0.1.2-alpha.4 | ✅ Done | [v0.1.2-alpha.4.md](skills/plugin-upgrade/references/v0.1.2-alpha.4.md) | 6 cards (`report` → `send_message`, Python runtime package rename, `Session.events` removal, branded seq types, PTC `workflow` and base `web_fetch` defaults; verified on three real hosts) |
+| 0.1.2-alpha.4 → 0.1.2-alpha.5 | ✅ Done | [v0.1.2-alpha.5.md](skills/plugin-upgrade/references/v0.1.2-alpha.5.md) | 3 cards (storage-domain `compatibleVersions` read tolerance and `backup-and-skip` salvage; boot/title-loss fix for legacy homes; storage-layer reproduction record) |
+| 0.1.2-alpha.5 → 0.1.2-rc.1 | ✅ Done | [v0.1.2-rc.1.md](skills/plugin-upgrade/references/v0.1.2-rc.1.md) | 0 cards (pure version bump; verification record, macOS real-host validation, and release-notes coverage matrix) |
 | Cross-version countermeasures | ✅ Done | [rollup-0.1.2.md](skills/plugin-upgrade/references/rollup-0.1.2.md) | 12 items (running old and new side by side, back up first, what to do when startup hangs, etc.) |
-| 0.1.1 → 0.1.2 final | 🔄 Waiting for the official release | — | dsh 0.1.2 final isn't out yet (latest is alpha.4; the corridor is verified through alpha.4); we'll re-verify everything once it is |
+| 0.1.1 → 0.1.2 final | 🔄 Waiting for the official release | — | dsh 0.1.2 final isn't out yet (latest is rc.1; the corridor is verified through rc.1); we'll re-verify everything once it is |
 | 0.1.2 → later versions | 📝 Up for grabs | — | Want to help write cards? See the [contributing guide](CONTRIBUTING.md) |
 
 ## The exam (benchmark)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## 这个仓库里有什么
 
-- **45 张升级说明卡**：每张卡记录一个真实的坑——什么坏了、为什么坏、怎么修、信息来源是哪个版本。按版本排好序，从 0.1.1 一路到 0.1.2-alpha.4（alpha.2→alpha.3 无插件面变更，0 张卡；alpha.3→alpha.4 有 6 张）。
+- **57 张升级说明卡**：每张卡记录一个真实的坑——什么坏了、为什么坏、怎么修、信息来源是哪个版本。按版本排好序，从 0.1.0-rc.8 一路到 0.1.2-rc.1（alpha.2→alpha.3 与 alpha.5→rc.1 无插件面变更，0 张卡；alpha.3→alpha.4 有 6 张；rc.8→rc.1 为 9 张草稿卡）。
 - **12 条通用对策**：有些坑和版本无关（比如"先备份再动手""新旧版本怎么共存"），这些写成了一份对策清单。
 - **8 个 skill**：一个统一工作流负责选择和编排，另外七个分别负责查升级、写新插件、测插件、发插件、对比两个版本的差别、排查运行时故障和给轻量插件接入重依赖。
 - **26 道考题（benchmark）**：用来测"AI 装了我们的 skill 之后到底会不会升级插件"，每道题都有自动判分；其中包含 dsh-web v0.3.8 → v0.3.9 的真实迁移。
@@ -132,8 +132,10 @@ Claude Code 中按名字调用 skill（插件安装后带命名空间）：
 | 0.1.2-alpha.1 → 0.1.2-alpha.2 | ✅ 完成 | [v0.1.2-alpha.2.md](skills/plugin-upgrade/references/v0.1.2-alpha.2.md) | 8 张卡 |
 | 0.1.2-alpha.2 → 0.1.2-alpha.3 | ✅ 完成 | [v0.1.2-alpha.3.md](skills/plugin-upgrade/references/v0.1.2-alpha.3.md) | 0 张卡（无插件面变更，含核对记录） |
 | 0.1.2-alpha.3 → 0.1.2-alpha.4 | ✅ 完成 | [v0.1.2-alpha.4.md](skills/plugin-upgrade/references/v0.1.2-alpha.4.md) | 6 张卡（`report` → `send_message`、Python 运行时包改名、`Session.events` 移除、seq 强类型、PTC `workflow` 与 base `web_fetch` 默认值；三台真宿主验证） |
+| 0.1.2-alpha.4 → 0.1.2-alpha.5 | ✅ 完成 | [v0.1.2-alpha.5.md](skills/plugin-upgrade/references/v0.1.2-alpha.5.md) | 3 张卡（storage 域 `compatibleVersions` 读兼容与 `backup-and-skip` 兜底；旧家升级拒启/标题丢失修复；storage 层复现核对） |
+| 0.1.2-alpha.5 → 0.1.2-rc.1 | ✅ 完成 | [v0.1.2-rc.1.md](skills/plugin-upgrade/references/v0.1.2-rc.1.md) | 0 张卡（纯版本 bump；含核对记录、macOS 真机验证与 release notes 覆盖矩阵） |
 | 跨版本通用对策 | ✅ 完成 | [rollup-0.1.2.md](skills/plugin-upgrade/references/rollup-0.1.2.md) | 12 条（新旧共存、先备份、启动卡死怎么办等） |
-| 0.1.1 → 0.1.2 正式版 | 🔄 等官方发版 | — | dsh 0.1.2 还没发正式版（最新是 alpha.4，走廊已核实到 alpha.4），发了之后我们要复核一遍 |
+| 0.1.1 → 0.1.2 正式版 | 🔄 等官方发版 | — | dsh 0.1.2 还没发正式版（最新是 rc.1，走廊已核实到 rc.1），发了之后我们要复核一遍 |
 | 0.1.2 → 更新版本 | 📝 等社区认领 | — | 想帮忙写卡？看 [贡献指南](CONTRIBUTING.md) |
 
 ## 考题（benchmark）

--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Claude Code 中按名字调用 skill（插件安装后带命名空间）：
 
 | 版本区间 | 状态 | 说明卡 | 备注 |
 | --- | --- | --- | --- |
+| 0.1.0-rc.8 → 0.1.1-rc.1 | 📝 草稿 | [v0.1.1-rc.1.md](skills/plugin-upgrade/references/v0.1.1-rc.1.md) | 9 张草稿卡（vlln 插件迁移：repository 机制移除、strict inject、0812 服务改名等；走廊为 0810–0812 内测快照窗口的最近公开 tag 对齐，待上游复核） |
 | 0.1.1-rc.1 → 0.1.1-rc.2 | ✅ 完成 | [v0.1.1-rc.2.md](skills/plugin-upgrade/references/v0.1.1-rc.2.md) | 3 张卡 |
 | 0.1.1-rc.2 → 0.1.2-alpha.1 | ✅ 完成 | [v0.1.2-alpha.1.md](skills/plugin-upgrade/references/v0.1.2-alpha.1.md) | 28 张卡 |
 | 0.1.2-alpha.1 → 0.1.2-alpha.2 | ✅ 完成 | [v0.1.2-alpha.2.md](skills/plugin-upgrade/references/v0.1.2-alpha.2.md) | 8 张卡 |

--- a/skills/plugin-upgrade/SKILL.md
+++ b/skills/plugin-upgrade/SKILL.md
@@ -92,6 +92,7 @@ Structure the report as:
 | [references/README.md](references/README.md) | Version corridors, card schema, and maintenance rules |
 | [references/pre-flight.md](references/pre-flight.md) | Seven-class touchpoint self-check and summary template |
 | [references/troubleshooting.md](references/troubleshooting.md) | Post-migration symptom → root cause → card lookup |
+| [references/v0.1.1-rc.1.md](references/v0.1.1-rc.1.md) | rc.8→rc.1 draft cards: repository-plugins mechanism removal, `dshClient`→`dsh.client` manifest merge, client-modules scan → bundle `dsh.client`, strict injection + weak `ctx.get`, session event contract, self-rendering client session aggregation, `tasks.peek` removal, 0812 service renames (vlln plugin migrations; corridor is the closest published-tag alignment for the internal 0810–0812 snapshot window) |
 | [references/v0.1.2-alpha.1.md](references/v0.1.2-alpha.1.md) | rc.2→alpha.1 curated cards |
 | [references/v0.1.2-alpha.2.md](references/v0.1.2-alpha.2.md) | alpha.1→alpha.2 curated cards |
 | [references/v0.1.2-alpha.3.md](references/v0.1.2-alpha.3.md) | alpha.2→alpha.3 curated cards (zero cards: no plugin-facing changes; carries the verification record) |

--- a/skills/plugin-upgrade/SKILL.zh-CN.md
+++ b/skills/plugin-upgrade/SKILL.zh-CN.md
@@ -123,6 +123,7 @@
 | [references/README.md](references/README.md) | 版本走廊、卡片 schema 与维护规则 |
 | [references/pre-flight.md](references/pre-flight.md) | 七类触点自查与汇总模板 |
 | [references/troubleshooting.md](references/troubleshooting.md) | 迁移后症状 → 根因 → 卡片 / 走廊配方速查 |
+| [references/v0.1.1-rc.1.md](references/v0.1.1-rc.1.md) | rc.8→rc.1 草稿卡：repository-plugins 机制移除、`dshClient`→`dsh.client` manifest 合并、client-modules 扫描 → bundle `dsh.client`、严格注入 + 弱 `ctx.get`、session 事件契约、自渲染 client 会话聚合、`tasks.peek` 移除、0812 服务改名（vlln 插件迁移；走廊为 0810–0812 内测快照窗口的最近公开 tag 对齐，待上游复核） |
 | [references/v0.1.2-alpha.1.md](references/v0.1.2-alpha.1.md) | rc.2→alpha.1 curated 卡 |
 | [references/v0.1.2-alpha.2.md](references/v0.1.2-alpha.2.md) | alpha.1→alpha.2 curated 卡 |
 | [references/v0.1.2-alpha.3.md](references/v0.1.2-alpha.3.md) | alpha.2→alpha.3 curated 卡（0 张卡：无插件面变更，含核对记录） |

--- a/skills/plugin-upgrade/references/README.md
+++ b/skills/plugin-upgrade/references/README.md
@@ -11,6 +11,7 @@ source: if a field is removed in alpha.1 and restored in alpha.2, do not delete 
 
 | Order | Card file | from | to | Cards | Status / coverage |
 |---|---|---|---|---:|---|
+| 0 | [v0.1.1-rc.1.md](v0.1.1-rc.1.md) | `dsh-v0.1.0-rc.8` | `dsh-v0.1.1-rc.1` | 9 | draft / curated (vlln plugin migrations: repository-plugins mechanism removal, `dshClient`→`dsh.client` manifest merge, client-modules scan → bundle `dsh.client`, strict inject + weak `ctx.get`, session event contract (`type` not `kind`), self-rendering client session aggregation, `tasks.peek` removal, 0812 service renames — `httpServer`→`webServer`, `tasks`→`jobs`; corridor is the closest published-tag alignment for the internal 0810–0812 snapshot window, upstream review may reassign) |
 | 1 | [v0.1.1-rc.2.md](v0.1.1-rc.2.md) | `dsh-v0.1.1-rc.1` | `dsh-v0.1.1-rc.2` | 3 | reviewed / curated |
 | 2 | [v0.1.2-alpha.1.md](v0.1.2-alpha.1.md) | `dsh-v0.1.1-rc.2` | `dsh-v0.1.2-alpha.1` | 28 | reviewed / curated |
 | 3 | [v0.1.2-alpha.2.md](v0.1.2-alpha.2.md) | `dsh-v0.1.2-alpha.1` | `dsh-v0.1.2-alpha.2` | 8 | reviewed / curated |

--- a/skills/plugin-upgrade/references/v0.1.1-rc.1.md
+++ b/skills/plugin-upgrade/references/v0.1.1-rc.1.md
@@ -1,0 +1,163 @@
+---
+kind: dsh-version-card-set
+schema: 1
+from: dsh-v0.1.0-rc.8
+to: dsh-v0.1.1-rc.1
+status: draft
+coverage: curated
+cardCount: 9
+idPrefix: DSH-0.1.1-R1
+verifiedAt: 2026-09-01
+---
+
+# Change cards · 0.1.0-rc.8 → 0.1.1-rc.1
+
+> This card set is **draft**: it collects real-world plugin migrations performed against
+> the internal 0810/0811/0812 snapshots (before the public `0.1.1-rc.1` baseline). The
+> corridor `dsh-v0.1.0-rc.8 → dsh-v0.1.1-rc.1` is the closest published-tag alignment for
+> that window; upstream review may reassign individual cards to a different edge.
+>
+> Every card's migration recipe is backed by an actual plugin commit (whale-girl,
+> dsh-loop, dsh-navbar, dsh-task-status, plugin-registry) that performed the upgrade and
+> verified the result on a real dsh instance.
+>
+> Card format: see [references/README.md](README.md) · Touchpoint numbering: see [pre-flight.md](pre-flight.md)
+
+## Contents
+
+- DSH-0.1.1-R1-01 · repository-plugins mechanism removed: external plugins become npm packages
+- DSH-0.1.1-R1-02 · Manifest field `dshClient` merged into `dsh.client`
+- DSH-0.1.1-R1-03 · client-modules scans only packages declaring `dsh.client`
+- DSH-0.1.1-R1-04 · cordis strict injection: `ctx.get` on undeclared services throws
+- DSH-0.1.1-R1-05 · Prefer weak `ctx.get` over property access for optional host services
+- DSH-0.1.1-R1-06 · Session event contract: field is `type`, not `kind`; subscription survives sessions absence
+- DSH-0.1.1-R1-07 · Self-rendering clients have no `ctx.sessions`; aggregate session state in the Node half
+- DSH-0.1.1-R1-08 · `tasks.peek` removed: use `read` + a shadow accumulation buffer
+- DSH-0.1.1-R1-09 · 0812 service renames: `httpServer`→`webServer`, `tasks`→`jobs`, `onTaskDone`→`onJobDone`
+
+---
+
+### DSH-0.1.1-R1-01 · repository-plugins mechanism removed: external plugins become npm packages
+
+- **Type**: breaking
+- **Applies to**: every external plugin that was installed/loaded through the repository-plugin mechanism, and any console/CLI built on `repository-plugins.repositories`
+- **Touchpoints**: #3, #5
+- **Action level**: required
+- **Symptoms**: `vendor/loader/src/repository.ts` is deleted; `repository-plugins.repositories` rows no longer load; `plugin_search`/`plugin_install`/`plugin_uninstall`/`plugin_status` built on the mechanism have no backend; packages previously mounted via the repository mechanism vanish from the boot graph.
+- **Migration recipe**: Convert the plugin to an npm package and install it through the single official profile path:
+  - bundle plugins: declare `dsh.bundle` in `package.json`, install via `dsh plugin --profile web add <pkg|git|dir>` into the `dsh.profile.bundles` layer stack (takes effect after a web restart);
+  - plain Cordis plugins: `dsh plugin --profile web add <pkg>` plus a `cordis.patch.yml` insert row in the profile (config-level HMR mounts live, no restart);
+  - drop legacy artifacts: `dsh.plugin.json`, repository rows, and the internal `__ModuleLoader__`-adjacent repository registration;
+  - keep the runtime entry (`main`/`exports["."]`) and `dsh.client` declaration intact; update any manager UI/CLI that enumerated repository sources.
+- **Verification**: cold-boot a profile containing the converted package; the boot graph shows the plugin row; for a Web Client plugin verify the client half enters `__DSH_BOOT__` and its advertised bundle URL returns 200; no `pending (waiting for service: …)` left on rows the plugin owns.
+- **Source**: [repository loader removal commit](https://github.com/deepseek-ai/deepseek-harness/commit/993550e6c851e1ae05aa7d587d10ae1626ae1191) · [plugin-registry 0811 console adaptation](https://github.com/vlln/plugin-registry/commit/bfa0e8d16348246fa52fa2c13bd6b51fefda33c3)
+- **Field note** (2026-08-12, whale-girl, bundle conversion): moving from the repository-plugin layout (`.dsh-plugin/` with self-executing UI entry injected via `httpServer.tapIndex`) to the standard bundle format (`dsh.bundle` + `cordis.patch.yml` + `__ModuleLoader__.load` client) touched the Node half, the client bundle, the build script, and the decision record — 1169 insertions / 1071 deletions across 8 files; the client entry changed from "page script" to `{name, apply}` registration. [whale-girl 426e86d](https://github.com/vlln/whale-girl/commit/426e86dd30d5fb3746752c82a71f9a4b22a817aa)
+
+---
+
+### DSH-0.1.1-R1-02 · Manifest field `dshClient` merged into `dsh.client`
+
+- **Type**: breaking
+- **Applies to**: plugins whose `package.json` still declares a legacy `dshClient` field (or `dsh.plugin.json`) for their client half
+- **Touchpoints**: None (packaging/manifest surface)
+- **Action level**: required-if-hit
+- **Symptoms**: hosts starting at the 0810 baseline only read `dsh.client`; a leftover `dshClient` field is ignored, so the client half is not recognized and the browser plugin roster or bundle assembly omits it.
+- **Migration recipe**: rename the field to `dsh.client` with the same value shape (platform `web` and the client entry path); check the bundled declaration after packing, not only the source `package.json`; remove any legacy `dsh.plugin.json` manifest.
+- **Verification**: pack the plugin and confirm the packed manifest carries `dsh.client`; after install, the profile's bundle layer or insert row resolves and the client route serves the expected artifact.
+- **Source**: [dsh-loop 0810 baseline migration](https://github.com/vlln/dsh-loop/commit/5b48a4595b1a739631c8a869a432d4571de344b9) · [dsh-task-status 0810 baseline migration](https://github.com/vlln/dsh-task-status/commit/16f6324b0ffb0fdf0fe04fd2750ef48828b64172) · [plugin-registry console 0810 migration](https://github.com/vlln/plugin-registry/commit/5ab6e22b7a2a589b002746777f29148f975b644a)
+- **Field note** (2026-08-10, dsh-loop): the merge is a small manifest edit (9+/9− in `package.json`) but silently drops the client half if missed; dsh-task-status and plugin-registry's console hit the same field in the same window — three repositories, one root cause.
+
+---
+
+### DSH-0.1.1-R1-03 · client-modules scans only packages declaring `dsh.client`
+
+- **Type**: breaking
+- **Applies to**: Web Client plugins whose client half did not declare `dsh.client` while the host still shipped a `dshClient`-era manifest
+- **Touchpoints**: #5
+- **Action level**: required-if-hit
+- **Symptoms**: starting 0811, client-modules enumerates packages by the `dsh.client` declaration only; a package that declares `dsh.bundle` but not `dsh.client` never enters the browser plugin roster, so the client UI is absent with no Node-half error.
+- **Migration recipe**: declare `dsh.client` (`platform: web` + client entry) in `package.json` even when the client bundle is built into the bundle; verify the packed manifest, not just the source.
+- **Verification**: install the plugin, reload the web UI, and confirm the client half registers (boot manifest line + DOM marker); absence of the declaration is invisible in Node logs.
+- **Source**: [dsh-navbar 3e81acd — declare `dsh.client` because client-modules scans it](https://github.com/vlln/dsh-navbar/commit/3e81acdedac111150436a9790ff7b4a4be302e7c) · related scan contract [DSH-0.1.2-A1-26](v0.1.2-alpha.1.md)
+
+---
+
+### DSH-0.1.1-R1-04 · cordis strict injection: `ctx.get` on undeclared services throws
+
+- **Type**: breaking
+- **Applies to**: plugins using `ctx.get('service')` or property access for services they did not list in `inject`
+- **Touchpoints**: #3
+- **Action level**: required-if-hit
+- **Symptoms**: under 0811 cordis strict injection, accessing an undeclared service throws `cannot get property without inject`; in some plugins the throw happens at the top of `apply()`, so the whole `ctx.effect` never registers and routes fall back or features silently disappear.
+- **Migration recipe**: declare every service consumed via `ctx.get(...)`/property access in the plugin's `inject` array; when a service is genuinely optional across profiles, probe it weakly (see [DSH-0.1.1-R1-05](v0.1.1-rc.1.md)) instead of widening `inject` unconditionally; run a cold boot on the exact target profile, not just a typecheck.
+- **Verification**: cold-boot the target profile and confirm the plugin's effect is registered and the feature works; the error appears at startup only on the real composition, so install/typecheck success is not sufficient evidence.
+- **Source**: [whale-girl 0f9e3b5 — inject gets `settings`/`httpServer`](https://github.com/vlln/whale-girl/commit/0f9e3b53cf31f1ce9a9f2e232156618d18a1b8b1)
+- **Field note** (2026-08-12, whale-girl): `inject` was extended from `['tasks','agents','sessions']` to `['tasks','agents','sessions','settings','httpServer']`; the failure mode was one line of diff but cost a full effect-not-registered bug, i.e. a small symptom with a large blast radius. The note documents why it is safe for the bundle shape: bundle plugins enter only the web profile, where `settings` (base layer) and `httpServer` (web composition) are guaranteed.
+
+---
+
+### DSH-0.1.1-R1-05 · Prefer weak `ctx.get` over property access for optional host services
+
+- **Type**: behavior
+- **Applies to**: plugins that treated an optional host service as a hard dependency or accessed it via property read
+- **Touchpoints**: #3
+- **Action level**: conditional
+- **Symptoms**: direct `ctx.httpServer` property access requires the service to be injected (strict injection); when the service is optional in some profile (e.g. headless), property access can fail or mislead.
+- **Migration recipe**: use `typeof ctx.get === 'function' ? ctx.get('httpServer') : undefined` for optional services and degrade gracefully; reserve hard `inject` entries for services that are guaranteed by the plugin's profile scope.
+- **Verification**: cold-boot both a profile with and without the optional service; the plugin still activates and degrades as designed.
+- **Source**: [whale-girl 8678b13 — weak `ctx.get` for httpServer](https://github.com/vlln/whale-girl/commit/8678b139eaad82decf5b29529c6b91e475851cf5)
+
+---
+
+### DSH-0.1.1-R1-06 · Session event contract: field is `type`, not `kind`; subscription survives sessions absence
+
+- **Type**: fix
+- **Applies to**: plugins that subscribe to `session/event` or derive session state from event fields
+- **Touchpoints**: #2
+- **Action level**: required-if-hit
+- **Symptoms**: session events carry the discriminator in `event.type`, not `event.kind`; handlers that switch on `kind` never match; additionally, a subscription that is dropped when the `sessions` service is absent loses session awareness permanently, and `sessionWait` state depends on `reason.kind === 'blocked'`.
+- **Migration recipe**: read `event.type` for the event discriminator; keep the `session/event` subscription registered even when the `sessions` service is temporarily absent (subscribe once, degrade per event, not by dropping the subscription); treat turn/end `reason.kind === 'blocked'` as waiting-on-user for `sessionWait` semantics; pin the event contract from the target tag's types/tests.
+- **Verification**: unit-test the handler with a real event object (field `type` present, no `kind`); verify session awareness still works after a transient `sessions` absence; confirm `sessionWait` reflects approval/blocked states.
+- **Source**: [whale-girl 78a6b70 — session event response fixes](https://github.com/vlln/whale-girl/commit/78a6b703aab16b92cf065d8e7138010e58a02b67) · companion test file in the same commit
+
+---
+
+### DSH-0.1.1-R1-07 · Self-rendering clients have no `ctx.sessions`; aggregate session state in the Node half
+
+- **Type**: breaking
+- **Applies to**: self-rendering Web Client plugins that previously consumed `ctx.sessions` directly (or a removed client runtime session API)
+- **Touchpoints**: #3, #5
+- **Action level**: required-if-hit
+- **Symptoms**: the official self-rendering client surface does not expose `ctx.sessions`; session-aware features (thinking state, waiting-on-user, turn completion) stop receiving data after the client-runtime dismantling.
+- **Migration recipe**: move session aggregation into the Node half: subscribe to session events there, derive the session mood / waiting / completion signal, and expose it through the plugin's own `/state` route (or equivalent) that the client polls; keep the client thin and event-driven from that polling; see dsh-client-runtime removal card [DSH-0.1.2-A1-25](v0.1.2-alpha.1.md) for the symbol migration surface.
+- **Verification**: cold-boot the plugin and exercise a session action; the client shows the aggregated state (e.g. thinking/waiting animation) within one poll cycle; no client-side `ctx.sessions` references remain.
+- **Source**: [whale-girl d01bccb — session state aggregated by Node half](https://github.com/vlln/whale-girl/commit/d01bccb677fc076e8e90b17a0975a9fb70e220fc)
+- **Field note** (2026-08-11, whale-girl): `fix(node): 会话感知改由 Node half 聚合进 /state——官方自渲染 client 无 ctx.sessions`; the client shrunk (70/52 lines removed), the Node half grew (54 lines) and a new 27-line decision record documented the aggregation.
+
+---
+
+### DSH-0.1.1-R1-08 · `tasks.peek` removed: use `read` + a shadow accumulation buffer
+
+- **Type**: breaking
+- **Applies to**: plugins that tail task/run output via a non-consuming `tasks.peek` API
+- **Touchpoints**: #3, #5
+- **Action level**: required-if-hit
+- **Symptoms**: `tasks.peek` no longer exists on the 0809+ host (`0809 无 tasks.peek`); tail-style output UI built on it breaks; naive fallback to `read` consumes output and breaks concurrent readers.
+- **Migration recipe**: read consumed output with `tasks.read`, maintain a per-task shadow buffer with a capped window, and render from the shadow; if multiple consumers must share the stream, layer a tee/observer pattern on `read` so the plugin's own reads bypass the patch and official reads are mirrored (see the follow-up tee fix in the field note); keep the buffer cursor monotonic.
+- **Verification**: expand a running task in the UI and confirm tail keeps updating without duplicating or losing lines; run two readers simultaneously and confirm neither starves; cold-boot with no `peek` references.
+- **Source**: [dsh-task-status 29dda2f — tail via `read` + shadow buffer](https://github.com/vlln/dsh-task-status/commit/29dda2f6bec4242700d61e6efdd3b926f084e8c5)
+- **Field note** (2026-08-10, dsh-task-status): two follow-up commits hardened the same seam — [ba1d526](https://github.com/vlln/dsh-task-status/commit/ba1d52670495e13c10858b3a2e9e747eb7dd909e) (mirror + direct-read to defeat races, "tail 竞争根治 v2") and [cc5097c](https://github.com/vlln/dsh-task-status/commit/cc5097c11391b210efd32c50c78e6c788aca5936) (tee patch on `ctx.tasks.read`, observer semantics, 41+/25− across client and Node halves); the initial `read`+shadow fix was itself 44+/17− in the Node half plus 16 lines of client changes, showing the API removal was only the first layer of the bug.
+
+---
+
+### DSH-0.1.1-R1-09 · 0812 service renames: `httpServer`→`webServer`, `tasks`→`jobs`, `onTaskDone`→`onJobDone`
+
+- **Type**: breaking
+- **Applies to**: plugins that inject, call, or listen on the renamed services
+- **Touchpoints**: #3, #2
+- **Action level**: required-if-hit
+- **Symptoms**: `inject` entries and `ctx.*` references for `httpServer`/`tasks` stop resolving; route registration and task-event handlers silently miss; event listeners keyed on `onTaskDone` no longer fire after the rename to `onJobDone`.
+- **Migration recipe**: rename the injected service identifiers and all `ctx` usages (`httpServer`→`webServer`, `tasks`→`jobs`); rename task-event listeners (`onTaskDone`→`onJobDone`); the route-registration interface (`webServer.register`) otherwise keeps its shape — do not rewrite unrelated code; update docs/comments that name the service.
+- **Verification**: cold-boot and confirm injection resolves with no `pending (waiting for service: …)`; hit a registered route and exercise one task event end-to-end; grep the packed artifact (not just source) for leftover old identifiers.
+- **Source**: [whale-girl 183354b](https://github.com/vlln/whale-girl/commit/183354b9c12272014ec534114622db6a11dfa59e) · [dsh-loop c5bf083](https://github.com/vlln/dsh-loop/commit/c5bf0832af381763697b388826b43da878186821) · [dsh-task-status 2b41273](https://github.com/vlln/dsh-task-status/commit/2b41273ef7cb46a1999f99b75384702faefcbeb8) · [plugin-registry 27aed06](https://github.com/vlln/plugin-registry/commit/27aed0623c76f89425f52a18aa93350b2a93e29b)
+- **Field note** (2026-08-12, four repositories in one day): the same rename hit whale-girl (16+/16−, one file), dsh-loop (29+/8−, source + packed lib + tsdown config), dsh-task-status (34+/34−, source + lib, plus the `tasks.read`→`jobs.read` comment/binding), and plugin-registry console (11+/11−, source + lib). Four independent repositories, one root cause — a signature of a high-frequency, low-diff breaking change that static scans for old service identifiers should catch.


### PR DESCRIPTION
## Summary

Add a new version-card corridor `dsh-v0.1.0-rc.8 → dsh-v0.1.1-rc.1` with 9 draft
cards collected from real-world vlln plugin migrations performed against the
internal 0810/0811/0812 snapshots (before the public `0.1.1-rc.1` baseline).
The corridor is the closest published-tag alignment for that window; upstream
review may reassign individual cards to a different edge.

Cards cover: repository-plugins mechanism removal (R1-01), `dshClient` →
`dsh.client` manifest merge (R1-02), client-modules scan → bundle `dsh.client`
(R1-03), cordis strict injection + weak `ctx.get` (R1-05), session event
contract `type` not `kind` (R1-06), self-rendering client session aggregation
(R1-07), `tasks.peek` removal (R1-08), and the 0812 service renames
`httpServer`→`webServer`, `tasks`→`jobs` (R1-09) with four independent field
notes (whale-girl, dsh-loop, dsh-task-status, plugin-registry).

## Scope Checklist

- [x] I checked existing Issues and PRs for overlap and coordinated any related work.
- [x] For version-specific work, I used exact DSH tags or commit hashes, not `latest` or inferred versions.
- [x] I cited fixed first-party sources for version-specific claims.
- [x] For migration or card work, I listed the affected touchpoints (`#1`-`#7`) and complete card IDs.
- [x] I kept Host, Web Client, and ordinary Cordis plugin faces distinct.

## Verification

Commands run:

```text
node scripts/validate.mjs
node scripts/validate-manifests.mjs
```

Both pass: `Validation OK: 8 skill, 6 card sets, 54 cards ...`;
`Manifest validation passed: 4 manifests`.

Additional checks:

- [x] I reviewed the complete diff and `git diff --check`.
- [x] 10 cards verified against real upstream commit diffs (deepseek-harness
  `993550e6`, plugin-registry `bfa0e8d`, whale-girl `426e86d`/`183354b`, etc.).

Unverified boundaries: the corridor edge itself (`rc.8 → rc.1`) has no public
upstream tag chain — it is the closest published-tag alignment for the internal
snapshot window; individual cards are draft-pending upstream review.

## Review Notes

The v0.1.2-alpha.2 corridor already exists upstream; this PR adds the missing
`rc.8 → rc.1` edge only, with no changes to reviewed corridors. Follow-up PR
`feat/cards-alpha3-corridor` appends the alpha.3 additive settings-card
capability.