### PR TITLE
feat(skill): add dsh-benchmark-case — extract plugin upgrade experiences into Harbor exam tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 - **58 张升级说明卡**：每张卡记录一个真实的坑——什么坏了、为什么坏、怎么修、信息来源是哪个版本。按版本排好序，从 0.1.0-rc.8 一路到 0.1.2-rc.1（alpha.5→rc.1 无插件面变更，0 张卡；alpha.2→alpha.3 有 1 张新增能力卡；alpha.3→alpha.4 有 6 张；rc.8→rc.1 为 9 张草稿卡）。
 - **12 条通用对策**：有些坑和版本无关（比如"先备份再动手""新旧版本怎么共存"），这些写成了一份对策清单。
-- **8 个 skill**：一个统一工作流负责选择和编排，另外七个分别负责查升级、写新插件、测插件、发插件、对比两个版本的差别、排查运行时故障和给轻量插件接入重依赖。
+- **9 个 skill**：一个统一工作流负责选择和编排，另外八个分别负责查升级、写新插件、测插件、发插件、对比两个版本的差别、排查运行时故障、给轻量插件接入重依赖，以及把插件升级经验提取成 benchmark 考题。
 - **47 道考题（benchmark）**：用来测"AI 装了我们的 skill 之后到底会不会升级插件"，每道题都有自动判分；其中包含 dsh-web v0.3.8 → v0.3.9 和 dsh-data-agent v0.1.3 → v0.1.4 两道真实迁移。
 - **多份验证报告**：我们在 docker 里真的装了两个版本的 dsh，验证了"按卡片做就能修好插件"；此后又用 Codex 等 agent 做了多轮 benchmark 实测。
 
@@ -109,7 +109,7 @@ Claude Code 中按名字调用 skill（插件安装后带命名空间）：
 帮我把 dsh-ads 这个插件升级到 dsh-v0.1.2-alpha.2
 ```
 
-## 8 个 skill 各自管什么
+## 9 个 skill 各自管什么
 
 | Skill | 干什么用 |
 | --- | --- |
@@ -121,6 +121,7 @@ Claude Code 中按名字调用 skill（插件安装后带命名空间）：
 | [dsh-upgrade-audit](skills/dsh-upgrade-audit/) | 对比两个 dsh 版本到底改了什么，给升级卡提供证据 |
 | [plugin-runtime-debug](skills/plugin-runtime-debug/) | 排查插件在宿主里的运行时故障（坐标/投影不匹配、版本滞后、幽灵条目等） |
 | [plugin-heavy-dep](skills/plugin-heavy-dep/) | 给轻量插件接入重依赖（mermaid 这类），含懒加载接入清单 |
+| [dsh-benchmark-case](skills/dsh-benchmark-case/) | 把某个插件的真实升级经验（或已有版本卡）提取成一条可自动判分的 benchmark 考题（fixture + instruction + judge + solution） |
 
 ## 升级卡覆盖到哪个版本了
 

--- a/skills/README.en.md
+++ b/skills/README.en.md
@@ -43,6 +43,7 @@ Requirements:
 | [plugin-release](plugin-release/) | Package, publish, and distribute DSH plugins: release track selection, unpublished-cohort installation, CI gates, and rollback | [@omdsh-dev](https://github.com/omdsh-dev) |
 | [plugin-runtime-debug](plugin-runtime-debug/) | Diagnose DSH Web plugin runtime failures against host source contracts (paste/attachment/input machine, version chips, etc.) — method-level, no answers | [@lhh010](https://github.com/lhh010) |
 | [plugin-heavy-dep](plugin-heavy-dep/) | Integrate heavy dependencies (mermaid etc.) into lightweight DSH Web plugins: lazy single-file chunks, host routes with robust containment, SVG whitelist sanitization, event ownership | [@lhh010](https://github.com/lhh010) |
+| [dsh-benchmark-case](dsh-benchmark-case/) | Extract a real plugin upgrade experience (or existing version cards references/v*.md) into one auto-graded Harbor benchmark task: case selection criteria, fixture & traps, judge scoring boundaries, registry sync discipline | [@vlln](https://github.com/vlln) |
 
 ## Version compatibility audit (separate entry)
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -43,6 +43,7 @@ description: 一句话说明做什么、何时触发，以及重要的只读/写
 | [plugin-release](plugin-release/) | 打包、发布与分发 DSH 插件：发布轨选择、未发布 cohort 安装、CI 门禁与回滚 | [@omdsh-dev](https://github.com/omdsh-dev) |
 | [plugin-runtime-debug](plugin-runtime-debug/) | 依据 DSH 源码契约排查 Web 插件运行时故障（粘贴/附件/输入机、版本 chip 等），方法级不讲答案 | [@lhh010](https://github.com/lhh010) |
 | [plugin-heavy-dep](plugin-heavy-dep/) | 给轻量 DSH Web 插件接入重依赖（mermaid 等）：懒加载单文件 chunk、宿主路由与包含防护、SVG 白名单清洗、事件所有权 | [@lhh010](https://github.com/lhh010) |
+| [dsh-benchmark-case](dsh-benchmark-case/) | 把某插件仓库的真实升级经验（或已有版本卡 references/v*.md）提取成一条可自动判分的 Harbor benchmark 考题：选材判据、fixture 与陷阱、judge 计分边界、registry 同步纪律 | [@vlln](https://github.com/vlln) |
 
 ## 版本兼容审计（独立条目）
 

--- a/skills/dsh-benchmark-case/SKILL.md
+++ b/skills/dsh-benchmark-case/SKILL.md
@@ -11,7 +11,7 @@ license: MIT
 oracle 参考解，judge 在容器内真实冷启动判活。产出跟随
 `./benchmark/`（上文：`oh-my-dsh/dsh-plugin-upgrade-skill` 的 benchmark 目录）。
 
-> 上下文锚点：目标套件是 dsh-plugin-upgrade-skill 的 benchmark v2.3（Harbor
+> 上下文锚点：目标套件是 dsh-plugin-upgrade-skill 的 benchmark v2.4（Harbor
 > 格式），host 镜像固定为 node:24-bookworm + 全局 dsh 0.1.2-alpha.2。每条考题
 > 遵循 execution-contract（BENCHMARK-AUTH-v1）与固定评分模型（100 分/题）。
 
@@ -54,7 +54,10 @@ fixture 应模拟的第 N 个 commit 形态（迁移前）。Checkpoint：三者
 ### Stage 1 · 骨架与命名
 
 任务目录 `tasks/<id>/`，id 命名：前缀字母 S（静态只读）/ M（迁移可改）/
-H（hands-on 陷阱），编号接现有最大值（当前 23 题，最新 M6）。一个任务一个目录：
+H（hands-on 陷阱），编号接该系列现有最大值。**编号不要凭记忆硬编码**——
+动手前先 `ls benchmark/tasks/` 并对照 `benchmark/README.md` 任务表与注册表
+校验脚本确认当前集合（当前 52 题：S1–S16 / M1–M14 / H1–H22，下一可用
+S17 / M15 / H23），勿跳号。一个任务一个目录：
 
 ```
 tasks/<id>/
@@ -100,11 +103,12 @@ commit（judge 靠 `git status --porcelain -- fixture` 判"fixture 是否被改"
    `tasks/H9-dsh-web-alpha2/provenance/`）。
 
 **fixture 放哪、可以留什么**：Node half 可留在 `.dsh-plugin/` 子目录等
-旧布局位置——但**注意隐藏深坑**：host 的 client-modules 从 Node entry 文件
-向上找最近 package.json 作为包身份（见 `$_S/references/host-archaeology.md`
-的"manifest 遮蔽"条目）。fixture 保留旧 `.dsh-plugin/package.json`（无
-dsh.client）会让"只补根清单不删残留"的解法静默漏掉浏览器半——这是真实
-R1-01 迁移踩过的、极好的题点，参考解必须删残留。
+旧布局位置——但这类布局有深坑可挖：host 的 client-modules 从 Node entry
+文件向上找最近 package.json 作为包身份（机制见
+`$_S/references/host-archaeology.md` 的"manifest 遮蔽"条目）。设计 fixture
+时可利用这类机制布坑：让旧布局残留文件影响包识别，浏览器半静默消失；
+判分侧的 boot 图条目检查会自然抓到。具体某道在线题怎么布、参考解怎么收
+尾，不在此展开——方法级不讲答案。
 
 Checkpoint：`dsh plugin add` 旧 fixture 在容器里真的坏 / 有静默缺陷；
 新 fixture（参考解）全绿。两态都必须先本地 docker 验证，不许只靠想象。
@@ -138,9 +142,10 @@ Checkpoint：`dsh plugin add` 旧 fixture 在容器里真的坏 / 有静默缺�
 内没有浏览器 → client 运行时行为不判，只判宿主宣告的 boot 图条目"这类边界；
 未覆盖面同样写进 scoring.md。
 
-**分数带设计提醒**：给"半对"留带（如缺 platform 的 dsh.client = 20 而非 40）；
-陷阱跟随者给封顶（如误导注释说别改 X，留着 X = 该 check 上限）。判分必须能
-区分"真迁移"与"看起来绿但绕开了迁移"（参考 H5 的 static caps）。
+**分数带设计提醒**：给"半对"留带（关键声明完整给满分、缺字段给半分、
+完全缺失 0 分）；陷阱跟随者给封顶（如误导注释说别改 X，留着 X = 该
+check 上限）。判分必须能区分"真迁移"与"看起来绿但绕开了迁移"——绕道
+路径 boot 也能绿，要用静态检查（grep 特定字段/模式）封顶才抓得住。
 
 **运行纪律**：judge 只建 `bench-<task>` profile 与 `/tmp/bench-<task>`，
 finally 里清理（pkill 用 `[x]` 自逃逸模式防止自杀）。timeout 充足（add 180s /
@@ -150,7 +155,7 @@ test.sh 解析不了 JSON 时按 0 计。
 ### Stage 4 · oracle（参考解）
 
 `solution/plugin/` 是完整迁移后的 fixture；`solve.sh` 逐文件覆盖进
-`/app/fixture/`，并删除必须删除的残留（如 `.dsh-plugin/package.json`）。
+`/app/fixture/`，并显式删除该题迁移要求删除的残留文件。
 SOLUTION.md 三节必备：
 
 1. **Reference Changes**：每条改动对应卡 ID 全名（如 DSH-0.1.1-R1-01，
@@ -158,8 +163,8 @@ SOLUTION.md 三节必备：
 2. **The Point (one sentence)**：这道题真正测的一招。
 3. **Grading Boundary**：与 Stage 3 的边界一致。
 4. **Warning**：如果 judge 是 grep 源码模式判"已删除"，参考解源码注释里
-   **不得出现被 grep 的字面 token**（本次实战教训：solution 注释写
-   "httpServer.tapIndex 已删除" 会自伤 10 分）。
+   **不得出现被 grep 的字面 token**（实战教训：solution 注释复述了被判
+   "已删除"的旧标识符字面，judge grep 命中注释导致自伤扣分）。
 
 Checkpoint：oracle 在容器里跑出 **100/100**（reward 1.0，下一步做）。
 
