### PR TITLE
fix(benchmark): isolate closed-book task agents

### DIFF
--- a/benchmark/scripts/validate-execution-contract.mjs
+++ b/benchmark/scripts/validate-execution-contract.mjs
@@ -139,6 +139,15 @@ for (const [taskId, mode] of expectedModes) {
     fail(taskFile, 'task version must be 1.1.0 for BENCHMARK-AUTH-v1')
   }
 
+  // A prompt-level closed-book clause is not an execution boundary: every task
+  // that declares one must also disable agent-container network access.
+  if (/closed-book|闭卷/i.test(normalized)) {
+    const agentBlock = taskToml.match(/\[agent\]([\s\S]*?)(?=\n\[|$)/)?.[1] ?? ''
+    if (!/^network_mode = "no-network"$/m.test(agentBlock)) {
+      fail(taskFile, 'closed-book task agent must run with no network')
+    }
+  }
+
   if (taskId === 'H9-dsh-web-alpha2') {
     const agentBlock = taskToml.match(/\[agent\]([\s\S]*?)(?=\n\[|$)/)?.[1] ?? ''
     const verifierBlock = taskToml.match(/\[verifier\]([\s\S]*?)(?=\n\[|$)/)?.[1] ?? ''

--- a/benchmark/tasks/H6-remote-error-trap/task.toml
+++ b/benchmark/tasks/H6-remote-error-trap/task.toml
@@ -15,6 +15,7 @@ execution_contract = "BENCHMARK-AUTH-v1"
 
 [agent]
 timeout_sec = 600.0
+network_mode = "no-network"
 
 [verifier]
 timeout_sec = 120.0

--- a/benchmark/tasks/S4-legacy-client-imports/task.toml
+++ b/benchmark/tasks/S4-legacy-client-imports/task.toml
@@ -15,6 +15,7 @@ execution_contract = "BENCHMARK-AUTH-v1"
 
 [agent]
 timeout_sec = 600.0
+network_mode = "no-network"
 
 [verifier]
 timeout_sec = 120.0

--- a/benchmark/tasks/S5-negative-naming/task.toml
+++ b/benchmark/tasks/S5-negative-naming/task.toml
@@ -15,6 +15,7 @@ execution_contract = "BENCHMARK-AUTH-v1"
 
 [agent]
 timeout_sec = 600.0
+network_mode = "no-network"
 
 [verifier]
 timeout_sec = 120.0

--- a/benchmark/tasks/S6-corridor-net-state/task.toml
+++ b/benchmark/tasks/S6-corridor-net-state/task.toml
@@ -15,6 +15,7 @@ execution_contract = "BENCHMARK-AUTH-v1"
 
 [agent]
 timeout_sec = 600.0
+network_mode = "no-network"
 
 [verifier]
 timeout_sec = 120.0

--- a/benchmark/tasks/S7-unpublished-cohort/task.toml
+++ b/benchmark/tasks/S7-unpublished-cohort/task.toml
@@ -15,6 +15,7 @@ execution_contract = "BENCHMARK-AUTH-v1"
 
 [agent]
 timeout_sec = 600.0
+network_mode = "no-network"
 
 [verifier]
 timeout_sec = 120.0


### PR DESCRIPTION
## Summary

Enforce agent-level network isolation for the five written tasks that explicitly declare a closed-book contract: H6, S4, S5, S6, and S7.

Each task now sets `network_mode = "no-network"` in its `[agent]` block. The execution-contract validator also rejects any task whose brief declares `closed-book` or `闭卷` without the matching agent policy, so future tasks and regressions cannot rely on prompt compliance alone.

## Scope Checklist

- [x] I checked existing Issues and PRs for overlap and found no duplicate work.
- [x] Version-specific source requirements are not applicable; this PR does not change migration facts or version claims.
- [x] Migration-card schema, touchpoints, and card IDs are not applicable; no cards are changed.
- [x] Host, Web Client, and ordinary Cordis plugin guidance is unchanged.
- [x] Benchmark-result token and duration reporting is not applicable; no result or validation report is added.

## Verification

Commands run:

```text
npm test
git diff --check
```

Additional checks:

- [x] The focused execution-contract validation passed for all 42 tasks.
- [x] Task TOML syntax and task-registry validation passed.
- [x] I reviewed the complete diff and confirmed the PR contains one commit changing only the six intended files.

Unverified boundaries:

- No live Harbor trial was launched. The agent network policy and regression guard were validated through the repository's configuration and contract test suite.
- Provider-side web search is outside `task.toml` container-network enforcement and still needs to be disabled by the selected runner when that capability exists; the five task briefs already prohibit network search.

## Review Notes

The shared environment remains public, matching the existing H9/H11 pattern; the agent-specific override is the boundary that prevents task-solving egress.

## Acknowledgements

Thanks to the review that identified the mismatch between the closed-book briefs and their executable agent policy.
