### PR TITLE
docs(paper): add Jiming Ye as co-author

### DIFF
--- a/paper/latex/acl_latex.tex
+++ b/paper/latex/acl_latex.tex
@@ -78,7 +78,11 @@
   \And
   William Jin \\
   Independent Researcher \\
-  \texttt{williamjinq@gmail.com} \\}
+  \texttt{williamjinq@gmail.com} \\
+  \And
+  Jiming Ye \\
+  Shenzhen University \\
+  \texttt{jiming\_ye@163.com} \\}
 
 \begin{document}
 \maketitle


### PR DESCRIPTION
## Summary

Adds an author entry to the ACL author block in `paper/latex/acl_latex.tex`, following the maintainer's request that contributors submit their names.

- **Jiming Ye** — Shenzhen University — `jiming_ye@163.com`

Contribution context:

- #10, #19, and #24 — added the plugin writing/testing skills, made them standalone, and completed their English documentation.
- #65 and #72 — corrected the client-runtime API migration guide and added the unattended benchmark execution contract.
- #89, #103, and #129 — added real-project benchmark tasks and paired Luna/Terra result coverage, including the dsh-web and dsh-data-agent alpha.2 cases.

Single file, one author entry, no other change. Appended after the current last entry; if #118 or #119 lands first, this branch will be rebased so the final author order remains append-only.

Note: the document currently builds with `\usepackage[review]{acl}`, which replaces the author block with "Anonymous ACL submission". This entry renders once the option is switched to `final` or `preprint`.

## Scope Checklist

- [x] I checked existing Issues and PRs for overlap and coordinated any related work. PRs #118 and #119 touch the same author block; the merge-order dependency is noted above.
- [ ] For version-specific work, I used exact DSH tags or commit hashes, not `latest` or inferred versions. — not applicable.
- [ ] I cited fixed first-party sources for version-specific claims. — not applicable.
- [ ] For migration or card work, I listed the affected touchpoints (`#1`-`#7`) and complete card IDs. — not applicable.
- [ ] I kept Host, Web Client, and ordinary Cordis plugin faces distinct. — not applicable.
- [ ] For benchmark result or validation-report PRs, the report states the consumed tokens and the total run duration per round (as recorded by Harbor's trial outputs). — not applicable.

## Verification

Commands run:

```text
node scripts/validate.mjs
node scripts/validate-manifests.mjs
git diff --check
```

Additional checks:

- [x] I ran the focused source check for the updated `\author{}` block.
- [x] I reviewed the complete diff and `git diff --check`.

Unverified boundaries (providers, browsers, operating systems, credentials, or product entry points):

- Not compiled with `pdflatex` locally because a LaTeX toolchain is not installed in the current environment.

## Review Notes

- PRs #118 and #119 independently append authors to the same block; this PR may need a trivial rebase depending on merge order.
- The underscore in the email address is escaped for LaTeX source while preserving the rendered address.