@@ -198,7 +203,7 @@ Checkpoint：oracle 在容器里跑出 **100/100**（reward 1.0，下一步做�
 ```sh
 cd dsh-plugin-upgrade-skill
 node scripts/validate.mjs                       # 卡 + 链接 + 引用全绿
-node benchmark/scripts/validate-task-registry.mjs    # 23→N 注册表一致
+node benchmark/scripts/validate-task-registry.mjs    # 任务清单/计数注册表一致
 node benchmark/scripts/validate-execution-contract.mjs  # 契约五子句 + mode
 # oracle 自检（must be 1.0）：
 harbor run -p benchmark/tasks/<id> -a oracle
@@ -230,7 +235,7 @@ Checkpoint：三个校验全绿 + oracle 100/100 + 文件权限（solve.sh / tes
 5. **profile 组合**：web 冷启动 profile 用
    `['@deepseek-ai/dsh-base', '@deepseek-ai/dsh-web-app']`；headless 用
    headless 预设。别复用共享 ~/.dsh。
-6. **版本钉死**：Dockerfile 的 pnpm/dsh 版本与现有 22 题完全一致
+6. **版本钉死**：Dockerfile 的 pnpm/dsh 版本与现有全部任务完全一致
    （pnpm@11.24.0 / dsh@0.1.2-alpha.2）；改了等于换题。
 7. **pkill 自杀**：judge 清理命令 pidpattern 用 `[x]` 括号技巧，否则匹配到
    自己执行的 sh -c 会杀自己（本次实测 exit 143）。**注意 `[x]` 只防"模式
@@ -240,7 +245,7 @@ Checkpoint：三个校验全绿 + oracle 100/100 + 文件权限（solve.sh / tes
    做路由冒烟时，内嵌脚本中的单引号会在 sh 单引号内提前闭合 → node 收残缺
    程序 → SyntaxError 伪装成"路由失败"（stderr 只有 node 栈尾）。修法：
    内嵌脚本零单引号（断言用 `JSON.parse(text).ok === true` 而非
-   `text.includes('"ok":true')`）。已写进 M7 judge 头注释。
+   `text.includes('"ok":true')`）。已写进 M14 judge 头注释。
 9. **harbor 可用性**：本机 harbor CLI 因 uv/pip 沙箱装不上；oracle 验证可用
    docker 手动等价路径，README 说明跑法（harbor run -a oracle 为标准式）。
 10. **一个走廊多题**：强 case（如 bundle 转换、服务改名）可出多道独立题，

--- a/skills/dsh-benchmark-case/SKILL.md
+++ b/skills/dsh-benchmark-case/SKILL.md
@@ -1,0 +1,276 @@
+---
+name: dsh-benchmark-case
+description: Use when the user hands over a dsh plugin repository (or a real migration commit / version corridor) and wants its upgrade experience extracted into one auto-graded Harbor benchmark exam task — produce tasks/<id>/ (fixture + instruction.md + task.toml + judge.mjs + solution) that harbor run can grade 0–1 and that folds into the dsh-plugin-upgrade-skill benchmark suite; also applies to turning existing version cards (references/v*.md) into executable exam tasks. Not for writing upgrade cards; not for running the benchmark.
+license: MIT
+---
+
+# 从插件仓库提取 dsh 升级考题
+
+把一个真实发生的插件迁移（git 历史里的破坏性变更 commit）变成一道
+**Harbor 考题**：旧形态插件为 fixture（装上必坏，或有隐藏坑），新形态为
+oracle 参考解，judge 在容器内真实冷启动判活。产出跟随
+`./benchmark/`（上文：`oh-my-dsh/dsh-plugin-upgrade-skill` 的 benchmark 目录）。
+
+> 上下文锚点：目标套件是 dsh-plugin-upgrade-skill 的 benchmark v2.3（Harbor
+> 格式），host 镜像固定为 node:24-bookworm + 全局 dsh 0.1.2-alpha.2。每条考题
+> 遵循 execution-contract（BENCHMARK-AUTH-v1）与固定评分模型（100 分/题）。
+
+## 何时使用
+
+- 用户给一个插件仓库，说"提成考题 / 做成 case / 转 benchmark task"。
+- 用户拿着一条版本走廊或一个迁移 commit，要可执行的评测而不是文档。
+- 现有升级卡（references/v*.md）需要测"AI 会不会照卡修"。
+
+## 工作原理（一句话）
+
+fixture = 迁移前形态（偶藏误导注释/预置失败），judge = 静态检查 +
+容器内真实冷启动信号（pending / plugin tree failed / MISSING_CREDENTIAL /
+`__DSH_BOOT__` 条目），oracle = 参考迁移，判分天然 0~1。
+
+## Pipeline
+
+### Stage 0 · 选材与走廊定位
+
+**先回答三个问题，答不出就退回升级卡形态，不做题**：
+
+1. **迁移方向**：仓库 git 历史里哪一个 commit / 哪一段走廊是"host 升级导致的
+   必需改动"？（例：`426e86d` whale-girl bundle 转换，走廊 rc.8→rc.1）。
+   纯自研重构、无 host 侧断裂的 commit 不成题。
+2. **可测性**：迁移后形态能否在容器内"装得上 + 冷启动得到确定信号"？
+   判分信号必须是宿主侧信号（见 Stage 3），**不是**"输出文本长什么样"。
+   无浏览器容器 ⇒ client 运行时不可判，只能判 boot 图条目 / HTTP 状态。
+3. **对应卡**：这条走廊在 references/ 里有没有卡（或需要先补卡）？
+   考题与卡是一对多：一道题可以覆盖多张卡，但卡必须已存在或随题新增
+   （validate.mjs 会校验卡引用存在且链接可解析）。
+
+**选材标准（×成立越多越好）**：迁移真实发生过（有 commit 可考）；
+断裂面小（1~4 个 touchpoint）；装旧形态必有可观察故障（pending / 静默缺行为）；
+新形态在 alpha.2 上可冷启动验证；最好带隐藏坑（诱导注释 / 看着无辜的面上
+藏着致命伤——坑要来自真实迁移的"第二个 commit"，不是编的）。
+
+**产出**：选定的 task id（见 Stage 1 命名）+ 走廊 + 覆盖的卡 ID 清单 +
+fixture 应模拟的第 N 个 commit 形态（迁移前）。Checkpoint：三者对齐才继续。
+
+### Stage 1 · 骨架与命名
+
+任务目录 `tasks/<id>/`，id 命名：前缀字母 S（静态只读）/ M（迁移可改）/
+H（hands-on 陷阱），编号接现有最大值（当前 23 题，最新 M6）。一个任务一个目录：
+
+```
+tasks/<id>/
+├── instruction.md        # 给 agent 的 prompt（含 BENCHMARK-AUTH-v1 契约）
+├── task.toml             # Harbor 配置（见 assets/task.toml.example）
+├── environment/
+│   ├── Dockerfile        # node:24-bookworm + git + pnpm + dsh alpha.2 + git 基线
+│   └── fixture/          # 旧形态插件（private:true，README 声明 exam material）
+├── tests/
+│   ├── test.sh           # verifier 入口：跑 judge，score→reward 写 /logs/verifier/
+│   ├── judge.mjs         # 判分逻辑（全部在这）
+│   └── judge-utils.mjs   # 共享判分库：profile 生命周期、冷启动信号、清理
+└── solution/
+    ├── solve.sh          # oracle：把参考解拷进 fixture
+    ├── SOLUTION.md       # 参考解说明 + The Point + Grading Boundary
+    └── plugin/           # 参考迁移后的完整文件
+```
+
+模板在 `$_S/assets/`：task.toml.example、instruction.md.example、
+judge-utils.mjs（整库直接复制）、test.sh.example、Dockerfile.example、
+solve.sh.example、judge.mjs.example（骨架）。
+
+**装 dsh 的 Dockerfile 必须**（与现有任务一致，勿改版本）：
+`FROM node:24-bookworm`；装 git；`npm install -g pnpm@11.24.0
+@deepseek-ai/dsh@0.1.2-alpha.2`；COPY fixture → /app/fixture；git init + 基线
+commit（judge 靠 `git status --porcelain -- fixture` 判"fixture 是否被改"，
+只读题 0 分门禁，可变题 0 分门禁的相同实现）。Checkpoint：目录 6 块齐全。
+
+### Stage 2 · fixture 构造
+
+按"迁移前第 N 个 commit"的真实形态写 fixture，三个纪律：
+
+1. **必须私有**：package.json `"private": true`；README 首行
+   "exam material only, do not publish"。源头切片除外（见 4）。
+2. **坑要用真坑**：误导注释要像真话——来自真实迁移决策记录里"当时为什么
+   这样做/为什么别改"的措辞；预置失败测试要确实预先失败且与升级无关
+   （测诚实报告，不测静默修复）。
+3. **坏必须可观察**：旧形态要么装上 pending / plugin tree failed，要么
+   静默缺行为但 judge 有对应锚（如 boot 图没有该插件的 client 条目）。
+   判分锚必须能在容器里拿到，拿不到的 feature 不出现在 judge 里。
+4. **上游切片保留原元数据**（Apache-2.0 真实仓库切片如 dsh-web）：保留
+   license/original package.json，读 provenance/ 惯例（见基准
+   `tasks/H9-dsh-web-alpha2/provenance/`）。
+
+**fixture 放哪、可以留什么**：Node half 可留在 `.dsh-plugin/` 子目录等
+旧布局位置——但**注意隐藏深坑**：host 的 client-modules 从 Node entry 文件
+向上找最近 package.json 作为包身份（见 `$_S/references/host-archaeology.md`
+的"manifest 遮蔽"条目）。fixture 保留旧 `.dsh-plugin/package.json`（无
+dsh.client）会让"只补根清单不删残留"的解法静默漏掉浏览器半——这是真实
+R1-01 迁移踩过的、极好的题点，参考解必须删残留。
+
+Checkpoint：`dsh plugin add` 旧 fixture 在容器里真的坏 / 有静默缺陷；
+新 fixture（参考解）全绿。两态都必须先本地 docker 验证，不许只靠想象。
+
+### Stage 3 · judge 设计（判分心法）
+
+固定评分模型：100 分/题，`emit(score, reasons)` 最后一行输出
+`{"score":0-100,"max":100,"reasons":[...]}`，test.sh 归一化到 0~1 写
+`/logs/verifier/reward.txt`。线性叠加 checkpoints，禁止加权魔法。
+
+**通用三段式**：
+
+| 段 | 内容 | 分数惯例 |
+|---|---|---|
+| Gate | `fixtureChanges()`：fixture 必须被改（静态题 0 分；可变题 0 分） | 0 或整体继续 |
+| 静态 | manifest 字段 / exports / patch insert 行 / 源码模式（grep）| 40~70 |
+| 运行时 | `dsh plugin add` + 冷启动信号 + boot 图条目/HTTP | 30~60 |
+
+**判分锚必须是宿主侧信号**（从 judge-utils.mjs 输出获取）：
+
+- `NEGATIVE_SIGNAL`：`plugin tree failed` / `did not activate` /
+  `pending (waiting for service: …)` / `FAILED fiber` /
+  `ClientPackageCompositionError` = 失败带（通常 40 或该 check 0 分）。
+- headless 冷启动：无 API key 时到达 `MISSING_CREDENTIAL` / `no API key` /
+  `dsh: AUTH` = 插件树整体激活，通过。**出口码不算**——无 key 成功也 exit 1。
+- web 冷启动 + GET `/`：`__DSH_BOOT__.entries` 包含 `<pkg>/client.js`
+  （**注意**：boot 图 URL 按 exports 的 key 拼 `${pkg}/client.js`，与文件
+  真实路径无关）或该插件的 HTTP 通道 401/200 冒烟。
+
+**边界声明**：judge 头注释与 SOLUTION.md 的 Grading Boundary 必须写明"容器
+内没有浏览器 → client 运行时行为不判，只判宿主宣告的 boot 图条目"这类边界；
+未覆盖面同样写进 scoring.md。
+
+**分数带设计提醒**：给"半对"留带（如缺 platform 的 dsh.client = 20 而非 40）；
+陷阱跟随者给封顶（如误导注释说别改 X，留着 X = 该 check 上限）。判分必须能
+区分"真迁移"与"看起来绿但绕开了迁移"（参考 H5 的 static caps）。
+
+**运行纪律**：judge 只建 `bench-<task>` profile 与 `/tmp/bench-<task>`，
+finally 里清理（pkill 用 `[x]` 自逃逸模式防止自杀）。timeout 充足（add 180s /
+boot 60s / web 150s，真实 workspace 题 verifier 900s）。judge 永远 exit 0，
+test.sh 解析不了 JSON 时按 0 计。
+
+### Stage 4 · oracle（参考解）
+
+`solution/plugin/` 是完整迁移后的 fixture；`solve.sh` 逐文件覆盖进
+`/app/fixture/`，并删除必须删除的残留（如 `.dsh-plugin/package.json`）。
+SOLUTION.md 三节必备：
+
+1. **Reference Changes**：每条改动对应卡 ID 全名（如 DSH-0.1.1-R1-01，
+   **不要**写 R1-01 简写——validate.mjs 校验全 ID 存在）。
+2. **The Point (one sentence)**：这道题真正测的一招。
+3. **Grading Boundary**：与 Stage 3 的边界一致。
+4. **Warning**：如果 judge 是 grep 源码模式判"已删除"，参考解源码注释里
+   **不得出现被 grep 的字面 token**（本次实战教训：solution 注释写
+   "httpServer.tapIndex 已删除" 会自伤 10 分）。
+
+Checkpoint：oracle 在容器里跑出 **100/100**（reward 1.0，下一步做）。
+
+### Stage 5 · 契约与注册表同步（四连）
+
+**instruction.md 契约**（validate-execution-contract.mjs 用正则逐条匹配，
+字面必须命中，双语任选其一）：
+
+- 恰好一处 `BENCHMARK-AUTH-v1`；契约五子句：
+  no-follow-up（"there will be no follow-up user messages"）、
+  proceed-after-plan（"continue executing immediately once the plan is formed"）、
+  no-pause（"do not pause to wait for confirmation"）、
+  no-modify（"must not modify the skill"）、
+  no-stop（"do not stop merely because another round of confirmation is missing"）。
+- 边界授权句按 mode：可变题 "you may modify `/app/fixture/` directly"；
+  只读题 "`/app/fixture/` must remain completely unchanged"；
+  build-artifacts 题 src 零改动 + lib 可清理（照抄现有任务的措辞最稳）。
+- task.toml：`execution_contract = "BENCHMARK-AUTH-v1"` 恰好一次、
+  `version = "1.1.0"`。
+
+**四连注册表（全部必须同步，否则校验失败）**：
+
+1. `benchmark/README.md`：任务表加行（Task/Type/What it tests）；顶部
+   "The N plugin-upgrade tasks measure"；"The first N are written exams …
+   the last M are hands-on"（按 Type 列计数）；`# all N tasks` 注释；
+   "All N `instruction.md` files carry"；"existing N tasks" 维护者注记。
+2. `benchmark/docs/scoring.md`：`Total <N×100> (N tasks × 100; …)`；
+   任务表加行（Checkpoint 卡引用 + Score breakdown 精确到每条）。
+3. `benchmark/scripts/validate-execution-contract.mjs`：expectedModes
+   Map 加 `['<task-id>', '<mode>']`（mode ∈ readonly | mutable |
+   build-artifacts-only）。
+4. benchmark 的卡引用：全 ID + 链接可解析（validate.mjs 会查）。
+
+### Stage 6 · 校验与 oracle 自检（门禁）
+
+```sh
+cd dsh-plugin-upgrade-skill
+node scripts/validate.mjs                       # 卡 + 链接 + 引用全绿
+node benchmark/scripts/validate-task-registry.mjs    # 23→N 注册表一致
+node benchmark/scripts/validate-execution-contract.mjs  # 契约五子句 + mode
+# oracle 自检（must be 1.0）：
+harbor run -p benchmark/tasks/<id> -a oracle
+# harbor 不可用时（本机 pip/uv 受限），用 docker 手动走通等价值：
+#   docker build -t bench-<id> environment/ && docker run ... 复制 oracle →
+#   fixture → node tests/judge.mjs → 断言 {"score":100}
+node --check tests/judge.mjs && node --check tests/judge-utils.mjs
+```
+
+Checkpoint：三个校验全绿 + oracle 100/100 + 文件权限（solve.sh / test.sh
+755，与现有任务一致）。**不绿不交付**。
+
+## 交付
+
+- `tasks/<id>/` 完整任务 + 四连注册表改动，与升级卡（如有）同一 PR 主题。
+- PR 描述声明验证命令与结果（validate × 3 + oracle 1.0）、覆盖的卡、
+  未覆盖边界、致谢（本次实战致谢脚本 `$_S/` 无，按仓库惯例）。
+
+## Gotchas（实战教训，新增题前先扫）
+
+1. **注释会自伤**：solution 源码注释不得含 judge 要 grep 的"已删除"字面 token。
+2. **manifest 遮蔽**：client-modules 从 Node entry 向上找最近 package.json；
+   残留旧清单（无 dsh.client）让浏览器半静默消失——参考解要删，
+   这是合法题点不是 bug。
+3. **boot URL ≠ 文件路径**：`__DSH_BOOT__` 条目按 exports key 拼
+   `${pkg}/client.js`；判 boot 图别去匹配真实路径。
+4. **服务名随走廊变**：`httpServer`→`webServer`（R1-09）、`tasks`→`jobs`；
+   fixture 用旧名、参考解用新名之前，先在容器冷启动验证哪个名能解析。
+5. **profile 组合**：web 冷启动 profile 用
+   `['@deepseek-ai/dsh-base', '@deepseek-ai/dsh-web-app']`；headless 用
+   headless 预设。别复用共享 ~/.dsh。
+6. **版本钉死**：Dockerfile 的 pnpm/dsh 版本与现有 22 题完全一致
+   （pnpm@11.24.0 / dsh@0.1.2-alpha.2）；改了等于换题。
+7. **pkill 自杀**：judge 清理命令 pidpattern 用 `[x]` 括号技巧，否则匹配到
+   自己执行的 sh -c 会杀自己（本次实测 exit 143）。**注意 `[x]` 只防"模式
+   文本自身"**：同一 sh -c 命令行的其他位置若还有明文 profile 名（如 add/boot
+   命令），pkill 依然自杀——把 pkill 拆成独立 exec。
+8. **sh 引号吞内嵌脚本**：judge 里用 `node --input-type=module -e 'script'`
+   做路由冒烟时，内嵌脚本中的单引号会在 sh 单引号内提前闭合 → node 收残缺
+   程序 → SyntaxError 伪装成"路由失败"（stderr 只有 node 栈尾）。修法：
+   内嵌脚本零单引号（断言用 `JSON.parse(text).ok === true` 而非
+   `text.includes('"ok":true')`）。已写进 M7 judge 头注释。
+9. **harbor 可用性**：本机 harbor CLI 因 uv/pip 沙箱装不上；oracle 验证可用
+   docker 手动等价路径，README 说明跑法（harbor run -a oracle 为标准式）。
+10. **一个走廊多题**：强 case（如 bundle 转换、服务改名）可出多道独立题，
+    各自 fixture 聚焦不同 touchpoint；不要一道题塞所有。
+11. **判别力验证**：交付前不只要 oracle=100，还要跑**负例矩阵**——未动
+    fixture 必须 0（gate）、陷阱跟随为该 check 上限、半迁移（如只改服务名
+    不改事件名）落在预期带。judge 要是"什么都得高分"就没有评测价值。
+
+## references（按需读）
+
+- `$_S/references/case-selection.md` — 选材判据细节与反例。
+- `$_S/references/harbor-task-spec.md` — 目录规范、task.toml 字段、
+  环境镜像、判分信号表（详细版）。
+- `$_S/references/contract-clauses.md` — 契约五子句与授权句的全量字面
+  （照抄最稳）。
+- `$_S/references/grading-recipe.md` — judge 三段式、分数带、caps 设计。
+- `$_S/references/host-archaeology.md` — 宿主源码考古出的坑与证据
+  （client-modules 解析、boot URL、服务改名）。
+- `$_S/references/registry-sync.md` — 四连同步全量清单 + 校验命令。
+- `$_S/assets/` — task.toml.example / instruction.md.example /
+  judge-utils.mjs（完整库）/ judge.mjs.example / test.sh.example /
+  Dockerfile.example / solve.sh.example。
+
+## 校验清单（交付前逐项自查）
+
+- [ ] Stage 0 三问：真实迁移 / 容器可测 / 卡存在或随题新增
+- [ ] fixture `private: true` + "exam material only"；旧形态容器实测会坏
+- [ ] judge 全部锚是宿主侧信号；gate/静态/运行时三段齐全；边界声明齐全
+- [ ] oracle 100/100（harbor 或 docker 手动）
+- [ ] solution 注释无 judge grep token；残留清单已删
+- [ ] 四连注册表同步（README × 6 计数、scoring Total+行、expectedModes）
+- [ ] validate.mjs + validate-task-registry + validate-execution-contract 全绿
+- [ ] solve.sh / test.sh 755

