### PR TITLE
fix(benchmark): scope peer cohort checks to dsh packages

### DIFF
--- a/benchmark/tasks/H14-mineru-api/tests/judge.mjs
+++ b/benchmark/tasks/H14-mineru-api/tests/judge.mjs
@@ -5,7 +5,7 @@
 //        + rpc.handle carries exactly (channel, handler) — no authority option (10)
 //        + ConnectionRpcResult type source declared (10)
 //        + dsh.client.inject drops dsh-client-runtime (5) and names dsh-client-connection (5)
-//        + every @deepseek-ai peer floor sits on the 0.1.2-alpha cohort (10);
+//        + every @deepseek-ai/dsh-* peer floor sits on the 0.1.2-alpha cohort (10);
 //   25 — real container verification: `dsh plugin add` succeeds (8), web cold boot with
 //        no negative signal (9), __DSH_BOOT__.entries lists the client entry (8);
 //   10 — version bumped vs the git baseline (6) + "private": true preserved (4).
@@ -228,14 +228,14 @@ function scoreStatic() {
 
   // (e) the peer cohort.
   const peers = pkg.peerDependencies ?? {}
-  const dshPeers = Object.entries(peers).filter(([k]) => k.startsWith('@deepseek-ai/'))
+  const dshPeers = Object.entries(peers).filter(([k]) => k.startsWith('@deepseek-ai/dsh-'))
   const offCohort = dshPeers.filter(([, v]) => !ALPHA_COHORT.test(String(v)))
   if (dshPeers.length > 0 && offCohort.length === 0) {
     score += 10
-    reasons.push(`all ${dshPeers.length} @deepseek-ai peer floors sit on the 0.1.2-alpha cohort (+10)`)
+    reasons.push(`all ${dshPeers.length} @deepseek-ai/dsh-* peer floors sit on the 0.1.2-alpha cohort (+10)`)
   } else {
     allPassed = false
-    reasons.push(`peer floors off the 0.1.2-alpha cohort: ${offCohort.map(([k, v]) => `${k}@${v}`).join(', ') || 'no @deepseek-ai peers declared'}`)
+    reasons.push(`peer floors off the 0.1.2-alpha cohort: ${offCohort.map(([k, v]) => `${k}@${v}`).join(', ') || 'no @deepseek-ai/dsh-* peers declared'}`)
   }
 
   return { score, allPassed, authorityRetained, apiproxyRetained, reasons }

--- a/benchmark/tasks/M11-sidebar-spur/tests/judge.mjs
+++ b/benchmark/tasks/M11-sidebar-spur/tests/judge.mjs
@@ -240,14 +240,14 @@ function scoreStatic() {
 
   // (e) the peer cohort.
   const peers = pkg.peerDependencies ?? {}
-  const dshPeers = Object.entries(peers).filter(([k]) => k.startsWith('@deepseek-ai/'))
+  const dshPeers = Object.entries(peers).filter(([k]) => k.startsWith('@deepseek-ai/dsh-'))
   const offCohort = dshPeers.filter(([, v]) => !ALPHA_COHORT.test(String(v)))
   if (dshPeers.length > 0 && offCohort.length === 0) {
     score += 8
-    reasons.push(`all ${dshPeers.length} @deepseek-ai peer floors sit on the 0.1.2-alpha cohort (+8)`)
+    reasons.push(`all ${dshPeers.length} @deepseek-ai/dsh-* peer floors sit on the 0.1.2-alpha cohort (+8)`)
   } else {
     allPassed = false
-    reasons.push(`peer floors off the 0.1.2-alpha cohort: ${offCohort.map(([k, v]) => `${k}@${v}`).join(', ') || 'no @deepseek-ai peers declared'}`)
+    reasons.push(`peer floors off the 0.1.2-alpha cohort: ${offCohort.map(([k, v]) => `${k}@${v}`).join(', ') || 'no @deepseek-ai/dsh-* peers declared'}`)
   }
 
   // (f) no bare `cordis` peer; the scoped cordis peer at ^4.0.1 exactly.

--- a/benchmark/tasks/M12-interpreters-card/tests/judge.mjs
+++ b/benchmark/tasks/M12-interpreters-card/tests/judge.mjs
@@ -5,7 +5,7 @@
 //        + createSnapshotStore/SnapshotStore re-anchored to dsh-client-store (10)
 //        + the dsh-settings type renamed Settings -> SettingsProvider (10)
 //        + dsh.client.inject recomposed to the POST list exactly (10)
-//        + every @deepseek-ai peer floor sits on the 0.1.2-alpha cohort (10);
+//        + every @deepseek-ai/dsh-* peer floor sits on the 0.1.2-alpha cohort (10);
 //   25 — real container verification: `dsh plugin add` succeeds (8), web cold boot with
 //        no negative signal (9), __DSH_BOOT__.entries lists the client entry (8);
 //   10 — version bumped vs the git baseline (6) + "private": true preserved (4).
@@ -235,14 +235,14 @@ function scoreStatic() {
 
   // (e) the peer cohort.
   const peers = pkg.peerDependencies ?? {}
-  const dshPeers = Object.entries(peers).filter(([k]) => k.startsWith('@deepseek-ai/'))
+  const dshPeers = Object.entries(peers).filter(([k]) => k.startsWith('@deepseek-ai/dsh-'))
   const offCohort = dshPeers.filter(([, v]) => !ALPHA_COHORT.test(String(v)))
   if (dshPeers.length > 0 && offCohort.length === 0) {
     score += 10
-    reasons.push(`all ${dshPeers.length} @deepseek-ai peer floors sit on the 0.1.2-alpha cohort (+10)`)
+    reasons.push(`all ${dshPeers.length} @deepseek-ai/dsh-* peer floors sit on the 0.1.2-alpha cohort (+10)`)
   } else {
     allPassed = false
-    reasons.push(`peer floors off the 0.1.2-alpha cohort: ${offCohort.map(([k, v]) => `${k}@${v}`).join(', ') || 'no @deepseek-ai peers declared'}`)
+    reasons.push(`peer floors off the 0.1.2-alpha cohort: ${offCohort.map(([k, v]) => `${k}@${v}`).join(', ') || 'no @deepseek-ai/dsh-* peers declared'}`)
   }
 
   if (runtimeRetained) allPassed = false


### PR DESCRIPTION
## Summary

Fix H14, M11, and M12 cohort grading so only `@deepseek-ai/dsh-*` peers use the `0.1.2-alpha` range. Cordis keeps its separate `^4.0.1` contract.

## Scope Checklist

- [x] I checked existing Issues and PRs for overlap; none found.
- [x] I retained the exact existing DSH prerelease contract.
- [x] No new version claims, sources, migration cards, or result reports.
- [x] I kept DSH packages and Cordis distinct.

## Verification

Commands run:

```text
npm test
```

Additional checks:

- [x] H14, M11, and M12 reference solutions score `50/50` with `allPassed=true`.
- [x] An off-cohort DSH peer is still rejected.
- [x] I reviewed the complete diff and ran `git diff --check`.

Unverified boundaries:

Full Harbor runtime was not rerun; this only changes static peer classification.

## Review Notes

Found during the full benchmark task review.