### PR TITLE
docs(paper): add Yucheng Xia as co-author

### DIFF
--- a/paper/latex/acl_latex.tex
+++ b/paper/latex/acl_latex.tex
@@ -82,7 +82,11 @@
   \And
   Jiming Ye \\
   Shenzhen University \\
-  \texttt{jiming\_ye@163.com} \\}
+  \texttt{jiming\_ye@163.com} \\
+  \And
+  Yucheng Xia \\
+  Harbin Engineering University \\
+  \texttt{Fisfzy@qq.com} \\}
 
 \begin{document}
 \maketitle


### PR DESCRIPTION
## Summary

Adds an author entry to the ACL author block in `paper/latex/acl_latex.tex`, following the maintainer's request that contributors submit their names.

- **Yucheng Xia** — Harbin Engineering University — `Fisfzy@qq.com`

Contribution context (`@Fisfzy`):

- `#27` — added the client-half migration card chain for DSH 0.1.2: four alpha.1 cards (`DSH-0.1.2-A1-25` client-runtime removal symbol→package map + `dsh.client.inject` phantom-dependency cleanup, `A1-26` three-point registration-id alignment / bare-package-name assembly rows, `A1-27` session-content reads via the `SessionBinding` durable event window, `A1-28` composer `textarea` → contenteditable DIV dual-track compatibility), plus rollup `R-09` (local `link:` + junction install track), a pre-flight scan enhancement (touchpoints #5/#6), and the new `references/troubleshooting.md` symptom→root-cause→card map. Grounded in a full migration of `dsh-input-history` 0.1.1 → 0.2.0 (a real third-party client plugin; Windows + staging + browser e2e, 2026-08), verified against the `dsh-v0.1.2-alpha.1` tag.

> This card chain covers the client-half migration surface — the removed `dsh-client-runtime` mapping, the registration-id contract, session-content reads, composer DOM drift, and the local `link:` install track — that the paper's task-to-card pipeline and its client-plane task coverage rest on. It coordinates with #26 (the `A1-29..31` / `A2-10` / `R-08` host-registry chain) and cross-references #67 profile-dependency management; the recent multi-plugin alpha.4/alpha.5 adaptation work lives in the companion plugin repositories and is out of scope for this paper's benchmark/skill corpus.

Single file, `\and`-separated entry appended inside the existing `\author{}` block (the closing `\}` moves to the last entry), no other change. If the open co-author PRs (#118/#119/#130/#133) land first I will rebase onto them.

Note: the document currently builds with `\usepackage[review]{acl}`, which replaces the author block with "Anonymous ACL submission". This entry only renders once the option is switched to `final` or `preprint`.

## Scope Checklist

- [x] I checked existing Issues and PRs for overlap and coordinated any related work.
- [ ] For version-specific work, I used exact DSH tags or commit hashes, not `latest` or inferred versions. — not applicable.
- [ ] I cited fixed first-party sources for version-specific claims. — not applicable.
- [ ] For migration or card work, I listed the affected touchpoints (`#1`-`#7`) and complete card IDs. — not applicable.
- [ ] I kept Host, Web Client, and ordinary Cordis plugin faces distinct. — not applicable.
- [ ] For benchmark result or validation-report PRs, the report states the consumed tokens and the total run duration per round. — not applicable, no result content in this PR.

## Verification

```text
node scripts/validate.mjs
node scripts/validate-manifests.mjs
git diff --check
```

All pass. Brace nesting of `\author{}` unchanged; the closing `}` moves to the new final entry.

Unverified boundaries: not compiled with `pdflatex` locally because a LaTeX toolchain is not installed in the current environment.

## Review Notes

- Name order follows the ACL convention of given name before family name (Yucheng Xia), as provided.
- The institution name "Harbin Engineering University" is the author's official English name; happy to switch if a different official rendering is preferred.
- The contact address is used verbatim as provided; happy to switch to an institutional address, or to move this to Acknowledgments instead of the byline, if that better matches your intent.