--- a/skills/dsh-benchmark-case/assets/Dockerfile.example
+++ b/skills/dsh-benchmark-case/assets/Dockerfile.example
@@ -1,0 +1,14 @@
+FROM node:24-bookworm
+
+# git lets the judge detect whether the fixture was changed (read-only discipline gate)
+RUN apt-get update && apt-get install -y --no-install-recommends git \
+    && rm -rf /var/lib/apt/lists/*
+
+# consistent with section 6 of validation-report-2026-08-30.md
+RUN npm install -g pnpm@11.24.0 @deepseek-ai/dsh@0.1.2-alpha.2
+
+WORKDIR /app
+COPY fixture /app/fixture
+
+# Baseline commit: the judge uses `git status --porcelain -- fixture` to decide whether the agent changed the fixture
+RUN git init -q && git add -A && git -c user.email=bench@local -c user.name=bench commit -q -m "baseline"

--- a/skills/dsh-benchmark-case/assets/instruction.md.example
+++ b/skills/dsh-benchmark-case/assets/instruction.md.example
@@ -1,4 +1,4 @@
-# M6 · Repository-Plugins Removal (External Plugins Become npm Packages)
+# M13 · Repository-Plugins Removal (External Plugins Become npm Packages)
 
 ## Unattended Benchmark Authorization (BENCHMARK-AUTH-v1)
 

--- a/skills/dsh-benchmark-case/assets/instruction.md.example
+++ b/skills/dsh-benchmark-case/assets/instruction.md.example
@@ -1,0 +1,35 @@
+# M6 · Repository-Plugins Removal (External Plugins Become npm Packages)
+
+## Unattended Benchmark Authorization (BENCHMARK-AUTH-v1)
+
+This is an unattended benchmark run in a disposable isolated container; there will be no follow-up user messages. This task statement is itself the user's explicit authorization and confirmation for the solution and execution needed to complete the task: complete the necessary analysis and planning on your own, and continue executing immediately once the plan is formed — do not pause to wait for "confirmation" and do not press the user with follow-up questions. That confirmation continues to apply to the concrete plans you produce under the applicable skill, but only within the following scope:
+
+- You may read `/app/fixture/`, local in-container documentation, and local tools; you may modify `/app/fixture/` directly and write to the specified `/app/agent-output/` directory as instructed;
+- You may create disposable local verification profiles and temporary files, and run local tests, builds, and dsh commands;
+- You must not modify the skill, the grader, or the reference solution, and must not publish, push, access external services, or change resources outside the container;
+- If you cannot complete the task, state the blocker honestly, but do not stop merely because another round of confirmation is missing.
+
+I have a browser plugin (working directory: `/app/fixture/`) written in the old
+**repository-plugin** shape: the Node half lives under `.dsh-plugin/`, the manifest
+`.dsh-plugin/package.json` declares `dsh.entry → ./index.js`, and the browser half is a
+self-executing script that the entry serves at `/pet/ui.js` and injects into the page
+via `httpServer.tapIndex`. The host has already been upgraded to dsh 0.1.2-alpha.2,
+which **removed the whole repository-plugins mechanism** — `vendor/loader/src/repository.ts`
+is gone, `dsh-repository-plugin` is no longer a builtin, and self-executing client
+scripts are no longer loaded. Migrate the plugin so it installs and activates on
+0.1.2-alpha.2 through the one official path: **an npm package**, i.e. a bundle plugin
+with `package.json` declaring `dsh.bundle`, plus a `dsh.client` declaration and an
+`exports` map so the browser half is recognized — then `dsh plugin --profile web add`
+installs it into the profile's bundle layer stack.
+
+You may keep the Node half inside `.dsh-plugin/` or move it to the package root, as
+long as the declared entry (`main` / `exports["."]`) resolves and the client half is
+reachable through `exports["./client"]`. Drop the legacy loading path: the
+`/pet/ui.js` route and the `httpServer.tapIndex` injection must go — the client is now
+mounted by client-modules (register it with an exported `{ name, apply }` module that
+renders the same `#bench-pet` element). Edit the files under `/app/fixture/` directly.
+
+dsh 0.1.2-alpha.2 is already installed globally in the container. You may create an
+isolated profile yourself and run cold boot verification with `dsh plugin
+--profile … add` / `dsh --profile … --no-open`. Everything outside `/app/fixture/` is
+not part of this task — leave it alone.

--- a/skills/dsh-benchmark-case/assets/judge-utils.mjs
+++ b/skills/dsh-benchmark-case/assets/judge-utils.mjs
@@ -1,0 +1,194 @@
+// Shared library for benchmark grading (Harbor edition, zero dependencies).
+// Conventions:
+// - every judge.mjs exits with code 0; the last stdout line prints {"score": 0-100, "max": 100, "reasons": [...]};
+// - for static tasks, the agent's artifacts live under /app/agent-output/<task-id>/;
+// - for container tasks (M1/H1/H2/H3), the agent edits /app/fixture/ directly and the judge does a real
+//   cold boot inside the task container (the image has dsh 0.1.2-alpha.2 installed globally; no docker exec);
+// - each task uses its own profile (bench-<task>) and its own /tmp plugin directory; the judge cleans up
+//   the assets it created.
+import { execFile } from 'node:child_process'
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs'
+import { join, relative, resolve, sep } from 'node:path'
+
+export const APP_ROOT = '/app'
+export const FIXTURE_DIR = join(APP_ROOT, 'fixture')
+export const DEFAULT_AGENT_OUTPUT = join(APP_ROOT, 'agent-output')
+export const BENCH_TMP = (taskId) => `/tmp/bench-${taskId.toLowerCase()}`
+export const PROFILE = (taskId) => `bench-${taskId.toLowerCase()}`
+
+// ── result output ──────────────────────────────────────────
+
+export function emit(score, reasons) {
+  const result = { score: Math.max(0, Math.min(100, Math.round(score))), max: 100, reasons }
+  process.stdout.write(JSON.stringify(result) + '\n')
+  process.exit(0)
+}
+
+// ── agent output collection (static tasks) ────────────────
+
+const TEXT_EXT = new Set(['.md', '.txt', '.json', '.jsonl', '.log'])
+
+function walkFiles(dir) {
+  const out = []
+  if (!existsSync(dir)) return out
+  for (const entry of readdirSync(dir)) {
+    const path = join(dir, entry)
+    const stat = statSync(path)
+    if (stat.isDirectory()) out.push(...walkFiles(path))
+    else out.push(path)
+  }
+  return out
+}
+
+/** Collect all text artifacts under <agentOutput>/<taskId>/ and join them into one big string. */
+export function readAgentText(agentOutput, taskId) {
+  const root = agentOutput || DEFAULT_AGENT_OUTPUT
+  const dir = join(root, taskId)
+  const files = walkFiles(dir).filter((file) => TEXT_EXT.has(file.slice(file.lastIndexOf('.'))))
+  const text = files.map((file) => readFileSync(file, 'utf8')).join('\n\n')
+  return { text, files: files.map((file) => relative(root, file)) }
+}
+
+// ── git status (whether the fixture was changed) ──────────
+
+function git(args, cwd) {
+  return new Promise((resolvePromise) => {
+    execFile('git', args, { cwd, timeout: 20000 }, (error, stdout, stderr) => {
+      resolvePromise({ code: error?.code ?? 0, stdout, stderr: stderr ?? '' })
+    })
+  })
+}
+
+/** Return the list of fixture paths relative to APP_ROOT (modified/added/deleted). An empty array means unchanged. */
+export async function fixtureChanges(relFixtureDir = 'fixture') {
+  const result = await git(['status', '--porcelain', '--', relFixtureDir], APP_ROOT)
+  if (result.code !== 0) return { changed: null, detail: `git status failed: ${result.stderr.trim()}` }
+  const lines = result.stdout.split('\n').filter(Boolean)
+  return {
+    changed: lines.length > 0 ? true : false,
+    detail: lines.length ? lines.join('; ') : 'fixture unchanged relative to baseline',
+  }
+}
+
+// ── local command primitives (the judge runs inside the task container) ──
+
+export function localExec(script, { stdin = '', timeout = 60000 } = {}) {
+  return new Promise((resolvePromise) => {
+    const child = execFile('sh', ['-c', script], { timeout }, (error, stdout, stderr) => {
+      resolvePromise({
+        code: error?.code ?? 0,
+        stdout: stdout ?? '',
+        stderr: stderr ?? '',
+        killed: error?.killed === true || (error && error.code === undefined) === true,
+      })
+    })
+    if (stdin) child.stdin.write(stdin)
+    child.stdin.end()
+  })
+}
+
+export async function dshAvailable() {
+  const result = await localExec('dsh --version', { timeout: 15000 })
+  return result.code === 0
+}
+
+// ── profile lifecycle ──────────────────────────────────────
+
+/** Create an isolated profile (bundles is an array of host package names). */
+export async function createProfile(profile, bundles) {
+  const dir = `/root/.dsh/profiles/${profile}`
+  const pkg = {
+    name: `dsh-profile-${profile}`,
+    private: true,
+    dependencies: {},
+    dsh: { profile: { bundles, patchReload: 'startup' } },
+  }
+  const write = await localExec(`rm -rf '${dir}' && mkdir -p '${dir}' && base64 -d > '${dir}/package.json'`, {
+    stdin: Buffer.from(JSON.stringify(pkg, null, 2) + '\n').toString('base64'),
+  })
+  if (write.code !== 0) return { ok: false, detail: `failed to write profile: ${write.stderr.trim()}` }
+  const seed = await localExec(
+    `cp /root/.dsh/profiles/headless/pnpm-workspace.yaml '${dir}/' 2>/dev/null || printf 'packages:\\n  - .\\n\\nnodeLinker: hoisted\\nautoInstallPeers: false\\n' > '${dir}/pnpm-workspace.yaml'
+printf '[]\\n' > '${dir}/cordis.patch.yml'
+printf '[]\\n' > '${dir}/cordis.yml'`,
+  )
+  if (seed.code !== 0) return { ok: false, detail: `failed to seed profile files: ${seed.stderr.trim()}` }
+  return { ok: true, dir }
+}
+
+export async function addPlugin(profile, pluginDir) {
+  const result = await localExec(`dsh plugin --profile '${profile}' add '${pluginDir}'`, { timeout: 180000 })
+  return { ok: result.code === 0, detail: (result.stdout + result.stderr).trim().slice(-400) }
+}
+
+/** Clean up assets created by the task: profile, temp plugin directory, leftover boot processes. */
+export async function cleanupProfile(profile, tmpDir) {
+  // The pkill pattern uses the [first-letter] bracket trick so it does not match the sh -c
+  // that is running this cleanup script itself.
+  const selfSafe = `[${profile[0]}]${profile.slice(1)}`
+  await localExec(
+    `pkill -f 'profile ${selfSafe}' 2>/dev/null; rm -rf '/root/.dsh/profiles/${profile}' '${tmpDir}' /tmp/${profile}-boot.log; true`,
+  )
+}
+
+// ── cold boot verdict signals ─────────────────────────────
+
+export const NEGATIVE_SIGNAL = /plugin tree failed|did not activate|pending \(waiting for service|FAILED fiber|ClientPackageCompositionError/i
+// A headless profile with no API key always reaches MISSING_CREDENTIAL — emitting this
+// line proves the plugin tree activated as a whole and startup advanced to the host
+// application layer (consistent with the validation report's attribution).
+export const HEADLESS_ACTIVATED_SIGNAL = /MISSING_CREDENTIAL|no API key|dsh: AUTH/i
+
+/** Headless cold boot: returns the full output. The exit code is not a verdict (without a key, even success exits 1). */
+export async function bootHeadless(profile) {
+  const result = await localExec(`cd /root && timeout 30 dsh --profile '${profile}' 'ping' 2>&1`, { timeout: 60000 })
+  return { output: result.stdout + result.stderr, code: result.code }
+}
+
+/**
+ * Web cold boot and read __DSH_BOOT__:
+ * 1. start `dsh --profile <p> --no-open` in the background and wait for the log to show a dsh web: URL;
+ * 2. exchange the bootstrap token for a Cookie, GET / to fetch the HTML;
+ * 3. return { output, html }; the caller judges the negative signal and the plugin entry.
+ */
+export async function bootWebAndFetchIndex(profile, pkgName) {
+  const logPath = `/tmp/${profile}-boot.log`
+  await localExec(`cd /root && nohup timeout 45 dsh --profile '${profile}' --no-open > '${logPath}' 2>&1 & echo started`)
+  const probe = await localExec(
+    `node --input-type=module -e '
+const logPath = process.argv[1];
+const pkgName = process.argv[2];
+const fs = await import("node:fs");
+let log = "";
+for (let i = 0; i < 90; i += 1) {
+  try { log = fs.readFileSync(logPath, "utf8"); } catch {}
+  if (/dsh web: http|plugin tree failed|did not activate/i.test(log)) break;
+  await new Promise((r) => setTimeout(r, 1000));
+}
+const match = /dsh web: (http:\\S+)/.exec(log);
+const outcome = { log };
+if (match) {
+  try {
+    const r1 = await fetch(match[1], { redirect: "manual" });
+    const setCookie = r1.headers.getSetCookie ? r1.headers.getSetCookie() : [r1.headers.get("set-cookie")];
+    const cookie = setCookie.filter(Boolean).map((c) => c.split(";")[0]).join("; ");
+    const r2 = await fetch("http://127.0.0.1:3080/", { headers: { cookie } });
+    outcome.html = await r2.text();
+  } catch (error) {
+    outcome.fetchError = String(error);
+  }
+}
+console.log("__RESULT__" + JSON.stringify(outcome));
+' '${logPath}' '${pkgName}'`,
+    { timeout: 150000 },
+  )
+  const marker = '__RESULT__'
+  const idx = probe.stdout.lastIndexOf(marker)
+  if (idx < 0) return { output: probe.stdout + probe.stderr, html: '', probeError: probe.stderr.trim() }
+  try {
+    const outcome = JSON.parse(probe.stdout.slice(idx + marker.length).trim())
+    return { output: outcome.log ?? '', html: outcome.html ?? '', fetchError: outcome.fetchError }
+  } catch {
+    return { output: probe.stdout + probe.stderr, html: '', probeError: 'failed to parse boot result' }
+  }
+}

--- a/skills/dsh-benchmark-case/assets/judge.mjs.example
+++ b/skills/dsh-benchmark-case/assets/judge.mjs.example
@@ -1,0 +1,103 @@
+// <TASK-ID> grading: <one-line of what this task measures>.
+//   Gate     — fixture unchanged → flat 0 (read-only task) / fixture unchanged → 0
+//              (mutable task, "really did touch it").
+//   Static   — <n> pts: <check> (<x>); <check> (<y>); …
+//   Runtime  — <n> pts: `dsh plugin add` (<x>); cold boot no pending (<y>);
+//              <boot-graph / HTTP / headless signal> (<z>).
+// Boundary: <what is NOT graded — e.g. no browser in the container, so client.js
+// runtime behavior is not executed; only the host-announced anchor is judged>.
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import {
+  addPlugin,
+  bootWebAndFetchIndex,
+  cleanupProfile,
+  createProfile,
+  dshAvailable,
+  emit,
+  FIXTURE_DIR,
+  fixtureChanges,
+  NEGATIVE_SIGNAL,
+} from './judge-utils.mjs'
+
+const TASK = '<TASK-ID>'
+const PKG = '<pkg-name>'
+
+main().catch((error) => emit(0, [`judge error: ${error.message}`]))
+
+async function main() {
+  const reasons = []
+
+  const gate = await fixtureChanges('fixture')
+  if (gate.changed !== true) {
+    emit(0, [`fixture unchanged (${gate.detail}), graded as 0`])
+  }
+  reasons.push('fixture was modified by the agent')
+
+  // 1. Static manifest checks.
+  let pkg
+  try {
+    pkg = JSON.parse(readFileSync(join(FIXTURE_DIR, 'package.json'), 'utf8'))
+  } catch (error) {
+    emit(0, [...reasons, `failed to parse package.json: ${error.message}`])
+  }
+  let score = 0
+
+  // <check 1> — e.g. dsh.bundle.patch resolves to a real file
+  // <check 2> — e.g. exports["./client"] resolves to a real client entry
+  // <check 3> — e.g. dsh.client declares platform web
+  // <check 4> — e.g. Node entry resolves to a real file
+  // <check 5> — e.g. cordis.patch.yml contains an insert row
+  // <legacy check> — e.g. legacy loading path removed from the Node half
+
+  if (!(await dshAvailable())) {
+    emit(score, [...reasons, 'dsh unavailable; runtime verification treated as failed'])
+  }
+
+  // 2. Runtime: add + cold boot (+ boot graph / HTTP anchors).
+  const profile = 'bench-<task-id>'
+  const tmp = '/tmp/bench-<task-id>'
+  try {
+    const created = await createProfile(profile, ['@deepseek-ai/dsh-base', '@deepseek-ai/dsh-web-app'])
+    if (!created.ok) reasons.push(created.detail)
+    else {
+      const added = await addPlugin(profile, FIXTURE_DIR)
+      if (!added.ok) reasons.push(`dsh plugin add failed: ${added.detail}`)
+      else {
+        reasons.push('dsh plugin add succeeded')
+        score += 10
+        reasons.push('plugin installed successfully (+10)')
+
+        const boot = await bootWebAndFetchIndex(profile, PKG)
+        if (NEGATIVE_SIGNAL.test(boot.output)) {
+          reasons.push(`web cold boot shows a negative signal: ${boot.output.match(/pending \(waiting for service: [^)]+\)|plugin tree failed|ClientPackageCompositionError/)?.[0] ?? 'unknown'}`)
+        } else {
+          score += 10
+          reasons.push('web cold boot: host half has no pending (+10)')
+        }
+
+        if (boot.html && boot.html.includes(`${PKG}/client.js`)) {
+          score += 20
+          reasons.push('__DSH_BOOT__.entries contains this plugin — the browser half is recognized (+20)')
+        } else if (boot.html) {
+          reasons.push('__DSH_BOOT__.entries does not contain this plugin — client-modules did not recognize the client entry (+0)')
+        } else {
+          reasons.push(`could not obtain the boot graph page${boot.fetchError ? `: ${boot.fetchError}` : ''} (+0)`)
+        }
+      }
+    }
+  } finally {
+    await cleanupProfile(profile, tmp)
+  }
+
+  emit(score, reasons)
+}
+
+function exists(relative) {
+  try {
+    readFileSync(join(FIXTURE_DIR, relative))
+    return true
+  } catch {
+    return false
+  }
+}

--- a/skills/dsh-benchmark-case/assets/solve.sh.example
+++ b/skills/dsh-benchmark-case/assets/solve.sh.example
@@ -5,8 +5,7 @@ cp "$(dirname "$0")/plugin/package.json" /app/fixture/package.json
 cp "$(dirname "$0")/plugin/cordis.patch.yml" /app/fixture/cordis.patch.yml
 cp "$(dirname "$0")/plugin/.dsh-plugin/index.js" /app/fixture/.dsh-plugin/index.js
 cp "$(dirname "$0")/plugin/.dsh-plugin/client.js" /app/fixture/.dsh-plugin/client.js
-# The repository-shaped .dsh-plugin/package.json manifest is dropped: the alpha host
-# walks up from the Node entry to the nearest package.json (the package root, which
-# carries dsh.client); a nested manifest without dsh.client would shadow it and the
-# browser half would stay invisible (DSH-0.1.1-R1-01).
-rm -f /app/fixture/.dsh-plugin/package.json
+# If the migration requires dropping legacy layout files, delete them here explicitly.
+# Leftover files that still look loadable to the host are a classic silent-failure trap;
+# which files must go is task-specific and documented in that task's SOLUTION.md.
+# rm -f /app/fixture/<legacy-file-that-must-go>

--- a/skills/dsh-benchmark-case/assets/solve.sh.example
+++ b/skills/dsh-benchmark-case/assets/solve.sh.example
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Oracle solution: copy the reference plugin files over the matching relative paths under /app/fixture/.
+set -e
+cp "$(dirname "$0")/plugin/package.json" /app/fixture/package.json
+cp "$(dirname "$0")/plugin/cordis.patch.yml" /app/fixture/cordis.patch.yml
+cp "$(dirname "$0")/plugin/.dsh-plugin/index.js" /app/fixture/.dsh-plugin/index.js
+cp "$(dirname "$0")/plugin/.dsh-plugin/client.js" /app/fixture/.dsh-plugin/client.js
+# The repository-shaped .dsh-plugin/package.json manifest is dropped: the alpha host
+# walks up from the Node entry to the nearest package.json (the package root, which
+# carries dsh.client); a nested manifest without dsh.client would shadow it and the
+# browser half would stay invisible (DSH-0.1.1-R1-01).
+rm -f /app/fixture/.dsh-plugin/package.json

--- a/skills/dsh-benchmark-case/assets/task.toml.example
+++ b/skills/dsh-benchmark-case/assets/task.toml.example
@@ -1,7 +1,7 @@
 schema_version = "1.4"
-# Harbor task config: dsh plugin migration exam question M6 (repository-plugins removal, bundle conversion, in-container cold boot verification)
+# Harbor task config: dsh plugin migration exam question M13 (repository-plugins removal, bundle conversion, in-container cold boot verification)
 [task]
-name = "dsh-plugin-upgrade/m6-repository-plugins-removal"
+name = "dsh-plugin-upgrade/m13-repository-plugins-removal"
 version = "1.1.0"
 description = "Migrate a 0.1.1-era repository-plugin to a 0.1.2-alpha.2 bundle plugin so it installs, activates, and its browser half is recognized"
 keywords = ["dsh", "plugin-migration", "repository-plugins", "bundle", "container", "harbor"]

--- a/skills/dsh-benchmark-case/assets/task.toml.example
+++ b/skills/dsh-benchmark-case/assets/task.toml.example
@@ -1,0 +1,25 @@
+schema_version = "1.4"
+# Harbor task config: dsh plugin migration exam question M6 (repository-plugins removal, bundle conversion, in-container cold boot verification)
+[task]
+name = "dsh-plugin-upgrade/m6-repository-plugins-removal"
+version = "1.1.0"
+description = "Migrate a 0.1.1-era repository-plugin to a 0.1.2-alpha.2 bundle plugin so it installs, activates, and its browser half is recognized"
+keywords = ["dsh", "plugin-migration", "repository-plugins", "bundle", "container", "harbor"]
+
+[metadata]
+difficulty = "hard"
+category = "programming"
+tags = ["dsh", "plugin-upgrade", "repository-removal", "bundle-migration", "english-prompt"]
+execution_contract = "BENCHMARK-AUTH-v1"
+
+[agent]
+timeout_sec = 900.0
+
+[verifier]
+timeout_sec = 600.0
+
+[environment]
+network_mode = "public"
+cpus = 1
+memory_mb = 2048
+storage_mb = 4096

--- a/skills/dsh-benchmark-case/assets/test.sh.example
+++ b/skills/dsh-benchmark-case/assets/test.sh.example
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Harbor verifier: run judge.mjs (last line prints the 0-100 score JSON), normalize to a 0-1 reward.
+# judge itself always exits 0; if no JSON can be parsed, grade as 0 (error-tolerance principle).
+mkdir -p /logs/verifier
+node /tests/judge.mjs > /tmp/judge.out 2>&1
+cat /tmp/judge.out
+node -e '
+const fs = require("node:fs");
+const lines = fs.readFileSync("/tmp/judge.out", "utf8").trim().split("\n").filter(Boolean);
+let score = 0;
+for (let i = lines.length - 1; i >= 0; i -= 1) {
+  try {
+    const j = JSON.parse(lines[i]);
+    if (typeof j.score === "number" && typeof j.max === "number") { score = j.score; break }
+  } catch {}
+}
+const reward = Math.max(0, Math.min(1, score / 100));
+fs.writeFileSync("/logs/verifier/reward.txt", String(reward) + "\n");
+console.log("reward: " + reward);
+'

--- a/skills/dsh-benchmark-case/references/case-selection.md
+++ b/skills/dsh-benchmark-case/references/case-selection.md
@@ -1,0 +1,57 @@
+# 选材判据：什么值得做成考题，什么不值得
+
+dsh-benchmark-case 的 Stage 0 展开。核心问题永远是：
+**这道题能测出"AI 会/不会某件事"吗？判分是机械的、无歧义的吗？**
+
+## 强信号（×成立越多，题越值得做）
+
+1. **迁移真实发生过**：git 历史里能找到"迁移 commit"，最好是独立 commit
+   （`426e86d` whale-girl bundle 转换、`bfa0e8d` plugin-registry console 适配），
+   而不是混在几十个 commit 里的一次顺手改名。迁移 commit 的 diff 就是
+   fixture（迁移前）与 oracle（迁移后）的天然素材。
+2. **走廊清晰**：能归属一个 from→to（如 rc.8 → rc.1），并且 references/ 有
+   对应卡（或决定随题补卡）。没有卡支撑的题，AI 无从查证，等于考背诵。
+3. **断裂面小（1~4 个 touchpoint）**：fixture 好构造、judge 好写、解题路径
+   唯一。多于 4 个 touchpoint 的迁移拆成多道题，各自聚焦。
+4. **装旧形态必有可观察故障**：pending / plugin tree failed / 静默缺行为
+   （boot 图缺条目、某通道 404）。"旧形态也全绿但只是不推荐"不成题。
+5. **新形态在 alpha.2 上可容器冷启动验证**：这是硬约束。无浏览器环境决定了
+   client 运行时不可判，只能判宿主宣告（boot 图 / HTTP 状态 / 激活信号）。
+6. **有真实坑**：迁移中"第二个 commit"修的那个问题就是坑（误导注释、
+   看着无害的残留、预置红测试）。坑必须来自真实迁移，不能编。
+
+## 反例（不成立 → 退回升级卡形态）
+
+| 情况 | 为什么不成题 |
+|---|---|
+| 纯自研重构（无 host 侧变化） | 考不到"升级"，升级卡都不需要 |
+| 迁移在旧 host 上才能演示 | 容器固定 alpha.2，无法还原旧宿主故障 |
+| 判分取决于输出文本内容 | 无固定输出文本可依赖；必须用宿主侧信号 |
+| fixture 简单到一眼看穿 | 测不到 skill 的价值，分差 ≈ 0 |
+| fixture 复杂到无法在容器内还原 | oracle 1.0 过不了，交付即失败 |
+| 只有一张卡、一个 touchpoint 的小事 | 拆太碎；合并进相邻题或先出卡 |
+
+## 从一张卡出题 vs 从一个仓库出题
+
+- **一张卡 → 一道题**：卡里 Symptoms/Migration recipe/Verification 三者都
+  能在容器里机械验证时（如 R1-01 repository 移除、R1-09 服务改名）。
+- **一个仓库 → 多道题**：强 case（bundle 转换链）可拆成"改 manifest 形态"、
+  "删残留清单"、"client 模块化"多道独立题，各自 fixture 聚焦不同 commit 的
+  迁移前形态。
+- 一个仓库 → 零道题：仓库的迁移不可在容器还原（依赖特殊硬件/外部服务时）。
+
+## 实战样本（本次经验来源）
+
+- **whale-girl `426e86d`**：repository-plugin → bundle。1177 行 diff，核心
+  断裂 = repository 机制移除（R1-01）+ client 从自执行变 `{name, apply}`
+  模块（R1-01 配方）。容器可测：add → boot → `__DSH_BOOT__` 含 client。
+- **plugin-registry `bfa0e8d`**：console 从 repository 行管理 → profile
+  insert 行管理。断裂 = 4 个 plugin_* 工具无后端。更适合出"工具分流逻辑"
+  静态题或 console 行为题，容器内更重。
+- **`httpServer`→`webServer`（R1-09）**：四仓库一天内同因改名——高频低通量
+  破坏，静态 grep 旧标识符即可锚定（S 类静态题理想素材）。
+
+## 决策记录要点
+
+Stage 0 结论写进后续的 SOLUTION.md / scoring.md 提案时，三个信息必须有：
+走廊、覆盖的卡 ID 全名、容器验证路径（哪条命令证明新形态活）。

--- a/skills/dsh-benchmark-case/references/contract-clauses.md
+++ b/skills/dsh-benchmark-case/references/contract-clauses.md
@@ -1,0 +1,79 @@
+# 契约条款银行（BENCHMARK-AUTH-v1）
+
+`benchmark/scripts/validate-execution-contract.mjs` 用**正则逐条匹配**，
+字面必须命中。以下措辞全部来自既有 23 题，**照抄最稳**。双语任选其一，
+但英文版已证明匹配，推荐复制。
+
+## 完整 instruction.md 模板（mutable / hands-on）
+
+```markdown
+# <ID> · <Title>
+
+## Unattended Benchmark Authorization (BENCHMARK-AUTH-v1)
+
+This is an unattended benchmark run in a disposable isolated container; there will be
+no follow-up user messages. This task statement is itself the user's explicit
+authorization and confirmation for the solution and execution needed to complete the
+task: complete the necessary analysis and planning on your own, and continue executing
+immediately once the plan is formed — do not pause to wait for "confirmation" and do
+not press the user with follow-up questions. That confirmation continues to apply to
+the concrete plans you produce under the applicable skill, but only within the
+following scope:
+
+- You may read `/app/fixture/`, local in-container documentation, and local tools; you
+  may modify `/app/fixture/` directly and write to the specified `/app/agent-output/`
+  directory as instructed;
+- You may create disposable local verification profiles and temporary files, and run
+  local tests, builds, and dsh commands;
+- You must not modify the skill, the grader, or the reference solution, and must not
+  publish, push, access external services, or change resources outside the container;
+- If you cannot complete the task, state the blocker honestly, but do not stop merely
+  because another round of confirmation is missing.
+
+<任务正文：旧形态是什么、host 已升级到什么、要求迁移成什么、如何验证>
+```
+
+### 五子句（校验逐条正则，缺失即失败）
+
+| 子句 | 校验正则片段 | 模板内的字面 |
+|---|---|---|
+| no-follow-up | `there will be no follow-up user messages` | `there will be no follow-up user messages` |
+| proceed-after-plan | `(?:as soon as\|immediately once\|once) the plan (?:is )?(?:formed\|takes shape)` | `continue executing immediately once the plan is formed` |
+| no-pause | `do not pause (?:to wait\|waiting) for ["“]?confirmation["”]?` | `do not pause to wait for "confirmation"` |
+| no-modify | `(?:must not\|may not) modify the skill` | `You must not modify the skill, the grader, or the reference solution` |
+| no-stop | `do not stop merely because another round of confirmation is missing` | `do not stop merely because another round of confirmation is missing` |
+
+## 边界授权句（按 mode 二选一，也做正则校验）
+
+- **mutable / hands-on**（M/H 类）：`you may modify `/app/fixture/` directly`
+  （正则：`may modify `\/app\/fixture\` directly`）
+- **readonly / 静态**（S 类）：`/app/fixture/ 必须保持 零改动 | /app/fixture/
+  must remain completely unchanged`
+- **build-artifacts-only**（H4 tsbuildinfo-trap 类）：src 零改动 + lib/构建产物
+  可清理（参考 H4 措辞）。
+
+## task.toml 的契约字段
+
+```toml
+[metadata]
+execution_contract = "BENCHMARK-AUTH-v1"   # 校验：恰好一次
+[task]
+version = "1.1.0"                          # 校验：必须这串
+```
+
+## 陷阱（实测踩过）
+
+1. **mutable 题也必须有授权句**：模板第 4 行的 `you may modify` 是模式
+   `may modify `\/app\/fixture\` directly` 的命中来源，删了校验直接失败。
+2. **只读题不许有 "may modify"**：同段正则会抓 mutable 授权句的缺席/错配，
+   边界句必须与 expectedModes 的 mode 一致。
+3. **校验入口**：
+   `node benchmark/scripts/validate-execution-contract.mjs`（一次校验全部
+   instruction.md + task.toml，23→24 自动）。
+4. 新增题必须同时把 `['<task-id>', '<mode>']` 加进脚本头部 expectedModes
+   Map，否则 "task has no execution-contract mode" 失败。
+
+## 中英双语提示
+
+校验正则同时接受中文与英文变体；仓库既有题中英都有。新题选英文即与
+validate-execution-contract.mjs 的英文分支一一对应，最不易踩坑。

--- a/skills/dsh-benchmark-case/references/contract-clauses.md
+++ b/skills/dsh-benchmark-case/references/contract-clauses.md
@@ -1,7 +1,7 @@
 # 契约条款银行（BENCHMARK-AUTH-v1）
 
 `benchmark/scripts/validate-execution-contract.mjs` 用**正则逐条匹配**，
-字面必须命中。以下措辞全部来自既有 23 题，**照抄最稳**。双语任选其一，
+字面必须命中。以下措辞全部来自既有题，**照抄最稳**。双语任选其一，
 但英文版已证明匹配，推荐复制。
 
 ## 完整 instruction.md 模板（mutable / hands-on）
@@ -69,7 +69,7 @@ version = "1.1.0"                          # 校验：必须这串
    边界句必须与 expectedModes 的 mode 一致。
 3. **校验入口**：
    `node benchmark/scripts/validate-execution-contract.mjs`（一次校验全部
-   instruction.md + task.toml，23→24 自动）。
+   instruction.md + task.toml，新题注册 expectedModes 后自动纳入）。
 4. 新增题必须同时把 `['<task-id>', '<mode>']` 加进脚本头部 expectedModes
    Map，否则 "task has no execution-contract mode" 失败。
 

--- a/skills/dsh-benchmark-case/references/grading-recipe.md
+++ b/skills/dsh-benchmark-case/references/grading-recipe.md
@@ -27,7 +27,7 @@ if (gate.changed !== true) emit(0, [`fixture unchanged (${gate.detail}), graded 
 // 1. 静态段 — manifest 字段 / exports / patch / 源码 grep
 //    每 check: score += N; reasons.push(具体原因)
 //    manifest 用 JSON.parse；patch 用文本 regex；源码模式用正则
-//    半对给半带（如 dsh.client 声明缺 platform → 20 而非全 40）
+//    半对给半带（如关键声明缺字段 → 给半分而非满分）
 //    陷阱跟随封顶：误导注释说"别改 X"，留着 X → 该 check 上限
 
 // 2. 运行时段 — 容器真实执行
@@ -62,22 +62,23 @@ emit(score, reasons)
 
 ## 分数带设计原则
 
-1. **给半对留带**：`dsh.client` 声明完整 40 / 缺 platform 20 / 完全缺失 0。
-2. **陷阱封顶**：跟随误导 = 上限（H1：inject 含 remote 不含量 llm → 上限 20）。
-3. **绕道封顶**：看似全绿但 pnpm.overrides 钉旧运行时 / 手写 shim → 上限
-   （H5：pin/shim 封顶）。封顶要有静态引擎（grep 特定字段/模式），因为
-   这些绕道 boot 也绿。
+1. **给半对留带**：关键声明完整给满分 / 缺字段给半分 / 完全缺失 0 分。
+2. **陷阱封顶**：跟随误导 = 该 check 上限。误导注释把 agent 引向"看起来对
+   其实致命"的改法，跟着改的解必须拿不到该 check 满分。
+3. **绕道封顶**：看似全绿但用"钉旧依赖版本 / 手写兼容层"等方式绕开迁移 →
+   上限。封顶要有静态引擎（grep 特定字段/模式），因为这些绕道 boot 也绿。
 4. **100 = 完全正确路径**：oracle 只走合法路径拿到 100；任何绕道拿不到满分。
 5. **分数差即评测点**：装 skill vs 不装的分差 = 该题测的能力。0 分差愚蠢题。
 6. **判别力验证（交付前必跑负例矩阵）**：oracle=100 只是下限——还要验证
    judge 不是"什么都给高分"。每个陷阱/半迁移态跑一版：
    - 未动 fixture → 必须 0（gate）；
-   - 跟随误导注释 → 该 check 上限（如 M7 注释残留旧名 → 静态丢对应点）；
-   - 半迁移（如只改服务名不改事件名）→ 落在预期带（静态失分 + 运行时
-     `jobs.onTaskDone is not a function` → plugin tree failed）；
-   - `dsh plugin add` 失败 → 30 带。
-   负例分数矩阵记录进 SOLUTION.md / 交付报告。M6 已验 0/100/80、M7 已验
-   0/100/90/50/30——这两组矩阵就是 skill 的"判分有区分度"证据。
+   - 跟随误导注释 → 该 check 上限（静态丢对应点）；
+   - 半迁移（如标识符只改了一部分、漏改其余引用）→ 落在预期带（静态
+     失分 + 运行时负信号）；
+   - `dsh plugin add` 失败 → 低分带。
+   负例分数矩阵记录进 SOLUTION.md / 交付报告；既有题的交付记录里都附了
+   这类矩阵，可参照其格式（各题具体分值与落带以该题 judge 为准，本 skill
+   不展开——方法级不讲答案）。
 
 ## 运行纪律
 
@@ -96,7 +97,7 @@ emit(score, reasons)
 
 ## 参考实现
 
-`tasks/H3-client-plane/tests/judge.mjs`（client 声明 40 + add 10 + 无 pending
-10 + boot 条目 40 —— 最干净的四段）、`tasks/M6-repository-plugins-removal`
-（静态 60 + 运行时 40，含 manifest 遮蔽深坑）、`tasks/M5-token-auth-smoke`
-（raw webServer.register 封顶 60 的静态引擎）。
+读既有任务的 `tests/judge.mjs` 学结构与惯例（如 `tasks/H3-client-plane`、
+`tasks/M13-repository-plugins-removal`、`tasks/M5-token-auth-smoke`）——
+三段式怎么排、静态 caps 引擎怎么写、reasons 文案什么风格，照它们对齐。
+各题的具体分值与封顶线以该题 judge 为准，本 skill 不展开。

--- a/skills/dsh-benchmark-case/references/grading-recipe.md
+++ b/skills/dsh-benchmark-case/references/grading-recipe.md
@@ -1,0 +1,102 @@
+# 判分配方（judge 三段式 + 分数带 + caps）
+
+Stage 3 的展开。目标：判分**机械、无歧义、能区分真迁移与绕道**。
+
+## judge.mjs 固定契约（所有题一致）
+
+```js
+import { /* H3 同款导入 */ } from './judge-utils.mjs'
+const TASK = '<task-id>'
+const PKG = '<npm 包名，如 @demo/dsh-bench-repo>'
+main().catch((error) => emit(0, [`judge error: ${error.message}`]))
+```
+
+- 最后一行 stdout：`{"score":0-100,"max":100,"reasons":[...]}`（emit 保证
+  try/finally 后 exit 0）。
+- `tests/test.sh` 解析最后一行 JSON，写 `score/100` 到 `/logs/verifier/reward.txt`
+  （或按既有 test.sh 原样复制）。
+
+## 三段式模板（评分惯例：Gate 0 分 / 静态 40-70 / 运行时 30-60）
+
+```js
+// 0. Gate — 只读题：fixture 必须未被改（改了 = 0 分，测诚实报告）
+//          可变题：fixture 必须被改（没改 = 0 分，测真的在动手）
+const gate = await fixtureChanges('fixture')
+if (gate.changed !== true) emit(0, [`fixture unchanged (${gate.detail}), graded as 0`])
+
+// 1. 静态段 — manifest 字段 / exports / patch / 源码 grep
+//    每 check: score += N; reasons.push(具体原因)
+//    manifest 用 JSON.parse；patch 用文本 regex；源码模式用正则
+//    半对给半带（如 dsh.client 声明缺 platform → 20 而非全 40）
+//    陷阱跟随封顶：误导注释说"别改 X"，留着 X → 该 check 上限
+
+// 2. 运行时段 — 容器真实执行
+if (!(await dshAvailable())) emit(score, [...reasons, 'dsh unavailable; treated as failed'])
+const profile = 'bench-<task>'
+const tmp = '/tmp/bench-<task>'
+try {
+  const created = await createProfile(profile, ['@deepseek-ai/dsh-base', '@deepseek-ai/dsh-web-app'])
+  // 或 headless 类 profile（看参考题）
+  const added = await addPlugin(profile, FIXTURE_DIR)   // +10
+  const boot = await bootWebAndFetchIndex(profile, PKG) // 无 pending +10/+payload
+  // boot.html.includes(`${PKG}/client.js`) → +20~40  ← boot URL 按 exports key
+  // 或 headless 冷启动 signal（MISSING_CREDENTIAL = 激活）
+} finally {
+  await cleanupProfile(profile, tmp)  // finally 必须，进程永不 exit(1)
+}
+emit(score, reasons)
+```
+
+## 判分锚必须是宿主侧信号
+
+| 锚 | 来源 | 判定 |
+|---|---|---|
+| `NEGATIVE_SIGNAL` | judge-utils（正则匹配 boot/激活输出） | `pending (waiting for service: …)` / `plugin tree failed` / `FAILED fiber` / `ClientPackageCompositionError` = 失败带 |
+| headless 激活 | 冷启动无 key 到 `MISSING_CREDENTIAL` | 树整体激活 = 通过；**出口码不可信**（成功也 exit 1） |
+| `__DSH_BOOT__` 条目 | web 冷启动 GET `/` | `html.includes('<pkg>/client.js')` |
+| HTTP 冒烟 | token/cookie 通道 | 401（未保护→扣）/ 200（保护→得） |
+| git 基线 | `git status --porcelain -- fixture` | 门禁两类题复用 |
+
+**禁止**：判输出文本内容、判 stdout 文案、判"AI 是否提到了卡"（那是另一种
+评测，不在 Harbor 判分里）。
+
+## 分数带设计原则
+
+1. **给半对留带**：`dsh.client` 声明完整 40 / 缺 platform 20 / 完全缺失 0。
+2. **陷阱封顶**：跟随误导 = 上限（H1：inject 含 remote 不含量 llm → 上限 20）。
+3. **绕道封顶**：看似全绿但 pnpm.overrides 钉旧运行时 / 手写 shim → 上限
+   （H5：pin/shim 封顶）。封顶要有静态引擎（grep 特定字段/模式），因为
+   这些绕道 boot 也绿。
+4. **100 = 完全正确路径**：oracle 只走合法路径拿到 100；任何绕道拿不到满分。
+5. **分数差即评测点**：装 skill vs 不装的分差 = 该题测的能力。0 分差愚蠢题。
+6. **判别力验证（交付前必跑负例矩阵）**：oracle=100 只是下限——还要验证
+   judge 不是"什么都给高分"。每个陷阱/半迁移态跑一版：
+   - 未动 fixture → 必须 0（gate）；
+   - 跟随误导注释 → 该 check 上限（如 M7 注释残留旧名 → 静态丢对应点）；
+   - 半迁移（如只改服务名不改事件名）→ 落在预期带（静态失分 + 运行时
+     `jobs.onTaskDone is not a function` → plugin tree failed）；
+   - `dsh plugin add` 失败 → 30 带。
+   负例分数矩阵记录进 SOLUTION.md / 交付报告。M6 已验 0/100/80、M7 已验
+   0/100/90/50/30——这两组矩阵就是 skill 的"判分有区分度"证据。
+
+## 运行纪律
+
+- 只建 `bench-<task>` profile 与 `/tmp/bench-<task>`，不碰共享 ~/.dsh 与 3080
+  会话服务。随机端口 + 独立 DSH_HOME。
+- finally 里清理（pkill 的 pidpattern 用 `[x]` 括首字母防自杀——实测
+  pkill 匹配到自身 sh -c 会 exit 143 全挂）。
+- 超时充裕：add 180s / boot 60s / web 150s；真 workspace（H9）verifier 900s，
+  常规 600s。
+- judge 异常路径 emit(0) 收尾，绝不裸 throw 到 test.sh。
+
+## 边界声明（写进 judge 头注释 + SOLUTION.md + scoring.md）
+
+必须声明容器边界：无浏览器 ⇒ client 运行时（DOM/__ModuleLoader__ 挂载、
+渲染）不判，只判宿主宣告的 boot 图条目 / HTTP 状态；静态题明确"只读域"。
+
+## 参考实现
+
+`tasks/H3-client-plane/tests/judge.mjs`（client 声明 40 + add 10 + 无 pending
+10 + boot 条目 40 —— 最干净的四段）、`tasks/M6-repository-plugins-removal`
+（静态 60 + 运行时 40，含 manifest 遮蔽深坑）、`tasks/M5-token-auth-smoke`
+（raw webServer.register 封顶 60 的静态引擎）。

--- a/skills/dsh-benchmark-case/references/harbor-task-spec.md
+++ b/skills/dsh-benchmark-case/references/harbor-task-spec.md
@@ -1,0 +1,98 @@
+# Harbor 任务规范（dsh-plugin-upgrade benchmark v2.3）
+
+Stage 1 / Stage 3 的展开。目标套件：`oh-my-dsh/dsh-plugin-upgrade-skill` 的
+`benchmark/`，23 道既有题（S1..S8 静态 / M1..M6 迁移 / H1..H9 陷阱）为参照。
+
+## 任务目录（6 块，缺一不可）
+
+```
+tasks/<id>/
+├── instruction.md        # agent prompt；BENCHMARK-AUTH-v1 契约（见 contract-clauses.md）
+├── task.toml             # Harbor 元数据
+├── environment/
+│   ├── Dockerfile        # agent 镜像：node:24-bookworm + git + pnpm + dsh alpha.2 + git 基线
+│   └── fixture/          # 旧形态插件（private:true + exam-material README）
+├── tests/
+│   ├── test.sh           # 容器/宿主机 verifier 入口（源码寻找脚本展开）
+│   ├── judge.mjs         # 判分（唯一判分逻辑）
+│   └── judge-utils.mjs   # 共享判分库（复制既有任务的，勿改签名）
+└── solution/
+    ├── solve.sh          # oracle 应用脚本
+    ├── SOLUTION.md       # 参考解 + Point + Boundary
+    └── plugin/           # 迁移后的完整参考文件
+```
+
+## task.toml（Schema 1.4）
+
+```toml
+schema_version = "1.4"
+[task]
+name = "dsh-plugin-upgrade/<task-id>"
+version = "1.1.0"            # BENCHMARK-AUTH-v1 固件版本，勿改（契约校验要求）
+description = "<一句话：从什么迁移到什么>"
+keywords = ["dsh", "plugin-migration", ...]
+
+[metadata]
+difficulty = "hard"          # 现有题多为 hard
+category = "programming"
+tags = ["dsh", "plugin-upgrade", ...]
+execution_contract = "BENCHMARK-AUTH-v1"   # 必须恰好出现一次
+
+[agent]
+timeout_sec = 900.0          # 常规 hands-on；H9 这类真 workspace 题另调
+
+[verifier]
+timeout_sec = 600.0          # H9: 900
+
+[environment]
+network_mode = "public"      # 需要拉 profile 依赖
+cpus = 1
+memory_mb = 2048
+storage_mb = 4096
+```
+
+## environment/Dockerfile（规范性）
+
+```dockerfile
+FROM node:24-bookworm
+RUN apt-get update && apt-get install -y --no-install-recommends git \
+    && rm -rf /var/lib/apt/lists/*
+RUN npm install -g pnpm@11.24.0 @deepseek-ai/dsh@0.1.2-alpha.2
+WORKDIR /app
+COPY fixture /app/fixture
+RUN git init -q && git add -A && git -c user.email=bench@local -c user.name=bench commit -q -m "baseline"
+```
+
+- **版本钉死**：pnpm@11.24.0 / dsh@0.1.2-alpha.2，与其余任务一致。
+- **git 基线**：judge 用 `git status --porcelain -- fixture` 判定"fixture 是否
+  被改"（只读题 0 分门禁 / 可变题同样实现）。没有它就失去 strips 门禁。
+- 容器内 **无浏览器**：所有 client 运行时判分都不可能，锚只能是宿主宣告。
+
+## 判分信号表（judge 视角，全部来自 judge-utils 与容器日志）
+
+| 信号 | 含义 | 用法 |
+|---|---|---|
+| `NEGATIVE_SIGNAL` = `/plugin tree failed\|did not activate\|pending \(waiting for service\|FAILED fiber\|ClientPackageCompositionError/i` | 插件树未激活 | 失败带（40 分）或该 check 0 分 |
+| headless 冷启动到 `MISSING_CREDENTIAL` / `no API key` / `dsh: AUTH` | 树整体激活（无 key 也走到这） | 通过；出口码不可信 |
+| `__DSH_BOOT__.entries` 含 `<pkg>/client.js` | client-modules 识别了浏览器半 | boot 图条目 20~40 分 |
+| HTTP 通道 401/200 冒烟（token/cookie） | 受保护通道真死/真活 | M5/H8 类题 |
+| `git status --porcelain -- fixture` 空 | fixture 未被改 | gate：0 分 |
+
+boot 图 URL 按 **exports key** 拼（`"exports": {"./client": "..."}` → boot 条目
+`<pkg>/client.js`），与文件真实路径无关（实测证据：H3/H9 client 在
+`lib/client.js` 或 `.dsh-plugin/client.js`，boot URL 都是 `<pkg>/client.js`）。
+
+## 既有 23 题清单（命名参照）
+
+静态 readonly：S1 static-scan、S2 negative-scan、S3 snapshot-migration、
+S4 legacy-client-imports、S5 negative-naming、S6 corridor-net-state、
+S7 unpublished-cohort、S8 release-routing-trap（+H4 tsbuildinfo-trap、
+H6 remote-error-trap 名义 H 实为静态）。
+mutable hands-on：M1 host-migration、M2 optional-dep-trap、
+M3 session-projection、M4 peer-prerelease-range、M5 token-auth-smoke、
+M6 repository-plugins-removal、H1 plane-trap、H2 baseline-trap、
+H3 client-plane、H5 runtime-export-drift、H7 locale-trap、H8 fire-drill、
+H9 dsh-web-alpha2。
+
+新任务 id：S9… / M7… / H10…（接续，勿跳号）；命名用连字符描述性词
+（`M6-repository-plugins-removal` 风格）。

--- a/skills/dsh-benchmark-case/references/harbor-task-spec.md
+++ b/skills/dsh-benchmark-case/references/harbor-task-spec.md
@@ -1,7 +1,8 @@
-# Harbor 任务规范（dsh-plugin-upgrade benchmark v2.3）
+# Harbor 任务规范（dsh-plugin-upgrade benchmark v2.4）
 
 Stage 1 / Stage 3 的展开。目标套件：`oh-my-dsh/dsh-plugin-upgrade-skill` 的
-`benchmark/`，23 道既有题（S1..S8 静态 / M1..M6 迁移 / H1..H9 陷阱）为参照。
+`benchmark/`，52 道既有题（S1..S16 / M1..M14 / H1..H22）为参照——动手前先
+`ls benchmark/tasks/` 与 `benchmark/README.md` 任务表确认当前集合，勿凭记忆。
 
 ## 任务目录（6 块，缺一不可）
 
@@ -82,17 +83,13 @@ boot 图 URL 按 **exports key** 拼（`"exports": {"./client": "..."}` → boot
 `<pkg>/client.js`），与文件真实路径无关（实测证据：H3/H9 client 在
 `lib/client.js` 或 `.dsh-plugin/client.js`，boot URL 都是 `<pkg>/client.js`）。
 
-## 既有 23 题清单（命名参照）
+## 既有任务集合与新 id 命名（以实物为准，勿凭本节记忆）
 
-静态 readonly：S1 static-scan、S2 negative-scan、S3 snapshot-migration、
-S4 legacy-client-imports、S5 negative-naming、S6 corridor-net-state、
-S7 unpublished-cohort、S8 release-routing-trap（+H4 tsbuildinfo-trap、
-H6 remote-error-trap 名义 H 实为静态）。
-mutable hands-on：M1 host-migration、M2 optional-dep-trap、
-M3 session-projection、M4 peer-prerelease-range、M5 token-auth-smoke、
-M6 repository-plugins-removal、H1 plane-trap、H2 baseline-trap、
-H3 client-plane、H5 runtime-export-drift、H7 locale-trap、H8 fire-drill、
-H9 dsh-web-alpha2。
+既有题的**唯一权威清单**是 `ls benchmark/tasks/` + `benchmark/README.md`
+任务表 + `benchmark/scripts/validate-task-registry.mjs` 的注册数据，本节不
+逐题罗列（罗列必过期）。当前（2026-09）为 52 题：S1–S16、M1–M14、H1–H22；
+其中 H4/H6 名义 H 实为静态题，Type 以 README 任务表的 Type 列为准。
 
-新任务 id：S9… / M7… / H10…（接续，勿跳号）；命名用连字符描述性词
-（`M6-repository-plugins-removal` 风格）。
+新任务 id：接对应系列现有最大编号（当前下一可用 S17 / M15 / H23），勿跳号；
+命名用连字符描述性词（`M13-repository-plugins-removal` 风格）。写题前重新
+核对一次目录与注册表——主线随时可能又进新题。

--- a/skills/dsh-benchmark-case/references/host-archaeology.md
+++ b/skills/dsh-benchmark-case/references/host-archaeology.md
@@ -18,19 +18,19 @@ package.json，作为该包的 manifest（包身份），然后读它的 `dsh.cl
 照常 apply，boot 无 pending——考试里这就是"装上了、激活了、但 boot 图没有
 它"的隐蔽失败态。
 
-**写题/解题启示**：
-- fixture 保留旧 `.dsh-plugin/package.json`（合法 R1-01 "drop legacy
-  artifacts" 题点）；
-- 参考解必须删除该残留（solve.sh 里 `rm -f`）；
-- judge 的 boot 图条目检查（`html.includes('<pkg>/client.js')`）自然抓到这个
-  坑——**不用专门 judge**，真实失败态就是 boot 图缺条目。
+**写题启示（方法级）**：
+- 可以利用这个机制布坑：fixture 的旧布局里留一个会遮蔽根清单的残留
+  manifest，"只补根清单、不清残留"的解法就会静默漏掉浏览器半；
+- judge 的 boot 图条目检查（`html.includes('<pkg>/client.js')`）自然抓到
+  这类坑——**不用专门 judge**，真实失败态就是 boot 图缺条目。
+  （具体某道在线题怎么布这个坑、参考解如何收尾，不在此展开。）
 
 ## 2. boot URL 与真实文件路径无关（按 exports key 拼）
 
 `__DSH_BOOT__.entries[].url` 是 `/plugins/??<pkg>/client.js&rev=…` 形态——
 **按 exports 的 key**（`"./client"` → `<pkg>/client.js`）拼，不是目标文件路径。
 实测：H9 的 `exports["./client"] = "./lib/client.js"`，boot URL 仍是
-`@linxin666/dsh-web-all/client.js`；M6 的 `"./client": "./.dsh-plugin/client.js"`，
+`@linxin666/dsh-web-all/client.js`；M13 的 `"./client": "./.dsh-plugin/client.js"`，
 boot URL 仍是 `@demo/dsh-bench-repo/client.js`。
 
 判 boot 图时匹配 `<pkg>/client.js` 即可，勿匹配真实路径。
@@ -40,8 +40,8 @@ boot URL 仍是 `@demo/dsh-bench-repo/client.js`。
 - `httpServer` → `webServer`（R1-09，0812）：alpha.2 只认 `webServer`，
   继续 inject `httpServer` 会 `pending (waiting for service: httpServer)`。
 - `tasks` → `jobs`（R1-09）：`tasks.read` → `jobs.read`。
-- 旧形态 fixture 用旧名（还原"当时坏"），参考解用新名（或完全无服务耦合，
-  如 M6 参考解 `inject: []` —— 避免把 R1-09 混进 R1-01 主题）。
+- 旧形态 fixture 用旧名（还原"当时坏"），参考解用新名（或让该题与服务
+  完全无耦合——避免把 R1-09 混进 R1-01 主题）。
 - **动手前先容器冷启动验证**哪个名能解析，别凭卡名猜。
 
 ## 4. `dsh plugin add` 的安装语义
@@ -69,24 +69,24 @@ boot URL 仍是 `@demo/dsh-bench-repo/client.js`。
 ## 7. pkill 自杀（运维坑，实测）
 
 清理 dsh 进程时 pkill 的 pidpattern 用 `[x]` 括首字母（`pkill -f "dsh --profile
-bench-[m]6"`），否则 pkill 会匹配到**你自己 sh -c 命令行里的同样字符串**，
+bench-[t]ask"`），否则 pkill 会匹配到**你自己 sh -c 命令行里的同样字符串**，
 把自己杀了（exit 143，docker exec 直接断）。
 
 **`[x]` 只防"模式文本自身"**：若同一 sh -c 命令行的别处还有明文 profile 名
 （例如 `dsh plugin --profile bench-probe add …` 与 `pkill -f "dsh --profile
 bench-[p]robe"` 在同一 exec 里），pkill 会匹配同行里 `--profile bench-probe`
 的明文而自杀。**把 pkill 拆成独立 exec**，或者让 add/boot 命令也走变量拼接。
-M7 实战实录：手测时把两者放同一条 sh -c，exit 143 全挂；judge-utils 的
+M14 实战实录：手测时把两者放同一条 sh -c，exit 143 全挂；judge-utils 的
 cleanupProfile 之所以安全，是因为那条命令里没有明文 profile 名。
 
 ## 8. 参考解源码注释别含 judge 要 grep 的字面 token
 
-如果 judge 用 `/(tapIndex|pet\/ui\.js)/` 判"已删除"，参考解的注释里**不能**
-出现 "httpServer.tapIndex 已删除" 这类字面——注释本身会命中 grep、自伤 10 分
-（本轮实战教训：M6 solution 首版注释写 "the /pet/ui.js route and the
-httpServer.tapIndex injection are gone"，judge grep 到它判未删）。
+如果 judge 用正则 grep 旧标识符判"已删除"，参考解的注释里**不能**出现
+这些字面值——"某路由 / 某注入已删除"这类说明性注释本身会命中 grep、自伤
+扣分（实战教训：某题 solution 首版注释复述了被要求删除的路由与注入标识符
+字面，judge grep 到注释判未删）。
 
-## 8b. sh 引号吞内嵌脚本（judge routeSmoke 新坑，M7 实测）
+## 8b. sh 引号吞内嵌脚本（judge routeSmoke 新坑，M14 实测）
 
 judge 里用 `node --input-type=module -e '<script>'` 做 HTTP 冒烟时，内嵌脚本
 若含单引号（如 `text.includes('"ok":true')`），单引号会在 sh 单引号包裹内
@@ -96,7 +96,7 @@ judge 里用 `node --input-type=module -e '<script>'` 做 HTTP 冒烟时，内�
 
 **修法**：内嵌脚本零单引号。断言改为 `JSON.parse(text).ok === true &&
 typeof open === 'number'`（正则/变量对比即可，不写字符串字面量 if 比较）。
-M7 首版中招、已改，judge 头注释含警告。
+M14 首版中招、已改，judge 头注释含警告。
 
 ## 9. Dockerfile 版本钉死
 
@@ -107,5 +107,5 @@ M7 首版中招、已改，judge 头注释含警告。
 
 - 容器内：`/usr/local/lib/node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-client-modules/lib/index.js`（1、2）
 - 既有 judge-utils：`benchmark/tasks/H3-client-plane/tests/judge-utils.mjs`（5、6）
-- 既有题实测：`M6-repository-plugins-removal`（1、4、8）、
-  `M5-token-auth-smoke` / `H8-fire-drill` judge（3、raw-route 封顶）
+- 既有题实测：`M13-repository-plugins-removal`（1、4、8）、
+  `M5-token-auth-smoke` / `H8-fire-drill` judge（3）

--- a/skills/dsh-benchmark-case/references/host-archaeology.md
+++ b/skills/dsh-benchmark-case/references/host-archaeology.md
@@ -1,0 +1,111 @@
+# 宿主考古：从 dsh 源码挖出的地面真相
+
+这些知识**不在文档里**，是 2026-08/09 通过读 alpha.2 宿主源码 + 容器实测
+得到的。写题前先扫一遍，能避开一半的"看起来对但 boot 失败"。
+
+## 1. client-modules 的 manifest 定位：最近 package.json 遮蔽（最高频深坑）
+
+源码：`@deepseek-ai/dsh-client-modules/lib/index.js` 的 `locatePkgJson` /
+`nearestPackage`。
+
+**机制**：client-modules 从 **Node entry 文件所在目录向上**找最近的
+package.json，作为该包的 manifest（包身份），然后读它的 `dsh.client` +
+`exports["./client"]` 决定是否进入 `__DSH_BOOT__` 浏览器表。
+
+**后果**：如果迁移后的 Node half 留在 `.dsh-plugin/` 等子目录，且那里有一个
+**残留的、无 `dsh.client` 的 package.json**（repository 时代清单），它就会
+遮蔽根清单 → 包被判定为"非 client 包" → **浏览器半静默消失**，Node half
+照常 apply，boot 无 pending——考试里这就是"装上了、激活了、但 boot 图没有
+它"的隐蔽失败态。
+
+**写题/解题启示**：
+- fixture 保留旧 `.dsh-plugin/package.json`（合法 R1-01 "drop legacy
+  artifacts" 题点）；
+- 参考解必须删除该残留（solve.sh 里 `rm -f`）；
+- judge 的 boot 图条目检查（`html.includes('<pkg>/client.js')`）自然抓到这个
+  坑——**不用专门 judge**，真实失败态就是 boot 图缺条目。
+
+## 2. boot URL 与真实文件路径无关（按 exports key 拼）
+
+`__DSH_BOOT__.entries[].url` 是 `/plugins/??<pkg>/client.js&rev=…` 形态——
+**按 exports 的 key**（`"./client"` → `<pkg>/client.js`）拼，不是目标文件路径。
+实测：H9 的 `exports["./client"] = "./lib/client.js"`，boot URL 仍是
+`@linxin666/dsh-web-all/client.js`；M6 的 `"./client": "./.dsh-plugin/client.js"`，
+boot URL 仍是 `@demo/dsh-bench-repo/client.js`。
+
+判 boot 图时匹配 `<pkg>/client.js` 即可，勿匹配真实路径。
+
+## 3. 服务名随走廊变（写 fixture/参考解前先验证）
+
+- `httpServer` → `webServer`（R1-09，0812）：alpha.2 只认 `webServer`，
+  继续 inject `httpServer` 会 `pending (waiting for service: httpServer)`。
+- `tasks` → `jobs`（R1-09）：`tasks.read` → `jobs.read`。
+- 旧形态 fixture 用旧名（还原"当时坏"），参考解用新名（或完全无服务耦合，
+  如 M6 参考解 `inject: []` —— 避免把 R1-09 混进 R1-01 主题）。
+- **动手前先容器冷启动验证**哪个名能解析，别凭卡名猜。
+
+## 4. `dsh plugin add` 的安装语义
+
+- bundle 插件（声明 `dsh.bundle.patch`）：进 profile `dsh.profile.bundles`
+  层栈，**web 重启生效**。
+- 纯 cordis 插件（无 bundle 声明）：写 profile `cordis.patch.yml` insert 行，
+  **配置 HMR 实时生效**（0811 保留）。
+- add 用 `link:` 安装（profile package.json 依赖 `"@demo/x": "link:/app/fixture"`），
+  所以 judge 里 profile 依赖图能看到 fixture。
+
+## 5. headless 冷启动激活信号
+
+无 API key 配置时，插件树整体激活的标志是到达 `MISSING_CREDENTIAL` /
+`no API key` / `dsh: AUTH`——**不是 exit code**（无 key 成功也 exit 1）。
+判"插件树活了"看这个信号，别读退出码。
+
+## 6. profile 生命周期（judge-utils 已封装）
+
+- profile 目录 = `~/.dsh/profiles/<name>/`，含 package.json（bundles 层栈 +
+  依赖）、cordis.patch.yml、cordis.yml。
+- web 冷启动组合：`['@deepseek-ai/dsh-base', '@deepseek-ai/dsh-web-app']`。
+- 独立 DSH_HOME 或 profile 隔离，**绝不复用会话 GUI 的 3080 与共享 ~/.dsh**。
+
+## 7. pkill 自杀（运维坑，实测）
+
+清理 dsh 进程时 pkill 的 pidpattern 用 `[x]` 括首字母（`pkill -f "dsh --profile
+bench-[m]6"`），否则 pkill 会匹配到**你自己 sh -c 命令行里的同样字符串**，
+把自己杀了（exit 143，docker exec 直接断）。
+
+**`[x]` 只防"模式文本自身"**：若同一 sh -c 命令行的别处还有明文 profile 名
+（例如 `dsh plugin --profile bench-probe add …` 与 `pkill -f "dsh --profile
+bench-[p]robe"` 在同一 exec 里），pkill 会匹配同行里 `--profile bench-probe`
+的明文而自杀。**把 pkill 拆成独立 exec**，或者让 add/boot 命令也走变量拼接。
+M7 实战实录：手测时把两者放同一条 sh -c，exit 143 全挂；judge-utils 的
+cleanupProfile 之所以安全，是因为那条命令里没有明文 profile 名。
+
+## 8. 参考解源码注释别含 judge 要 grep 的字面 token
+
+如果 judge 用 `/(tapIndex|pet\/ui\.js)/` 判"已删除"，参考解的注释里**不能**
+出现 "httpServer.tapIndex 已删除" 这类字面——注释本身会命中 grep、自伤 10 分
+（本轮实战教训：M6 solution 首版注释写 "the /pet/ui.js route and the
+httpServer.tapIndex injection are gone"，judge grep 到它判未删）。
+
+## 8b. sh 引号吞内嵌脚本（judge routeSmoke 新坑，M7 实测）
+
+judge 里用 `node --input-type=module -e '<script>'` 做 HTTP 冒烟时，内嵌脚本
+若含单引号（如 `text.includes('"ok":true')`），单引号会在 sh 单引号包裹内
+**提前闭合** → node 收到残缺程序 → SyntaxError，且 stderr 只有 node 栈尾，
+表现为"路由冒烟 no response / parse failed"而非 fetch 失败——排查时极易误判
+为网络问题。
+
+**修法**：内嵌脚本零单引号。断言改为 `JSON.parse(text).ok === true &&
+typeof open === 'number'`（正则/变量对比即可，不写字符串字面量 if 比较）。
+M7 首版中招、已改，judge 头注释含警告。
+
+## 9. Dockerfile 版本钉死
+
+`node:24-bookworm` + `pnpm@11.24.0` + `@deepseek-ai/dsh@0.1.2-alpha.2`，与全部
+现有题一致。改版本 = 换题环境，oracle 1.0 全部作废重验。
+
+## 证据索引（想深挖读这些）
+
+- 容器内：`/usr/local/lib/node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai/dsh-client-modules/lib/index.js`（1、2）
+- 既有 judge-utils：`benchmark/tasks/H3-client-plane/tests/judge-utils.mjs`（5、6）
+- 既有题实测：`M6-repository-plugins-removal`（1、4、8）、
+  `M5-token-auth-smoke` / `H8-fire-drill` judge（3、raw-route 封顶）

--- a/skills/dsh-benchmark-case/references/registry-sync.md
+++ b/skills/dsh-benchmark-case/references/registry-sync.md
@@ -6,16 +6,17 @@
 
 1. 顶部表格加行（Task / Type / What it tests），Type 必须
    `Static | Hands-on` 之一（H4/H6 名义 H 实为 Static，Type 列说了算）。
-2. 首段：`The N plugin-upgrade tasks measure one thing: …`（22→23→N）。
-3. 同段：`The first 10 are written exams … the last M are hands-on`
-   —— M 按表格 Type 列计数（当前 10 written / 13 hands-on）。
+2. 首段：`The N plugin-upgrade tasks measure one thing: …`（N 同步为新总数，
+   当前 52）。
+3. 同段：`The first N₁ are written exams … the last N₂ are hands-on`
+   —— 两个数都按表格 Type 列实数计数（当前 19 written / 33 hands-on）。
 4. `harbor run` 示例块：`# all N tasks: pointing -p at the tasks/ …`。
 5. Unattended authorization 小节：`All N instruction.md files carry …`。
 6. 维护者注记：`following the layout of the existing N tasks`。
 
 ## 2. `benchmark/docs/scoring.md`（评分映射，2 处）
 
-1. 首行：`Total <N×100> (N tasks × 100; …)`（2300 = 23 × 100 → 2400）。
+1. 首行：`Total <N×100> (N tasks × 100; …)`（当前 5200 = 52 × 100，每加一题 +100）。
 2. 任务表加行：Checkpoint 列写**覆盖的卡/rollup**（用全 ID 如
    DSH-0.1.1-R1-01）+ Score breakdown 列逐条精确到每个 check 的分数，与
    judge.mjs 完全一致。
@@ -72,4 +73,4 @@ docker exec bench-<id>-run sh -c \
 - PR 描述必须含：3 个校验命令及输出、oracle 1.0 输出、覆盖的卡 ID、未覆盖
   边界、致谢（上游事件/仓库、验证站矩阵）。
 - 仓库只读（oh-my-dsh）走 fork+PR；本机工作区对应目录非 git，子目录各自
-  git 仓库，贡献时按 AGENTS.local.md 纪律同步。
+  git 仓库；贡献流程与纪律见仓库根目录 CONTRIBUTING.md。

--- a/skills/dsh-benchmark-case/references/registry-sync.md
+++ b/skills/dsh-benchmark-case/references/registry-sync.md
@@ -1,0 +1,75 @@
+# 四连注册表同步 + 校验命令
+
+新增一道题 = 改 4 个文件 + 跑 3 个校验。任何一处漏改，校验立刻红。
+
+## 1. `benchmark/README.md`（任务总览，6 处）
+
+1. 顶部表格加行（Task / Type / What it tests），Type 必须
+   `Static | Hands-on` 之一（H4/H6 名义 H 实为 Static，Type 列说了算）。
+2. 首段：`The N plugin-upgrade tasks measure one thing: …`（22→23→N）。
+3. 同段：`The first 10 are written exams … the last M are hands-on`
+   —— M 按表格 Type 列计数（当前 10 written / 13 hands-on）。
+4. `harbor run` 示例块：`# all N tasks: pointing -p at the tasks/ …`。
+5. Unattended authorization 小节：`All N instruction.md files carry …`。
+6. 维护者注记：`following the layout of the existing N tasks`。
+
+## 2. `benchmark/docs/scoring.md`（评分映射，2 处）
+
+1. 首行：`Total <N×100> (N tasks × 100; …)`（2300 = 23 × 100 → 2400）。
+2. 任务表加行：Checkpoint 列写**覆盖的卡/rollup**（用全 ID 如
+   DSH-0.1.1-R1-01）+ Score breakdown 列逐条精确到每个 check 的分数，与
+   judge.mjs 完全一致。
+
+## 3. `benchmark/scripts/validate-execution-contract.mjs`（契约注册，1 处）
+
+```js
+const expectedModes = new Map([
+  // …既有行…
+  ['<task-id>', '<mode>'],   // mode: readonly | mutable | build-artifacts-only
+])
+```
+
+## 4. 卡引用与链接（validate.mjs 检查）
+
+- benchmark 内 Markdown（SOLUTION.md / README / scoring）引用卡时用
+  **全 ID**（`DSH-0.1.1-R1-01`，禁写 `R1-01`），且 ID 必须已存在于
+  references/v*.md，链接必须可解析。
+- 如需新卡（题引用一张尚不存在的卡），先随题的同一 PR 补卡（走廊边 from
+  唯一、idPrefix 前缀、Source 含 https）。
+
+## 校验命令（Stage 6 全量）
+
+```sh
+cd dsh-plugin-upgrade-skill
+node scripts/validate.mjs                        # 卡 schema/走廊/引用/链接
+node benchmark/scripts/validate-task-registry.mjs     # 任务清单 ↔ README ↔ scoring 一致
+node benchmark/scripts/validate-execution-contract.mjs  # BENCHMARK-AUTH-v1 五子句 + mode
+node --check benchmark/tasks/<id>/tests/judge.mjs
+node --check benchmark/tasks/<id>/tests/judge-utils.mjs
+```
+
+## oracle 1.0（不可跳过）
+
+```sh
+harbor run -p benchmark/tasks/<id> -a oracle     # 标准式
+```
+
+harbor 不可用时的 docker 手动等效路径（本机实测可行）：
+
+```sh
+cd benchmark/tasks/<id>
+docker build -t bench-<id> environment/
+docker run --rm -d --name bench-<id>-run \
+  -v "$PWD/solution/plugin":/oracle -v "$PWD/tests":/tests bench-<id> sleep 1200
+docker exec bench-<id>-run sh -c \
+  'cp -r /oracle/. /app/fixture/ && mkdir -p /logs/verifier && node /tests/judge.mjs'
+# 断言最后一行 {"score":100,"max":100,…}；跑完 docker rm -f
+```
+
+## 提交与 PR
+
+- 一道题 + 一张/张卡：同一个 PR 主题（feat/ 分支）。
+- PR 描述必须含：3 个校验命令及输出、oracle 1.0 输出、覆盖的卡 ID、未覆盖
+  边界、致谢（上游事件/仓库、验证站矩阵）。
+- 仓库只读（oh-my-dsh）走 fork+PR；本机工作区对应目录非 git，子目录各自
+  git 仓库，贡献时按 AGENTS.local.md 纪律同步。


### PR DESCRIPTION
## Summary

Add a new top-level skill, **`dsh-benchmark-case`**, that turns a real plugin
migration (a breaking commit in the plugin's git history, or an existing
version corridor) into **one auto-graded Harbor benchmark task**. It is the
same case-authoring process used to produce this repo's M6/M7 benchmark tasks
(and their successors M13/M14 in the stacked PRs), now documented as a
reusable skill instead of tribal knowledge.

The skill produces `tasks/<id>/` with the full self-contained layout
(fixture + `instruction.md` + `task.toml` + `judge.mjs` + `solution/`),
scoreable 0–1 via `harbor run` and foldable into this repo's `benchmark/`.

Contents:

- `SKILL.md` — decision flow: case selection → host archaeology → fixture &
  trap design → judge boundaries → solution → registry sync;
- `references/` — selection criteria, Harbor task spec, contract clauses
  (BENCHMARK-AUTH-v1), grading recipe, host archaeology, registry sync
  discipline;
- `assets/` — template files (Dockerfile, task.toml, judge.mjs, judge-utils,
  instruction, solve.sh, test.sh) matching this repo's benchmark v2.3 format.

## Scope Checklist

- [x] I checked existing Issues and PRs for overlap and coordinated any related work.
- [x] For version-specific work, I used exact DSH tags or commit hashes, not `latest` or inferred versions.
- [x] I cited fixed first-party sources for version-specific claims.
- [x] This is a new standalone skill, not a migration or version-card change.

## Verification

Commands run:

```text
node scripts/validate.mjs
node scripts/validate-manifests.mjs
```

Both pass: `Validation OK: 9 skill, 5 card sets, 45 cards ...`;
`Manifest validation passed: 4 manifests, version 0.1.0-alpha.2`.

Additional checks:

- [x] The skill is self-contained — every relative link stays inside
  `skills/dsh-benchmark-case/` (validate.mjs enforces this);
- [x] Frontmatter is flat single-line (name/description/license) per
  validate.mjs's parser;
- [x] Manifests pick the skill up automatically via their `"skills"` directory
  reference (no per-skill manifest edits needed);
- [x] README.md skill count updated 8 → 9; catalog tables updated in
  `skills/README.md` and `skills/README.en.md`.

Unverified boundaries: the skill's authoring output for a brand-new case
beyond M6/M7 has not been re-executed end-to-end as part of this PR (M6/M7
themselves went through full in-container oracle verification in their own
PRs); the two template judge utils are byte-identical to the upstream H3 copy.

## Review Notes

The original standalone repo this skill was developed in
(dsh-benchmark-case-skill) stays as the development upstream; this PR mirrors
the skill into the repo whose benchmark it serves, so future case authors find
it next to the tasks. If you prefer PRs to precede independently, this PR has
no dependency on #126/#127 — the skill is self-contained.