### PR TITLE
feat(benchmark): S12 global-upgrade EBUSY+downgrade + S13 peer-range-vs-runtime (tasks 43-44)

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,7 +1,7 @@
 # dsh plugin upgrade tasks (benchmark v2.4 · Harbor format)
 
-The 47 plugin-upgrade tasks measure one thing: **once an AI has our upgrade skill
-installed, will it actually upgrade the plugin**. The first 14 are written exams (read
+The 49 plugin-upgrade tasks measure one thing: **once an AI has our upgrade skill
+installed, will it actually upgrade the plugin**. The first 16 are written exams (read
 the code, produce the answer); the last 33 are hands-on (actually install dsh and run
 the plugin — whether it is alive is obvious at a glance). Every task ships with
 auto-grading, so no human marking is involved.
@@ -44,6 +44,8 @@ honestly instead of quietly fixing it and pretending nothing happened).
 | S9-composer-coordinate-trap | Static | A community attachment plugin works on the first paste then fails every later one, and the dock × leaves an `unavailable` chip — can it tie both symptoms to one coordinate-projection misread and derive the conversion from host source |
 | S10-paste-rename-and-version-chip | Static | Post-release follow-ups: pasted files need unified `paste_image(N)` renaming driven by the authoritative live-chip set (drops/picker untouched), and the version chip reported a CDN-stale fetched tag as latest — can it design both correctly |
 | S11-mermaid-lazyload-trap | Static | A lazy-loaded mermaid chunk rollout fails three ways: split-chunk sibling imports 404, a Windows-only 403 from a case-sensitive containment guard, and a Ctrl+scroll double-fire under the zoom modal — can it derive each mechanism from the evidence |
+| S12-global-upgrade-ebusy-trap | Static | A user upgrades dsh and fails twice: EBUSY on koffi.node (running process holds a native-module lock) then a silent downgrade to rc.2 (unpinned npm install follows the latest dist-tag) — can it diagnose both and give the safe upgrade sequence |
+| S13-peer-range-vs-runtime | Static | A TUI plugin's peerDependencies claim ^0.1.2-alpha.2 (npm installs without warnings) but it crashes on dsh alpha.5 because alpha.4 removed Session.events — can it distinguish peer range satisfaction from runtime API compatibility |
 | M2-optional-dep-trap | Hands-on | The plugin declares an optional dependency but imports it unconditionally at top level (the comment says optional is harmless): does it fix the dependency contract instead of wrapping the import, and prove it with a cold boot |
 | M3-session-projection | Hands-on | A self-assembled profile mounts dsh-tool-todo without the sessionProjections service: does it fix the composition (never edit shipped packages) so the tree activates while the todo tool survives in the final composition |
 | M4-peer-prerelease-range | Hands-on | A peer lower bound written as ^0.1.0-rc.8 does not match 0.1.2-alpha.2 under npm semver's prerelease rule: does it rewrite the bound to the target cohort instead of widening it into a meaningless range |
@@ -231,7 +233,7 @@ harbor run -p benchmark/tasks/S1-static-scan -a oracle
 # evaluate a single task with an agent
 harbor run -p benchmark/tasks/M1-host-migration -a claude-code -m anthropic/claude-opus-4-1
 
-# all 47 tasks: pointing -p at the tasks/ directory runs them as a dataset batch
+# all 49 tasks: pointing -p at the tasks/ directory runs them as a dataset batch
 harbor run -p benchmark/tasks -a claude-code -m anthropic/claude-opus-4-1
 ```
 
@@ -243,7 +245,7 @@ the judge's per-item reasons are in the verifier log.
 
 ### Unattended authorization
 
-All 47 `instruction.md` files carry the `BENCHMARK-AUTH-v1` marker: the task prompt
+All 49 `instruction.md` files carry the `BENCHMARK-AUTH-v1` marker: the task prompt
 itself is the user's confirmation of the plan and the execution within the stated
 scope. The agent should complete the necessary analysis/planning and then proceed — it
 must not stop just because Harbor will not send a second round of "confirmation". The
@@ -420,7 +422,7 @@ numbers cannot be compared across models or against later runs.
   adding ordinary fixture tasks** — the point is to stop anyone from accidentally
   publishing fake plugins to npm.
 - When adding a task, scaffold it with `harbor task init`, then fill in
-  judge / solve.sh following the layout of the existing 47 tasks, and verify the
+  judge / solve.sh following the layout of the existing 49 tasks, and verify the
   reference answer scores 1.0 with `harbor run -p <task> -a oracle`.
 - After adding or modifying prompts, run
   `node benchmark/scripts/validate-execution-contract.mjs` to make sure the

--- a/benchmark/docs/scoring.md
+++ b/benchmark/docs/scoring.md
@@ -1,6 +1,6 @@
 # Scoring rules and checkpoint mapping
 
-Total 4700 (47 tasks × 100; the Harbor reward is 0–1, normalized as score/100).
+Total 4900 (49 tasks × 100; the Harbor reward is 0–1, normalized as score/100).
 Every judge: exit 0, with the last stdout line
 `{"score": 0-100, "max": 100, "reasons": [...]}`; `tests/test.sh` parses that last
 line as JSON and writes score/100 to `/logs/verifier/reward.txt`.
@@ -39,6 +39,8 @@ line as JSON and writes score/100 to `/logs/verifier/reward.txt`.
 | S9-composer-coordinate-trap | skills/plugin-runtime-debug (read-the-verb's-contract method; real 2026-09-01 dsh-paste-input v0.1.10 incident) | Five diagnosis aspects × 20: the two projections named (clipboard vs detect/U+FFFC), first-works-then-fails signature, unavailable traced to the declined verb + early bookkeeping delete, conversion rule at both call sites, repeat-interaction + removal regression plan; fixture modified → flat 0 (read-only discipline) |
 | S10-paste-rename-and-version-chip | skills/plugin-runtime-debug (authoritative-state + cached-remote-value families; same 2026-09-01 session's v0.1.10 rename feature and v0.1.11 chip fix) | Five design/diagnosis aspects × 20: rename scheme + numbering, authoritative conflict source (live chips; fragile records cache), paste-only scope, CDN-lagged fetched tag vs running version (show the newer), regression + lib-only release hygiene; fixture modified → flat 0 (read-only discipline) |
 | S11-mermaid-lazyload-trap | skills/plugin-heavy-dep (heavy-dependency lazy-load checklist; real 2026-09-01 dsh-file-trace mermaid integration, v0.2.3/v0.2.4) | Five diagnosis aspects × 20: split-chunk relative resolution + single-file fix, realpath drive-letter case → 403 mechanism, path.relative containment + JS MIME, modal wheel ownership, regression coverage; fixture modified → flat 0 (read-only discipline) |
+| S12-global-upgrade-ebusy-trap | real 2026-09-02 dsh alpha upgrade incident | Five × 20: koffi lock / stop process / dist-tag downgrade / pin version / README prevention |
+| S13-peer-range-vs-runtime | real 2026-09-02 dsh-tui crash | Five × 20: Session.events→snapshotEvents / peer=static not API / pass-peer-crash categories / author feature detect / user changelog check |
 | M6-sleep-tool | DSH-0.1.2-A2-03 peer hygiene (bare cordis contract, ContentBlock → dsh-llm); real @huanlin/dsh-plugin-sleep e25a4a9 | Static 50 (bare cordis gone 12 + @deepseek-ai/cordis 10 + dsh-tools floor 12 + dsh-llm peer 10 + meta optional 6) + headless activation 25 + diagnose 15 (exists 5, names 5, A2-03 3, R-01 2) + release 10; memo bait (keep bare cordis) caps at 60, changed-but-unfixed caps at 40 (M4 precedent) |
 | M7-d399-overlay | DSH-0.1.2-A1-25 client-runtime removal; DSH-0.1.2-A1-19 roster anchor | Static 50 (runtimeGone 10 + inject recomposed 10 + ISessions annotation 10 + cohort 12 + scoped cordis 8) + deploy 25 + diagnose 15 (exists 5, names 5, A1-25 3, R-01 2) + release 10; runtime retained caps at 20 |
 | M8-brand-text | DSH-0.1.2-A1-25 (store engine → dsh-client-store); rollup R-06 baseline attribution (H2 precedent) | Static 50 (runtimeGone + storeTypeSource + inject recomposed + cordis ^4.0.1 without -rc + cohort, 10 each) + deploy 25 + diagnose 15 incl. pre-existing-red-test honesty item + release 10; runtime retained caps at 20, store-bait retained caps at 60 |

--- a/benchmark/scripts/validate-execution-contract.mjs
+++ b/benchmark/scripts/validate-execution-contract.mjs
@@ -37,6 +37,8 @@ const expectedModes = new Map([
   ['S9-composer-coordinate-trap', 'readonly'],
   ['S10-paste-rename-and-version-chip', 'readonly'],
   ['S11-mermaid-lazyload-trap', 'readonly'],
+  ['S12-global-upgrade-ebusy-trap', 'readonly'],
+  ['S13-peer-range-vs-runtime', 'readonly'],
   ['H12-remote-result-boundary-trap', 'readonly'],
   ['M2-optional-dep-trap', 'mutable'],
   ['M3-session-projection', 'mutable'],

--- a/benchmark/tasks/S12-global-upgrade-ebusy-trap/README.md
+++ b/benchmark/tasks/S12-global-upgrade-ebusy-trap/README.md
@@ -1,6 +1,6 @@
 # S12-global-upgrade-ebusy-trap · Global upgrade EBUSY + downgrade trap (read-only)
 
-A user tries to upgrade dsh from alpha.5 to alpha.6 and fails twice: first EBUSY on
+A user tries to upgrade dsh from alpha.4 to alpha.5 and fails twice: first EBUSY on
 koffi.node (the running dsh host process holds an OS file lock on the native addon that a
 page refresh cannot release), then after stopping dsh, a combined install command from a
 plugin README silently downgrades dsh to rc.2 (unpinned npm install -g resolves to the

--- a/benchmark/tasks/S12-global-upgrade-ebusy-trap/README.md
+++ b/benchmark/tasks/S12-global-upgrade-ebusy-trap/README.md
@@ -1,0 +1,15 @@
+# S12-global-upgrade-ebusy-trap · Global upgrade EBUSY + downgrade trap (read-only)
+
+A user tries to upgrade dsh from alpha.5 to alpha.6 and fails twice: first EBUSY on
+koffi.node (the running dsh host process holds an OS file lock on the native addon that a
+page refresh cannot release), then after stopping dsh, a combined install command from a
+plugin README silently downgrades dsh to rc.2 (unpinned npm install -g resolves to the
+`latest` dist-tag, not the current or newest version). 题面见 [instruction.md](instruction.md)，
+判分逻辑见 [tests/judge.mjs](tests/judge.mjs)。
+
+- **Environment**: `node:24-bookworm` + git (fixture baseline-committed for the read-only gate).
+- **Verifier**: judge checks the fixture is unchanged + five diagnosis aspects, 0-100.
+- **Oracle**: `harbor run -p benchmark/tasks/S12-global-upgrade-ebusy-trap -a oracle`, expected 1.0.
+
+Fixture provenance: trimmed from a real 2026-09-02 upgrade incident (dsh alpha.4→alpha.5,
+author's own session).

--- a/benchmark/tasks/S12-global-upgrade-ebusy-trap/environment/Dockerfile
+++ b/benchmark/tasks/S12-global-upgrade-ebusy-trap/environment/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:24-bookworm
+
+# git 供 judge 检测 fixture 是否被改动（只读纪律门禁）
+RUN apt-get update && apt-get install -y --no-install-recommends git     && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY fixture /app/fixture
+
+# 基线提交：judge 用 `git status --porcelain -- fixture` 判定 agent 是否守只读纪律
+RUN git init -q && git add -A && git -c user.email=bench@local -c user.name=bench commit -q -m "baseline"

--- a/benchmark/tasks/S12-global-upgrade-ebusy-trap/environment/fixture/README.md
+++ b/benchmark/tasks/S12-global-upgrade-ebusy-trap/environment/fixture/README.md
@@ -1,0 +1,9 @@
+# S12 fixture - Global upgrade evidence pack (static)
+
+Evidence for the S12-global-upgrade-ebusy-trap task. **Read-only fixture - do not execute or publish
+anything here**; the task grading requires this directory to be unchanged relative to git HEAD.
+
+- `attempt1-ebusy.log` - npm install -g output while dsh is running
+- `attempt2-downgrade.log` - npm install + version check after the EBUSY fix
+- `npm-dist-tags.txt` - the @deepseek-ai/dsh dist-tags listing at the time
+- `running-processes.txt` - what was running during attempt 1

--- a/benchmark/tasks/S12-global-upgrade-ebusy-trap/environment/fixture/attempt1-ebusy.log
+++ b/benchmark/tasks/S12-global-upgrade-ebusy-trap/environment/fixture/attempt1-ebusy.log
@@ -1,0 +1,5 @@
+$ npm install -g @deepseek-ai/dsh@0.1.2-alpha.5
+npm error code EBUSY
+npm error syscall copyfile
+npm error path C:\...\@koromix\koffi-win32-x64\win32_x64\koffi.node
+npm error dest C:\...\@deepseek-ai\.dsh-TMPDIR\...\koffi.node

--- a/benchmark/tasks/S12-global-upgrade-ebusy-trap/environment/fixture/attempt2-downgrade.log
+++ b/benchmark/tasks/S12-global-upgrade-ebusy-trap/environment/fixture/attempt2-downgrade.log
@@ -1,0 +1,4 @@
+$ npm install -g @deepseek-ai/dsh @deepseek-harness-tui/dsh-tui
+(installs fine, but...)
+$ dsh --version
+0.1.1-rc.2

--- a/benchmark/tasks/S12-global-upgrade-ebusy-trap/environment/fixture/npm-dist-tags.txt
+++ b/benchmark/tasks/S12-global-upgrade-ebusy-trap/environment/fixture/npm-dist-tags.txt
@@ -3,5 +3,5 @@ $ npm view @deepseek-ai/dsh dist-tags
 {
   next: '0.1.1-rc.2',
   latest: '0.1.1-rc.2',
-  alpha: '0.1.2-alpha.6'
+  alpha: '0.1.2-alpha.5'
 }

--- a/benchmark/tasks/S12-global-upgrade-ebusy-trap/environment/fixture/npm-dist-tags.txt
+++ b/benchmark/tasks/S12-global-upgrade-ebusy-trap/environment/fixture/npm-dist-tags.txt
@@ -1,0 +1,7 @@
+# npm view @deepseek-ai/dsh dist-tags (at the time of the upgrade attempt)
+$ npm view @deepseek-ai/dsh dist-tags
+{
+  next: '0.1.1-rc.2',
+  latest: '0.1.1-rc.2',
+  alpha: '0.1.2-alpha.6'
+}

--- a/benchmark/tasks/S12-global-upgrade-ebusy-trap/environment/fixture/running-processes.txt
+++ b/benchmark/tasks/S12-global-upgrade-ebusy-trap/environment/fixture/running-processes.txt
@@ -1,0 +1,12 @@
+# Process listing at the time of attempt 1 (EBUSY):
+$ tasklist /FI "IMAGENAME eq node.exe"
+Image Name        PID    Session
+node.exe          42432  Console     <- dsh web host (holds koffi.node)
+node.exe          23768  Console     <- agent session worker
+node.exe          23920  Console     <- npm install -g (attempting the copy)
+
+# The dsh web host process loaded @koromix/koffi (a native FFI addon for
+# sandbox/filesystem operations) at startup. koffi.node is a native .node
+# binary - once loaded into a process, the OS holds a file lock on it until
+# the process exits. Refreshing the browser page only reloads the SPA; the
+# host process (which loaded koffi) stays alive.

--- a/benchmark/tasks/S12-global-upgrade-ebusy-trap/instruction.md
+++ b/benchmark/tasks/S12-global-upgrade-ebusy-trap/instruction.md
@@ -1,0 +1,48 @@
+# S12 · Global Upgrade EBUSY + Downgrade Trap (Read-Only)
+
+## Unattended Evaluation Authorization (BENCHMARK-AUTH-v1)
+
+This is an unattended evaluation running in a disposable, isolated container; there will be no follow-up user messages. This task brief is itself the user's explicit authorization and confirmation for the approach and execution needed to complete the task: complete the necessary analysis and planning on your own, and keep executing as soon as the plan is formed — do not pause to wait for "confirmation", and do not ask the user follow-up questions. That confirmation continues to apply to the concrete plans you produce under the applicable skill, but only within the following scope:
+
+- You may inspect `/app/fixture/`, in-container local documentation, and local tools read-only; `/app/fixture/` must remain completely unchanged; you may write your report into the designated `/app/agent-output/` directory as the brief specifies;
+- You may create temporary files needed for the report and run read-only local scan commands, but you must not execute migrations or installations;
+- You must not modify the skill, the evaluator, or the reference answers, and you must not publish, push, access external services, or alter resources outside the container;
+- If you cannot complete the task, state the blocker honestly, but do not stop merely because another round of confirmation is missing.
+
+I maintain a DSH installation on Windows with six community Web plugins installed across three GitHub mirrors.
+The currently running dsh is `0.1.2-alpha.5`. A new release `dsh-v0.1.2-alpha.6` just dropped and I want to
+upgrade. My attempt fails — twice, in different ways. The evidence pack in `/app/fixture/` (read-only — do not
+modify) contains my terminal session captures and the npm dist-tags listing.
+
+**What I did and saw:**
+
+1. **Attempt 1 (install while dsh is running)**:
+   ```
+   $ npm install -g @deepseek-ai/dsh@0.1.2-alpha.6
+   npm error code EBUSY
+   npm error syscall copyfile
+   npm error path C:\...\@koromix\koffi-win32-x64\win32_x64\koffi.node
+   npm error dest C:\...\@deepseek-ai\.dsh-TMPDIR\...\koffi.node
+   ```
+
+2. **Attempt 2 (after stopping dsh, but using the official combined command from a plugin README)**:
+   ```
+   $ npm install -g @deepseek-ai/dsh @deepseek-harness-tui/dsh-tui
+   (installs fine, but...)
+   $ dsh --version
+   0.1.1-rc.2          ← NOT the alpha.6 I wanted!
+   ```
+
+**Your report** (write to `/app/agent-output/S12-global-upgrade-ebusy-trap/`, any filename):
+
+1. Attempt 1 root cause: WHY is `koffi.node` locked — what is holding it, and why does a browser-page refresh
+   not free the lock? What is the correct stop-then-upgrade sequence?
+2. Attempt 2 root cause: WHY did `dsh --version` show rc.2 instead of alpha.6 — what does the unpinned
+   `@deepseek-ai/dsh` in the combined command resolve to, and WHY? What npm dist-tag does it follow?
+3. The exact safe upgrade commands for my situation (I want alpha.6, and I also want the TUI plugin).
+4. Prevention: what should plugin README authors do differently with their install commands so this trap
+   cannot catch their users (the answer involves version pinning).
+
+What is tested: understanding that (a) a running dsh process holds a native-module file lock that a page
+refresh cannot release, and (b) `npm install -g <pkg>` without a version pin resolves to the `latest`
+dist-tag, not the currently installed or most recent version.

--- a/benchmark/tasks/S12-global-upgrade-ebusy-trap/instruction.md
+++ b/benchmark/tasks/S12-global-upgrade-ebusy-trap/instruction.md
@@ -10,39 +10,31 @@ This is an unattended evaluation running in a disposable, isolated container; th
 - If you cannot complete the task, state the blocker honestly, but do not stop merely because another round of confirmation is missing.
 
 I maintain a DSH installation on Windows with six community Web plugins installed across three GitHub mirrors.
-The currently running dsh is `0.1.2-alpha.5`. A new release `dsh-v0.1.2-alpha.6` just dropped and I want to
+The currently running dsh is `0.1.2-alpha.4`. A new release `dsh-v0.1.2-alpha.5` just dropped and I want to
 upgrade. My attempt fails — twice, in different ways. The evidence pack in `/app/fixture/` (read-only — do not
 modify) contains my terminal session captures and the npm dist-tags listing.
 
 **What I did and saw:**
 
-1. **Attempt 1 (install while dsh is running)**:
-   ```
-   $ npm install -g @deepseek-ai/dsh@0.1.2-alpha.6
-   npm error code EBUSY
-   npm error syscall copyfile
-   npm error path C:\...\@koromix\koffi-win32-x64\win32_x64\koffi.node
-   npm error dest C:\...\@deepseek-ai\.dsh-TMPDIR\...\koffi.node
-   ```
+1. **Attempt 1 (install while dsh is running)**: `npm install -g @deepseek-ai/dsh@0.1.2-alpha.5` fails with
+   EBUSY while copying `koffi.node` — full output in `attempt1-ebusy.log`. What else was running at the time is
+   in `running-processes.txt`.
 
-2. **Attempt 2 (after stopping dsh, but using the official combined command from a plugin README)**:
-   ```
-   $ npm install -g @deepseek-ai/dsh @deepseek-harness-tui/dsh-tui
-   (installs fine, but...)
-   $ dsh --version
-   0.1.1-rc.2          ← NOT the alpha.6 I wanted!
-   ```
+2. **Attempt 2 (after stopping dsh, but using the official combined command from a plugin README)**: the
+   combined install goes through fine, but `dsh --version` afterwards prints `0.1.1-rc.2` — NOT the alpha.5 I
+   wanted! Full session in `attempt2-downgrade.log`; the registry state at the time is in `npm-dist-tags.txt`.
 
 **Your report** (write to `/app/agent-output/S12-global-upgrade-ebusy-trap/`, any filename):
 
 1. Attempt 1 root cause: WHY is `koffi.node` locked — what is holding it, and why does a browser-page refresh
    not free the lock? What is the correct stop-then-upgrade sequence?
-2. Attempt 2 root cause: WHY did `dsh --version` show rc.2 instead of alpha.6 — what does the unpinned
+2. Attempt 2 root cause: WHY did `dsh --version` show rc.2 instead of alpha.5 — what does the unpinned
    `@deepseek-ai/dsh` in the combined command resolve to, and WHY? What npm dist-tag does it follow?
-3. The exact safe upgrade commands for my situation (I want alpha.6, and I also want the TUI plugin).
+3. The exact safe upgrade commands for my situation (I want alpha.5, and I also want the TUI plugin).
 4. Prevention: what should plugin README authors do differently with their install commands so this trap
-   cannot catch their users (the answer involves version pinning).
+   cannot catch their users.
 
-What is tested: understanding that (a) a running dsh process holds a native-module file lock that a page
-refresh cannot release, and (b) `npm install -g <pkg>` without a version pin resolves to the `latest`
-dist-tag, not the currently installed or most recent version.
+What is tested: diagnosing an OS-level install failure from the evidence (who holds the file, and what does
+and does not release it) rather than guessing, tracing what an unpinned global install actually resolves to at
+the registry instead of assuming it preserves or advances the installed version, and turning both diagnoses
+into a safe ordered upgrade procedure plus preventive guidance for README authors.

--- a/benchmark/tasks/S12-global-upgrade-ebusy-trap/solution/SOLUTION.md
+++ b/benchmark/tasks/S12-global-upgrade-ebusy-trap/solution/SOLUTION.md
@@ -5,7 +5,7 @@
 全局升级 dsh 的两个操作陷阱：① EBUSY——运行中的 dsh 宿主进程加载了原生模块
 koffi.node，OS 级文件锁持续到进程退出，刷新浏览器页面不释放（只有完全停止宿主进程
 才行）；② 降级陷阱——`npm install -g @deepseek-ai/dsh` 不带版本号会解析到 `latest`
-dist-tag（= rc.2），而不是当前安装的 alpha 版或最新 alpha 版，把已钉好的 alpha.5
+dist-tag（= rc.2），而不是当前安装的 alpha 版或最新 alpha 版，把已钉好的 alpha.4
 静默降级。正确姿势 = 完全停止 dsh → 钉版本安装 → 重启。预防 = README 安装命令必须
 钉版本。
 

--- a/benchmark/tasks/S12-global-upgrade-ebusy-trap/solution/SOLUTION.md
+++ b/benchmark/tasks/S12-global-upgrade-ebusy-trap/solution/SOLUTION.md
@@ -1,0 +1,24 @@
+# S12 参考解法
+
+## 考点（一句话）
+
+全局升级 dsh 的两个操作陷阱：① EBUSY——运行中的 dsh 宿主进程加载了原生模块
+koffi.node，OS 级文件锁持续到进程退出，刷新浏览器页面不释放（只有完全停止宿主进程
+才行）；② 降级陷阱——`npm install -g @deepseek-ai/dsh` 不带版本号会解析到 `latest`
+dist-tag（= rc.2），而不是当前安装的 alpha 版或最新 alpha 版，把已钉好的 alpha.5
+静默降级。正确姿势 = 完全停止 dsh → 钉版本安装 → 重启。预防 = README 安装命令必须
+钉版本。
+
+## 参考报告
+
+见 [report.md](report.md)，期望 judge 得分 100。
+
+## 判分要点
+
+只读门禁 + 五要点各 20：koffi 原生模块锁 / 必须完全停止进程（不是刷新页面）/ npm
+latest dist-tag 降级 / 钉版本安装 / README 预防。
+
+## fixture 出处
+
+裁剪自 2026-09-02 真实升级事故（dsh alpha.4→alpha.5 升级时 EBUSY + dsh-tui 安装时
+降级，作者亲历）。

--- a/benchmark/tasks/S12-global-upgrade-ebusy-trap/solution/report.md
+++ b/benchmark/tasks/S12-global-upgrade-ebusy-trap/solution/report.md
@@ -23,9 +23,9 @@ The combined command `npm install -g @deepseek-ai/dsh @deepseek-harness-tui/dsh-
 NOT preserve the currently-installed version of `@deepseek-ai/dsh`. Without a version
 specifier, npm resolves the package to its **`latest` dist-tag** — which, per the evidence
 (`npm-dist-tags.txt`), points to `0.1.1-rc.2` (the stable release channel), NOT to
-`0.1.2-alpha.6` (which is on the `alpha` dist-tag).
+`0.1.2-alpha.5` (which is on the `alpha` dist-tag).
 
-So the user's pinned alpha.5 install was silently replaced by the older rc.2 — a **downgrade**
+So the user's pinned alpha.4 install was silently replaced by the older rc.2 — a **downgrade**
 disguised as an install.
 
 ## 3. Safe upgrade commands
@@ -33,11 +33,11 @@ disguised as an install.
 ```sh
 # 1. Stop dsh completely (host process, not just the browser tab)
 # 2. Upgrade dsh with the EXACT version pinned
-npm install -g @deepseek-ai/dsh@0.1.2-alpha.6
+npm install -g @deepseek-ai/dsh@0.1.2-alpha.5
 # 3. Install the TUI plugin (separate command, dsh already handled)
 npm install -g @deepseek-harness-tui/dsh-tui
 # 4. Verify
-dsh --version    # should print 0.1.2-alpha.6
+dsh --version    # should print 0.1.2-alpha.5
 # 5. Restart
 dsh web
 ```
@@ -53,7 +53,7 @@ README install commands should ALWAYS pin the version:
 npm install -g @deepseek-ai/dsh @deepseek-harness-tui/dsh-tui
 
 # GOOD (pins the version the plugin was tested against):
-npm install -g @deepseek-ai/dsh@0.1.2-alpha.6 @deepseek-harness-tui/dsh-tui
+npm install -g @deepseek-ai/dsh@0.1.2-alpha.5 @deepseek-harness-tui/dsh-tui
 ```
 
 The rule: **an install command that can change what the user already has must specify

--- a/benchmark/tasks/S12-global-upgrade-ebusy-trap/solution/report.md
+++ b/benchmark/tasks/S12-global-upgrade-ebusy-trap/solution/report.md
@@ -1,0 +1,60 @@
+# S12 Global upgrade EBUSY + downgrade trap (reference answer)
+
+## 1. Attempt 1 root cause: running dsh host process holds an OS file lock on koffi.node
+
+The dsh web host process (node.exe PID 42432 in the evidence) loaded `@koromix/koffi` — a
+**native FFI addon** compiled as a `.node` binary — at startup. On Windows (and most OSes),
+once a native `.node` module is loaded into a process, the OS holds an **exclusive file lock**
+on the binary file until the process exits. `npm install -g` needs to copy/replace that file
+to update the package, and the copy fails with `EBUSY`.
+
+**Why refreshing the browser page doesn't help**: a page refresh only reloads the SPA
+(the web GUI in the browser). The **host process** (the Node.js process running dsh) is a
+separate process that stays alive — and it's the host process that loaded koffi. The lock
+is held at the OS process level, not the browser level.
+
+**Correct sequence**: fully **stop dsh** (close the web app AND the host process — `Ctrl+C`
+in the terminal running dsh, or kill the node.exe process), THEN run the npm install, THEN
+restart dsh.
+
+## 2. Attempt 2 root cause: unpinned npm install resolves to `latest` dist-tag
+
+The combined command `npm install -g @deepseek-ai/dsh @deepseek-harness-tui/dsh-tui` does
+NOT preserve the currently-installed version of `@deepseek-ai/dsh`. Without a version
+specifier, npm resolves the package to its **`latest` dist-tag** — which, per the evidence
+(`npm-dist-tags.txt`), points to `0.1.1-rc.2` (the stable release channel), NOT to
+`0.1.2-alpha.6` (which is on the `alpha` dist-tag).
+
+So the user's pinned alpha.5 install was silently replaced by the older rc.2 — a **downgrade**
+disguised as an install.
+
+## 3. Safe upgrade commands
+
+```sh
+# 1. Stop dsh completely (host process, not just the browser tab)
+# 2. Upgrade dsh with the EXACT version pinned
+npm install -g @deepseek-ai/dsh@0.1.2-alpha.6
+# 3. Install the TUI plugin (separate command, dsh already handled)
+npm install -g @deepseek-harness-tui/dsh-tui
+# 4. Verify
+dsh --version    # should print 0.1.2-alpha.6
+# 5. Restart
+dsh web
+```
+
+## 4. Prevention: plugin README authors must pin versions in install commands
+
+The root cause of attempt 2 is that a third-party plugin README showed an install command
+with an **unpinned** `@deepseek-ai/dsh`. This is a footgun for every user who follows it.
+README install commands should ALWAYS pin the version:
+
+```sh
+# BAD (resolves to latest = rc.2, silently downgrades alpha users):
+npm install -g @deepseek-ai/dsh @deepseek-harness-tui/dsh-tui
+
+# GOOD (pins the version the plugin was tested against):
+npm install -g @deepseek-ai/dsh@0.1.2-alpha.6 @deepseek-harness-tui/dsh-tui
+```
+
+The rule: **an install command that can change what the user already has must specify
+the exact version it intends to deliver.**

--- a/benchmark/tasks/S12-global-upgrade-ebusy-trap/solution/solve.sh
+++ b/benchmark/tasks/S12-global-upgrade-ebusy-trap/solution/solve.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Oracle solution: write the reference report to the agent output directory (does not touch the fixture, honoring read-only discipline).
+set -e
+mkdir -p /app/agent-output/S12-global-upgrade-ebusy-trap
+cp "$(dirname "$0")/report.md" /app/agent-output/S12-global-upgrade-ebusy-trap/report.md

--- a/benchmark/tasks/S12-global-upgrade-ebusy-trap/task.toml
+++ b/benchmark/tasks/S12-global-upgrade-ebusy-trap/task.toml
@@ -1,0 +1,25 @@
+schema_version = "1.4"
+# Harbor task config: dsh plugin global-upgrade operational traps (static, read-only)
+[task]
+name = "dsh-plugin-upgrade/s12-global-upgrade-ebusy-trap"
+version = "1.1.0"
+description = "Diagnose two failed dsh upgrades: EBUSY on koffi.node (running process holds a native-module lock) and a silent downgrade to rc.2 (unpinned npm install -g resolves to latest, not the desired alpha)"
+keywords = ["dsh", "plugin-release", "npm", "upgrade", "harbor"]
+
+[metadata]
+difficulty = "medium"
+category = "programming"
+tags = ["dsh", "plugin-release", "upgrade-safety", "english-prompt"]
+execution_contract = "BENCHMARK-AUTH-v1"
+
+[agent]
+timeout_sec = 300.0
+
+[verifier]
+timeout_sec = 120.0
+
+[environment]
+network_mode = "public"
+cpus = 1
+memory_mb = 2048
+storage_mb = 4096

--- a/benchmark/tasks/S12-global-upgrade-ebusy-trap/tests/judge-utils.mjs
+++ b/benchmark/tasks/S12-global-upgrade-ebusy-trap/tests/judge-utils.mjs
@@ -1,0 +1,191 @@
+// Shared benchmark grading library (harbor edition, zero dependencies).
+// Conventions:
+// - every judge.mjs always exits with code 0; the last stdout line outputs {"score": 0-100, "max": 100, "reasons": [...]};
+// - static tasks put agent artifacts under /app/agent-output/<task-id>/;
+// - container tasks (M1/H1/H2/H3) let the agent modify /app/fixture/ directly, and the judge does a real cold boot inside the task container
+//   (the image has dsh 0.1.2-alpha.2 installed globally, no docker exec needed);
+// - each task uses its own profile (bench-<task>) and its own /tmp plugin directory; the judge cleans up the assets it created.
+import { execFile } from 'node:child_process'
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs'
+import { join, relative, resolve, sep } from 'node:path'
+
+export const APP_ROOT = '/app'
+export const FIXTURE_DIR = join(APP_ROOT, 'fixture')
+export const DEFAULT_AGENT_OUTPUT = join(APP_ROOT, 'agent-output')
+export const BENCH_TMP = (taskId) => `/tmp/bench-${taskId.toLowerCase()}`
+export const PROFILE = (taskId) => `bench-${taskId.toLowerCase()}`
+
+// ── Result output ──────────────────────────────────────
+
+export function emit(score, reasons) {
+  const result = { score: Math.max(0, Math.min(100, Math.round(score))), max: 100, reasons }
+  process.stdout.write(JSON.stringify(result) + '\n')
+  process.exit(0)
+}
+
+// ── Agent output collection (static tasks) ─────────────
+
+const TEXT_EXT = new Set(['.md', '.txt', '.json', '.jsonl', '.log'])
+
+function walkFiles(dir) {
+  const out = []
+  if (!existsSync(dir)) return out
+  for (const entry of readdirSync(dir)) {
+    const path = join(dir, entry)
+    const stat = statSync(path)
+    if (stat.isDirectory()) out.push(...walkFiles(path))
+    else out.push(path)
+  }
+  return out
+}
+
+/** Collect all text artifacts under <agentOutput>/<taskId>/ and join them into one big string. */
+export function readAgentText(agentOutput, taskId) {
+  const root = agentOutput || DEFAULT_AGENT_OUTPUT
+  const dir = join(root, taskId)
+  const files = walkFiles(dir).filter((file) => TEXT_EXT.has(file.slice(file.lastIndexOf('.'))))
+  const text = files.map((file) => readFileSync(file, 'utf8')).join('\n\n')
+  return { text, files: files.map((file) => relative(root, file)) }
+}
+
+// ── Git status (whether the fixture changed) ───────────
+
+function git(args, cwd) {
+  return new Promise((resolvePromise) => {
+    execFile('git', args, { cwd, timeout: 20000 }, (error, stdout, stderr) => {
+      resolvePromise({ code: error?.code ?? 0, stdout, stderr: stderr ?? '' })
+    })
+  })
+}
+
+/** Return the fixture paths relative to APP_ROOT (modified/added/deleted). Empty array = unchanged. */
+export async function fixtureChanges(relFixtureDir = 'fixture') {
+  const result = await git(['status', '--porcelain', '--', relFixtureDir], APP_ROOT)
+  if (result.code !== 0) return { changed: null, detail: `git status failed: ${result.stderr.trim()}` }
+  const lines = result.stdout.split('\n').filter(Boolean)
+  return {
+    changed: lines.length > 0 ? true : false,
+    detail: lines.length ? lines.join('; ') : 'fixture unchanged relative to baseline',
+  }
+}
+
+// ── Local command primitives (judge runs in the task container) ──
+
+export function localExec(script, { stdin = '', timeout = 60000 } = {}) {
+  return new Promise((resolvePromise) => {
+    const child = execFile('sh', ['-c', script], { timeout }, (error, stdout, stderr) => {
+      resolvePromise({
+        code: error?.code ?? 0,
+        stdout: stdout ?? '',
+        stderr: stderr ?? '',
+        killed: error?.killed === true || (error && error.code === undefined) === true,
+      })
+    })
+    if (stdin) child.stdin.write(stdin)
+    child.stdin.end()
+  })
+}
+
+export async function dshAvailable() {
+  const result = await localExec('dsh --version', { timeout: 15000 })
+  return result.code === 0
+}
+
+// ── Profile lifecycle ──────────────────────────────────
+
+/** Create an isolated profile (bundles is an array of host package names). */
+export async function createProfile(profile, bundles) {
+  const dir = `/root/.dsh/profiles/${profile}`
+  const pkg = {
+    name: `dsh-profile-${profile}`,
+    private: true,
+    dependencies: {},
+    dsh: { profile: { bundles, patchReload: 'startup' } },
+  }
+  const write = await localExec(`rm -rf '${dir}' && mkdir -p '${dir}' && base64 -d > '${dir}/package.json'`, {
+    stdin: Buffer.from(JSON.stringify(pkg, null, 2) + '\n').toString('base64'),
+  })
+  if (write.code !== 0) return { ok: false, detail: `profile write failed: ${write.stderr.trim()}` }
+  const seed = await localExec(
+    `cp /root/.dsh/profiles/headless/pnpm-workspace.yaml '${dir}/' 2>/dev/null || printf 'packages:\\n  - .\\n\\nnodeLinker: hoisted\\nautoInstallPeers: false\\n' > '${dir}/pnpm-workspace.yaml'
+printf '[]\\n' > '${dir}/cordis.patch.yml'
+printf '[]\\n' > '${dir}/cordis.yml'`,
+  )
+  if (seed.code !== 0) return { ok: false, detail: `profile seed files failed: ${seed.stderr.trim()}` }
+  return { ok: true, dir }
+}
+
+export async function addPlugin(profile, pluginDir) {
+  const result = await localExec(`dsh plugin --profile '${profile}' add '${pluginDir}'`, { timeout: 180000 })
+  return { ok: result.code === 0, detail: (result.stdout + result.stderr).trim().slice(-400) }
+}
+
+/** Clean up task-created assets: profile, temporary plugin directory, leftover boot processes. */
+export async function cleanupProfile(profile, tmpDir) {
+  // The pkill pattern uses the [first-letter] bracket trick to avoid matching the sh -c process running this cleanup script itself.
+  const selfSafe = `[${profile[0]}]${profile.slice(1)}`
+  await localExec(
+    `pkill -f 'profile ${selfSafe}' 2>/dev/null; rm -rf '/root/.dsh/profiles/${profile}' '${tmpDir}' /tmp/${profile}-boot.log; true`,
+  )
+}
+
+// ── Cold boot signal detection ─────────────────────────
+
+export const NEGATIVE_SIGNAL = /plugin tree failed|did not activate|pending \(waiting for service|FAILED fiber|ClientPackageCompositionError/i
+// A headless profile without an API key always reaches MISSING_CREDENTIAL — emitting this line proves
+// the plugin tree fully activated and the boot flow reached the host application layer (consistent with the validation report attribution).
+export const HEADLESS_ACTIVATED_SIGNAL = /MISSING_CREDENTIAL|no API key|dsh: AUTH/i
+
+/** Headless cold boot: returns the full output. Exit code is not a verdict (success is also 1 without a key). */
+export async function bootHeadless(profile) {
+  const result = await localExec(`cd /root && timeout 30 dsh --profile '${profile}' 'ping' 2>&1`, { timeout: 60000 })
+  return { output: result.stdout + result.stderr, code: result.code }
+}
+
+/**
+ * Web cold boot and read __DSH_BOOT__:
+ * 1. start `dsh --profile <p> --no-open` in the background, wait for a dsh web: URL line in the log;
+ * 2. exchange the bootstrap token for a Cookie, GET / for the HTML;
+ * 3. return { output, html }; the caller judges negative signals and the plugin entry.
+ */
+export async function bootWebAndFetchIndex(profile, pkgName) {
+  const logPath = `/tmp/${profile}-boot.log`
+  await localExec(`cd /root && nohup timeout 45 dsh --profile '${profile}' --no-open > '${logPath}' 2>&1 & echo started`)
+  const probe = await localExec(
+    `node --input-type=module -e '
+const logPath = process.argv[1];
+const pkgName = process.argv[2];
+const fs = await import("node:fs");
+let log = "";
+for (let i = 0; i < 90; i += 1) {
+  try { log = fs.readFileSync(logPath, "utf8"); } catch {}
+  if (/dsh web: http|plugin tree failed|did not activate/i.test(log)) break;
+  await new Promise((r) => setTimeout(r, 1000));
+}
+const match = /dsh web: (http:\\S+)/.exec(log);
+const outcome = { log };
+if (match) {
+  try {
+    const r1 = await fetch(match[1], { redirect: "manual" });
+    const setCookie = r1.headers.getSetCookie ? r1.headers.getSetCookie() : [r1.headers.get("set-cookie")];
+    const cookie = setCookie.filter(Boolean).map((c) => c.split(";")[0]).join("; ");
+    const r2 = await fetch("http://127.0.0.1:3080/", { headers: { cookie } });
+    outcome.html = await r2.text();
+  } catch (error) {
+    outcome.fetchError = String(error);
+  }
+}
+console.log("__RESULT__" + JSON.stringify(outcome));
+' '${logPath}' '${pkgName}'`,
+    { timeout: 150000 },
+  )
+  const marker = '__RESULT__'
+  const idx = probe.stdout.lastIndexOf(marker)
+  if (idx < 0) return { output: probe.stdout + probe.stderr, html: '', probeError: probe.stderr.trim() }
+  try {
+    const outcome = JSON.parse(probe.stdout.slice(idx + marker.length).trim())
+    return { output: outcome.log ?? '', html: outcome.html ?? '', fetchError: outcome.fetchError }
+  } catch {
+    return { output: probe.stdout + probe.stderr, html: '', probeError: 'failed to parse boot result' }
+  }
+}

--- a/benchmark/tasks/S12-global-upgrade-ebusy-trap/tests/judge.mjs
+++ b/benchmark/tasks/S12-global-upgrade-ebusy-trap/tests/judge.mjs
@@ -1,0 +1,64 @@
+// S12-global-upgrade-ebusy-trap grading: fixture read-only gate + five diagnosis aspects.
+// Expected diagnosis:
+//   1. EBUSY root cause: the running dsh web HOST PROCESS loaded @koromix/koffi
+//      (a native .node addon). The OS holds a file lock on loaded .node binaries until
+//      the process exits. A browser page refresh only reloads the SPA; the host process
+//      stays alive and the lock persists.
+//   2. Downgrade root cause: npm install -g without a version pin resolves to the
+//      `latest` dist-tag (0.1.1-rc.2), NOT the currently-installed or newest version.
+//      The combined command unseated the pinned alpha.5 install.
+//   3. Safe sequence: fully stop dsh (not just refresh) -> npm install -g
+//      @deepseek-ai/dsh@0.1.2-alpha.6 (PINNED) -> npm install -g @deepseek-harness-tui/dsh-tui
+//      -> restart dsh.
+//   4. Prevention: plugin README install commands must always pin the version
+//      (e.g. @deepseek-ai/dsh@0.1.2-alpha.6), never a bare @deepseek-ai/dsh.
+//   5. The skill's lesson: a running process holds OS-level file locks on native
+//      modules that outlast page navigation; and npm dist-tags (latest vs alpha)
+//      are the real resolution target of unpinned installs.
+import { emit, fixtureChanges, readAgentText } from './judge-utils.mjs'
+
+const TASK = 'S12-global-upgrade-ebusy-trap'
+
+const ASPECTS = [
+  { key: 'EBUSY root cause: running dsh host process holds OS file lock on koffi.node (native addon), page refresh does not free it',
+    pattern: /koffi|(native.{0,30}(module|addon|binary))|\.node.{0,30}(lock|held|held|busy)/i, points: 20 },
+  { key: 'must fully stop/exit the dsh process, not just refresh the page',
+    pattern: /(stop|exit|kill|close|shut.?down).{0,120}(dsh|host|process)/i, points: 20 },
+  { key: 'downgrade root cause: unpinned npm install -g resolves to latest dist-tag (rc.2), not the desired version',
+    pattern: /latest|dist.?tag|(unpin|no.?version|without.{0,20}version)/i, points: 20 },
+  { key: 'safe upgrade: pin the version explicitly (@deepseek-ai/dsh@<exact-version>)',
+    pattern: /@deepseek-ai\/dsh@\d|pin|exact.{0,20}version|version.{0,20}pin/i, points: 20 },
+  { key: 'prevention: README install commands should pin versions so users never run unpinned global installs',
+    pattern: /README|install.{0,40}command|documentation|doc/i, points: 20 },
+]
+
+main().catch((error) => emit(0, [`judge error: ${error.message}`]))
+
+async function main() {
+  const reasons = []
+
+  const gate = await fixtureChanges('fixture')
+  if (gate.changed === true) {
+    emit(0, [`fixture was modified, 0 points for this task (read-only discipline): ${gate.detail}`])
+  }
+  if (gate.changed === null) reasons.push(`warning: ${gate.detail}`)
+  else reasons.push('fixture unchanged (read-only discipline passed)')
+
+  const { text, files } = readAgentText('', TASK)
+  if (!text.trim()) {
+    emit(0, [...reasons, `no report found under /app/agent-output/${TASK}/, treated as 0 points`])
+  }
+  reasons.push(`read agent report: ${files.join(', ')}`)
+
+  let score = 0
+  for (const aspect of ASPECTS) {
+    if (aspect.pattern.test(text)) {
+      score += aspect.points
+      reasons.push(`hit aspect: ${aspect.key} (+${aspect.points})`)
+    } else {
+      reasons.push(`missing aspect: ${aspect.key} (-${aspect.points})`)
+    }
+  }
+
+  emit(score, reasons)
+}

--- a/benchmark/tasks/S12-global-upgrade-ebusy-trap/tests/judge.mjs
+++ b/benchmark/tasks/S12-global-upgrade-ebusy-trap/tests/judge.mjs
@@ -6,12 +6,12 @@
 //      stays alive and the lock persists.
 //   2. Downgrade root cause: npm install -g without a version pin resolves to the
 //      `latest` dist-tag (0.1.1-rc.2), NOT the currently-installed or newest version.
-//      The combined command unseated the pinned alpha.5 install.
+//      The combined command unseated the pinned alpha.4 install.
 //   3. Safe sequence: fully stop dsh (not just refresh) -> npm install -g
-//      @deepseek-ai/dsh@0.1.2-alpha.6 (PINNED) -> npm install -g @deepseek-harness-tui/dsh-tui
+//      @deepseek-ai/dsh@0.1.2-alpha.5 (PINNED) -> npm install -g @deepseek-harness-tui/dsh-tui
 //      -> restart dsh.
 //   4. Prevention: plugin README install commands must always pin the version
-//      (e.g. @deepseek-ai/dsh@0.1.2-alpha.6), never a bare @deepseek-ai/dsh.
+//      (e.g. @deepseek-ai/dsh@0.1.2-alpha.5), never a bare @deepseek-ai/dsh.
 //   5. The skill's lesson: a running process holds OS-level file locks on native
 //      modules that outlast page navigation; and npm dist-tags (latest vs alpha)
 //      are the real resolution target of unpinned installs.

--- a/benchmark/tasks/S12-global-upgrade-ebusy-trap/tests/test.sh
+++ b/benchmark/tasks/S12-global-upgrade-ebusy-trap/tests/test.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Harbor verifier: run judge.mjs (its last line outputs a 0-100 score JSON), normalized to a 0~1 reward.
+# judge itself always exits 0; when no JSON can be parsed, treat the score as 0 (error-tolerant principle).
+mkdir -p /logs/verifier
+node /tests/judge.mjs > /tmp/judge.out 2>&1
+cat /tmp/judge.out
+node -e '
+const fs = require("node:fs");
+const lines = fs.readFileSync("/tmp/judge.out", "utf8").trim().split("\n").filter(Boolean);
+let score = 0;
+for (let i = lines.length - 1; i >= 0; i -= 1) {
+  try {
+    const j = JSON.parse(lines[i]);
+    if (typeof j.score === "number" && typeof j.max === "number") { score = j.score; break }
+  } catch {}
+}
+const reward = Math.max(0, Math.min(1, score / 100));
+fs.writeFileSync("/logs/verifier/reward.txt", String(reward) + "\n")
+'

--- a/benchmark/tasks/S13-peer-range-vs-runtime/README.md
+++ b/benchmark/tasks/S13-peer-range-vs-runtime/README.md
@@ -1,0 +1,14 @@
+# S13-peer-range-vs-runtime · Peer range vs runtime reality (read-only)
+
+A TUI plugin's peerDependencies claim ^0.1.2-alpha.2 (npm installs without warnings, the
+range is satisfied by dsh alpha.5), but it crashes at runtime because dsh alpha.4 removed
+Session.events and replaced it with on-demand read APIs. The agent must distinguish
+semver-range satisfaction from runtime API compatibility. 题面见 [instruction.md](instruction.md)，
+判分逻辑见 [tests/judge.mjs](tests/judge.mjs)。
+
+- **Environment**: `node:24-bookworm` + git (fixture baseline-committed for the read-only gate).
+- **Verifier**: judge checks the fixture is unchanged + five diagnosis aspects, 0-100.
+- **Oracle**: `harbor run -p benchmark/tasks/S13-peer-range-vs-runtime -a oracle`, expected 1.0.
+
+Fixture provenance: trimmed from a real 2026-09-02 incident (dsh-tui beta.4 on dsh alpha.5,
+author's own session).

--- a/benchmark/tasks/S13-peer-range-vs-runtime/environment/Dockerfile
+++ b/benchmark/tasks/S13-peer-range-vs-runtime/environment/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:24-bookworm
+
+# git 供 judge 检测 fixture 是否被改动（只读纪律门禁）
+RUN apt-get update && apt-get install -y --no-install-recommends git     && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY fixture /app/fixture
+
+# 基线提交：judge 用 `git status --porcelain -- fixture` 判定 agent 是否守只读纪律
+RUN git init -q && git add -A && git -c user.email=bench@local -c user.name=bench commit -q -m "baseline"

--- a/benchmark/tasks/S13-peer-range-vs-runtime/environment/fixture/README.md
+++ b/benchmark/tasks/S13-peer-range-vs-runtime/environment/fixture/README.md
@@ -1,0 +1,9 @@
+# S13 fixture - Peer range vs runtime evidence pack (static)
+
+Evidence for the S13-peer-range-vs-runtime task. **Read-only fixture - do not execute or publish
+anything here**; the task grading requires this directory to be unchanged relative to git HEAD.
+
+- `npm-install-output.txt` - npm install succeeded, no peer warnings
+- `crash-stack.txt` - the startup crash stack trace
+- `plugin-source-excerpt.js` - where the plugin reads the removed API
+- `dsh-changelog-excerpt.md` - the relevant dsh release notes

--- a/benchmark/tasks/S13-peer-range-vs-runtime/environment/fixture/crash-stack.txt
+++ b/benchmark/tasks/S13-peer-range-vs-runtime/environment/fixture/crash-stack.txt
@@ -1,0 +1,14 @@
+# Running dsh-tui for the first time after install:
+$ dsh-tui
+
+Error: dsh: plugin tree failed to load: failed to apply loader entry dsh-tui
+  (@deepseek-harness-tui/dsh-tui): events is not iterable
+TypeError: events is not iterable
+    at prepareReplayEvents (channel.js:623:25)
+    at replayEvents (channel.js:6127:33)
+    at createChannel (channel.js:6685:5)
+    at apply (plugin.js:425:21)
+    at async Fiber._reload (cordis/lib/index.js:1355:5)
+
+# The crash happens INSIDE the plugin's own code, reading something called
+# `events` from the dsh session object and trying to iterate it.

--- a/benchmark/tasks/S13-peer-range-vs-runtime/environment/fixture/dsh-changelog-excerpt.md
+++ b/benchmark/tasks/S13-peer-range-vs-runtime/environment/fixture/dsh-changelog-excerpt.md
@@ -1,0 +1,11 @@
+# dsh-v0.1.2-alpha.4 release notes (excerpt)
+
+## Other Changes
+
+- **Replace `Session.events` with on-demand read APIs**: `seq`, `eventAt()`,
+  and `snapshotEvents()` - the eagerly materialized events array is removed
+  to reduce memory overhead in long sessions. Developers should pay attention
+  to compatibility. (@kermanx)
+
+- **Distinguish `SessionSeq` and `SessionLogOffset` with strong types** -
+  developers should pay attention to compatibility. (@tianyicui)

--- a/benchmark/tasks/S13-peer-range-vs-runtime/environment/fixture/npm-install-output.txt
+++ b/benchmark/tasks/S13-peer-range-vs-runtime/environment/fixture/npm-install-output.txt
@@ -1,0 +1,16 @@
+# npm install -g @deepseek-harness-tui/dsh-tui
+# (with @deepseek-ai/dsh@0.1.2-alpha.5 already installed globally)
+$ npm install -g @deepseek-harness-tui/dsh-tui
+
+added 77 packages in 2m
+20 packages are for funding
+
+# No peer dependency warnings were emitted. The plugin's peerDependencies:
+#   "@deepseek-ai/dsh-llm": "^0.1.2-alpha.2"
+#   "@deepseek-ai/dsh-agent": "^0.1.2-alpha.2"
+#   "@deepseek-ai/dsh-session": "^0.1.2-alpha.2"
+#   ... (24 more dsh-* packages, all "^0.1.2-alpha.2")
+#
+# The installed @deepseek-ai/dsh@0.1.2-alpha.5 bundles these packages at
+# 0.1.2-alpha.5, which satisfies >=0.1.2-alpha.2 <0.2.0-0 in semver.
+# npm's peer check passes silently.

--- a/benchmark/tasks/S13-peer-range-vs-runtime/environment/fixture/plugin-source-excerpt.js
+++ b/benchmark/tasks/S13-peer-range-vs-runtime/environment/fixture/plugin-source-excerpt.js
@@ -1,0 +1,14 @@
+// channel.js (dsh-tui plugin) - line 734 area
+// The plugin reads the session's events array for transcript replay:
+
+export function createChannel(ctx, initialAgent, options) {
+    // ...
+    const events = liveAgent.session.events;    // <- line 734
+    // ...
+    replayEvents(agent.session.events);          // <- line 6685
+}
+
+// line 657: const last = session.events.at(-1);
+// line 2685: const events = agent.session.events;
+// line 3004: const liveEvents = liveSession.events;
+// ... 42 total references to `.events` on session objects

--- a/benchmark/tasks/S13-peer-range-vs-runtime/instruction.md
+++ b/benchmark/tasks/S13-peer-range-vs-runtime/instruction.md
@@ -1,0 +1,36 @@
+# S13 · Peer Range vs Runtime Reality (Read-Only)
+
+## Unattended Evaluation Authorization (BENCHMARK-AUTH-v1)
+
+This is an unattended evaluation running in a disposable, isolated container; there will be no follow-up user messages. This task brief is itself the user's explicit authorization and confirmation for the approach and execution needed to complete the task: complete the necessary analysis and planning on your own, and keep executing as soon as the plan is formed — do not pause to wait for "confirmation", and do not ask the user follow-up questions. That confirmation continues to apply to the concrete plans you produce under the applicable skill, but only within the following scope:
+
+- You may inspect `/app/fixture/`, in-container local documentation, and local tools read-only; `/app/fixture/` must remain completely unchanged; you may write your report into the designated `/app/agent-output/` directory as the brief specifies;
+- You may create temporary files needed for the report and run read-only local scan commands, but you must not execute migrations or installations;
+- You must not modify the skill, the evaluator, or the reference answers, and you must not publish, push, access external services, or alter resources outside the container;
+- If you cannot complete the task, state the blocker honestly, but do not stop merely because another round of confirmation is missing.
+
+I installed a popular community TUI plugin (`@deepseek-harness-tui/dsh-tui@0.1.0-beta.4`) on my dsh
+`0.1.2-alpha.5`. The npm install succeeded without any peer warnings — the plugin's peerDependencies declare
+`^0.1.2-alpha.2` for every `@deepseek-ai/dsh-*` package, and my dsh at alpha.5 satisfies that range.
+But when I run it, the plugin crashes at startup.
+
+The evidence pack in `/app/fixture/` (read-only) has: the npm peer-deps output, the crash stack trace, the
+plugin's source excerpt where it crashes, and the relevant dsh changelog entry.
+
+**Your report** (write to `/app/agent-output/S13-peer-range-vs-runtime/`, any filename):
+
+1. The exact runtime incompatibility: WHAT API did dsh remove, WHEN (which release), and what replaced it —
+   cite the changelog entry.
+2. WHY did npm install without warnings even though the plugin is broken at runtime: what does a peer range
+   (`^0.1.2-alpha.2`) actually guarantee, and what does it NOT guarantee?
+3. The fundamental principle: "peer range satisfaction" checks what, and "runtime compatibility" checks what?
+   Name at least two categories of breakage that pass peer-range validation but crash at runtime.
+4. What the plugin author should have done: both to catch this before publishing (testing against the actual
+   target version), and to help users (what should the peer range or engines field encode vs. what needs a
+   runtime feature-detection guard)?
+5. What I (the user) can do RIGHT NOW to identify this class of issue before installing: name a concrete
+   pre-install check.
+
+What is tested: distinguishing semver-range satisfaction (a static, package-metadata-level check) from runtime
+API compatibility (a behavioral, code-level reality), and knowing that `^0.1.2-alpha.2` does NOT guarantee
+`Session.events` still exists at alpha.4/5 just because alpha.5 > alpha.2 in semver ordering.

--- a/benchmark/tasks/S13-peer-range-vs-runtime/solution/SOLUTION.md
+++ b/benchmark/tasks/S13-peer-range-vs-runtime/solution/SOLUTION.md
@@ -1,0 +1,25 @@
+# S13 参考解法
+
+## 考点（一句话）
+
+peerDependencies 的 semver 范围满足（^0.1.2-alpha.2 被 alpha.5 满足）≠ 运行时兼容
+（alpha.4 删除了 Session.events，插件的 42 处 session.events 引用全部变 undefined）。
+Peer range 是静态包元数据版本界检查，不检查 API 面、行为契约或能力探测。正确诊断 =
+看崩溃栈定位到 session.events → 查 changelog 确认 alpha.4 删除 → 区分静态范围满足
+vs 运行时兼容 → 作者应钉紧 peer 范围或加运行时特性探测 → 用户应查 changelog 或
+grep 插件源码。
+
+## 参考报告
+
+见 [report.md](report.md)，期望 judge 得分 100。
+
+## 判分要点
+
+只读门禁 + 五要点各 20：Session.events→snapshotEvents 机制 / peer 范围=静态版本界
+而非 API 兼容 / 两类通过 peer 但运行时崩溃（API 删除 + 行为变更）/ 作者责任（实测
+目标版本 + 特性探测或收紧 peer）/ 用户预检（查 changelog + grep 源码）。
+
+## fixture 出处
+
+裁剪自 2026-09-02 真实事故（dsh-tui beta.4 在 dsh alpha.5 上安装成功但启动崩溃，
+作者亲历）。

--- a/benchmark/tasks/S13-peer-range-vs-runtime/solution/report.md
+++ b/benchmark/tasks/S13-peer-range-vs-runtime/solution/report.md
@@ -1,0 +1,66 @@
+# S13 Peer range vs runtime reality (reference answer)
+
+## 1. The exact runtime incompatibility
+
+dsh **v0.1.2-alpha.4** removed `Session.events` — the eagerly materialized events array —
+and replaced it with three on-demand read APIs: `seq`, `eventAt()`, and `snapshotEvents()`.
+The changelog entry (in `dsh-changelog-excerpt.md`) explicitly says "developers should pay
+attention to compatibility." The plugin reads `session.events` in **42 places** (per
+`plugin-source-excerpt.js`), all of which now receive `undefined`. When the code tries to
+iterate `undefined`, it crashes with `TypeError: events is not iterable`.
+
+## 2. Why npm installed without warnings
+
+The plugin's peerDependencies declare `^0.1.2-alpha.2` for every `@deepseek-ai/dsh-*`
+package. The installed dsh at `0.1.2-alpha.5` satisfies this range because, in npm's
+semver prerelease ordering, `0.1.2-alpha.5 > 0.1.2-alpha.2` (same base version, higher
+prerelease identifier). npm's peer resolution is a **static, package-metadata-level check**:
+it verifies that the installed version falls within the declared semver range.
+
+What it does NOT do: load the plugin's code, inspect what APIs it calls, or verify that
+those APIs exist in the installed version's runtime. Peer range satisfaction is a version
+bounds check — full stop.
+
+## 3. Peer range satisfaction vs runtime compatibility
+
+| Peer range satisfaction checks | Runtime compatibility requires |
+|---|---|
+| Semver version bounds | API surface presence (methods, properties) |
+| Package co-installability (no version conflicts) | Behavioral contracts (sync vs async, return types) |
+| — | Feature flags / capability detection |
+
+Two categories of breakage that pass peer validation but crash at runtime:
+
+1. **API removal**: `Session.events` was removed at alpha.4. The plugin calls it; the
+   property is `undefined`; iteration fails. Peer range passes because alpha.5 > alpha.2.
+2. **Behavioral/contract change**: a method that used to be synchronous now returns a
+   Promise, or an argument order changed. The method still exists (peer check passes),
+   but calling it the old way produces wrong results or throws.
+
+## 4. What the plugin author should have done
+
+**Before publishing**: test against the actual target version (alpha.4+), not just the
+peer floor (alpha.2). The peer range `^0.1.2-alpha.2` means "I've tested against alpha.2" —
+but the plugin runs against alpha.5. The author should either:
+
+- Tighten the peer range to `>=0.1.2-alpha.2 <0.1.2-alpha.4` (explicitly excluding the
+  breaking version), OR
+- Add a **runtime feature-detection guard**: `if (typeof session.snapshotEvents ===
+  'function') { /* new API */ } else if (session.events !== undefined) { /* old API */ }`
+  so the plugin works across both.
+
+**To help users**: the README should state the exact dsh versions tested; the peer range
+should reflect the ACTUAL compatibility boundary (where the API changed), not the earliest
+version the author happened to test against.
+
+## 5. User's pre-install check
+
+Before installing a third-party plugin on a newer dsh than the plugin's peer floor:
+
+1. **Read the changelog** between the peer floor (alpha.2) and your version (alpha.5):
+   look for "removed", "replaced", "breaking", "developers should pay attention".
+2. **Grep the plugin source** for the API surface it uses (e.g. `grep -r 'session.events'`)
+   and check whether that API exists in your dsh version's type definitions.
+
+The core principle: **peerDependencies declare the author's claimed compatibility range;
+only runtime testing proves it.** A gap between the claim and reality is invisible to npm.

--- a/benchmark/tasks/S13-peer-range-vs-runtime/solution/solve.sh
+++ b/benchmark/tasks/S13-peer-range-vs-runtime/solution/solve.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Oracle solution: write the reference report to the agent output directory (does not touch the fixture, honoring read-only discipline).
+set -e
+mkdir -p /app/agent-output/S13-peer-range-vs-runtime
+cp "$(dirname "$0")/report.md" /app/agent-output/S13-peer-range-vs-runtime/report.md

--- a/benchmark/tasks/S13-peer-range-vs-runtime/task.toml
+++ b/benchmark/tasks/S13-peer-range-vs-runtime/task.toml
@@ -1,0 +1,25 @@
+schema_version = "1.4"
+# Harbor task config: peer range vs runtime compatibility (static, read-only)
+[task]
+name = "dsh-plugin-upgrade/s13-peer-range-vs-runtime"
+version = "1.1.0"
+description = "A TUI plugin's peerDependencies claim ^0.1.2-alpha.2 compatibility (npm installs without warnings) but crashes at runtime because dsh alpha.4 removed Session.events — diagnose why peer satisfaction is not runtime compatibility"
+keywords = ["dsh", "plugin-runtime", "peer-dependencies", "semver", "harbor"]
+
+[metadata]
+difficulty = "medium"
+category = "programming"
+tags = ["dsh", "plugin-runtime", "peer-dependencies", "english-prompt"]
+execution_contract = "BENCHMARK-AUTH-v1"
+
+[agent]
+timeout_sec = 300.0
+
+[verifier]
+timeout_sec = 120.0
+
+[environment]
+network_mode = "public"
+cpus = 1
+memory_mb = 2048
+storage_mb = 4096

--- a/benchmark/tasks/S13-peer-range-vs-runtime/tests/judge-utils.mjs
+++ b/benchmark/tasks/S13-peer-range-vs-runtime/tests/judge-utils.mjs
@@ -1,0 +1,191 @@
+// Shared benchmark grading library (harbor edition, zero dependencies).
+// Conventions:
+// - every judge.mjs always exits with code 0; the last stdout line outputs {"score": 0-100, "max": 100, "reasons": [...]};
+// - static tasks put agent artifacts under /app/agent-output/<task-id>/;
+// - container tasks (M1/H1/H2/H3) let the agent modify /app/fixture/ directly, and the judge does a real cold boot inside the task container
+//   (the image has dsh 0.1.2-alpha.2 installed globally, no docker exec needed);
+// - each task uses its own profile (bench-<task>) and its own /tmp plugin directory; the judge cleans up the assets it created.
+import { execFile } from 'node:child_process'
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs'
+import { join, relative, resolve, sep } from 'node:path'
+
+export const APP_ROOT = '/app'
+export const FIXTURE_DIR = join(APP_ROOT, 'fixture')
+export const DEFAULT_AGENT_OUTPUT = join(APP_ROOT, 'agent-output')
+export const BENCH_TMP = (taskId) => `/tmp/bench-${taskId.toLowerCase()}`
+export const PROFILE = (taskId) => `bench-${taskId.toLowerCase()}`
+
+// ── Result output ──────────────────────────────────────
+
+export function emit(score, reasons) {
+  const result = { score: Math.max(0, Math.min(100, Math.round(score))), max: 100, reasons }
+  process.stdout.write(JSON.stringify(result) + '\n')
+  process.exit(0)
+}
+
+// ── Agent output collection (static tasks) ─────────────
+
+const TEXT_EXT = new Set(['.md', '.txt', '.json', '.jsonl', '.log'])
+
+function walkFiles(dir) {
+  const out = []
+  if (!existsSync(dir)) return out
+  for (const entry of readdirSync(dir)) {
+    const path = join(dir, entry)
+    const stat = statSync(path)
+    if (stat.isDirectory()) out.push(...walkFiles(path))
+    else out.push(path)
+  }
+  return out
+}
+
+/** Collect all text artifacts under <agentOutput>/<taskId>/ and join them into one big string. */
+export function readAgentText(agentOutput, taskId) {
+  const root = agentOutput || DEFAULT_AGENT_OUTPUT
+  const dir = join(root, taskId)
+  const files = walkFiles(dir).filter((file) => TEXT_EXT.has(file.slice(file.lastIndexOf('.'))))
+  const text = files.map((file) => readFileSync(file, 'utf8')).join('\n\n')
+  return { text, files: files.map((file) => relative(root, file)) }
+}
+
+// ── Git status (whether the fixture changed) ───────────
+
+function git(args, cwd) {
+  return new Promise((resolvePromise) => {
+    execFile('git', args, { cwd, timeout: 20000 }, (error, stdout, stderr) => {
+      resolvePromise({ code: error?.code ?? 0, stdout, stderr: stderr ?? '' })
+    })
+  })
+}
+
+/** Return the fixture paths relative to APP_ROOT (modified/added/deleted). Empty array = unchanged. */
+export async function fixtureChanges(relFixtureDir = 'fixture') {
+  const result = await git(['status', '--porcelain', '--', relFixtureDir], APP_ROOT)
+  if (result.code !== 0) return { changed: null, detail: `git status failed: ${result.stderr.trim()}` }
+  const lines = result.stdout.split('\n').filter(Boolean)
+  return {
+    changed: lines.length > 0 ? true : false,
+    detail: lines.length ? lines.join('; ') : 'fixture unchanged relative to baseline',
+  }
+}
+
+// ── Local command primitives (judge runs in the task container) ──
+
+export function localExec(script, { stdin = '', timeout = 60000 } = {}) {
+  return new Promise((resolvePromise) => {
+    const child = execFile('sh', ['-c', script], { timeout }, (error, stdout, stderr) => {
+      resolvePromise({
+        code: error?.code ?? 0,
+        stdout: stdout ?? '',
+        stderr: stderr ?? '',
+        killed: error?.killed === true || (error && error.code === undefined) === true,
+      })
+    })
+    if (stdin) child.stdin.write(stdin)
+    child.stdin.end()
+  })
+}
+
+export async function dshAvailable() {
+  const result = await localExec('dsh --version', { timeout: 15000 })
+  return result.code === 0
+}
+
+// ── Profile lifecycle ──────────────────────────────────
+
+/** Create an isolated profile (bundles is an array of host package names). */
+export async function createProfile(profile, bundles) {
+  const dir = `/root/.dsh/profiles/${profile}`
+  const pkg = {
+    name: `dsh-profile-${profile}`,
+    private: true,
+    dependencies: {},
+    dsh: { profile: { bundles, patchReload: 'startup' } },
+  }
+  const write = await localExec(`rm -rf '${dir}' && mkdir -p '${dir}' && base64 -d > '${dir}/package.json'`, {
+    stdin: Buffer.from(JSON.stringify(pkg, null, 2) + '\n').toString('base64'),
+  })
+  if (write.code !== 0) return { ok: false, detail: `profile write failed: ${write.stderr.trim()}` }
+  const seed = await localExec(
+    `cp /root/.dsh/profiles/headless/pnpm-workspace.yaml '${dir}/' 2>/dev/null || printf 'packages:\\n  - .\\n\\nnodeLinker: hoisted\\nautoInstallPeers: false\\n' > '${dir}/pnpm-workspace.yaml'
+printf '[]\\n' > '${dir}/cordis.patch.yml'
+printf '[]\\n' > '${dir}/cordis.yml'`,
+  )
+  if (seed.code !== 0) return { ok: false, detail: `profile seed files failed: ${seed.stderr.trim()}` }
+  return { ok: true, dir }
+}
+
+export async function addPlugin(profile, pluginDir) {
+  const result = await localExec(`dsh plugin --profile '${profile}' add '${pluginDir}'`, { timeout: 180000 })
+  return { ok: result.code === 0, detail: (result.stdout + result.stderr).trim().slice(-400) }
+}
+
+/** Clean up task-created assets: profile, temporary plugin directory, leftover boot processes. */
+export async function cleanupProfile(profile, tmpDir) {
+  // The pkill pattern uses the [first-letter] bracket trick to avoid matching the sh -c process running this cleanup script itself.
+  const selfSafe = `[${profile[0]}]${profile.slice(1)}`
+  await localExec(
+    `pkill -f 'profile ${selfSafe}' 2>/dev/null; rm -rf '/root/.dsh/profiles/${profile}' '${tmpDir}' /tmp/${profile}-boot.log; true`,
+  )
+}
+
+// ── Cold boot signal detection ─────────────────────────
+
+export const NEGATIVE_SIGNAL = /plugin tree failed|did not activate|pending \(waiting for service|FAILED fiber|ClientPackageCompositionError/i
+// A headless profile without an API key always reaches MISSING_CREDENTIAL — emitting this line proves
+// the plugin tree fully activated and the boot flow reached the host application layer (consistent with the validation report attribution).
+export const HEADLESS_ACTIVATED_SIGNAL = /MISSING_CREDENTIAL|no API key|dsh: AUTH/i
+
+/** Headless cold boot: returns the full output. Exit code is not a verdict (success is also 1 without a key). */
+export async function bootHeadless(profile) {
+  const result = await localExec(`cd /root && timeout 30 dsh --profile '${profile}' 'ping' 2>&1`, { timeout: 60000 })
+  return { output: result.stdout + result.stderr, code: result.code }
+}
+
+/**
+ * Web cold boot and read __DSH_BOOT__:
+ * 1. start `dsh --profile <p> --no-open` in the background, wait for a dsh web: URL line in the log;
+ * 2. exchange the bootstrap token for a Cookie, GET / for the HTML;
+ * 3. return { output, html }; the caller judges negative signals and the plugin entry.
+ */
+export async function bootWebAndFetchIndex(profile, pkgName) {
+  const logPath = `/tmp/${profile}-boot.log`
+  await localExec(`cd /root && nohup timeout 45 dsh --profile '${profile}' --no-open > '${logPath}' 2>&1 & echo started`)
+  const probe = await localExec(
+    `node --input-type=module -e '
+const logPath = process.argv[1];
+const pkgName = process.argv[2];
+const fs = await import("node:fs");
+let log = "";
+for (let i = 0; i < 90; i += 1) {
+  try { log = fs.readFileSync(logPath, "utf8"); } catch {}
+  if (/dsh web: http|plugin tree failed|did not activate/i.test(log)) break;
+  await new Promise((r) => setTimeout(r, 1000));
+}
+const match = /dsh web: (http:\\S+)/.exec(log);
+const outcome = { log };
+if (match) {
+  try {
+    const r1 = await fetch(match[1], { redirect: "manual" });
+    const setCookie = r1.headers.getSetCookie ? r1.headers.getSetCookie() : [r1.headers.get("set-cookie")];
+    const cookie = setCookie.filter(Boolean).map((c) => c.split(";")[0]).join("; ");
+    const r2 = await fetch("http://127.0.0.1:3080/", { headers: { cookie } });
+    outcome.html = await r2.text();
+  } catch (error) {
+    outcome.fetchError = String(error);
+  }
+}
+console.log("__RESULT__" + JSON.stringify(outcome));
+' '${logPath}' '${pkgName}'`,
+    { timeout: 150000 },
+  )
+  const marker = '__RESULT__'
+  const idx = probe.stdout.lastIndexOf(marker)
+  if (idx < 0) return { output: probe.stdout + probe.stderr, html: '', probeError: probe.stderr.trim() }
+  try {
+    const outcome = JSON.parse(probe.stdout.slice(idx + marker.length).trim())
+    return { output: outcome.log ?? '', html: outcome.html ?? '', fetchError: outcome.fetchError }
+  } catch {
+    return { output: probe.stdout + probe.stderr, html: '', probeError: 'failed to parse boot result' }
+  }
+}

--- a/benchmark/tasks/S13-peer-range-vs-runtime/tests/judge.mjs
+++ b/benchmark/tasks/S13-peer-range-vs-runtime/tests/judge.mjs
@@ -1,0 +1,68 @@
+// S13-peer-range-vs-runtime grading: fixture read-only gate + five diagnosis aspects.
+// Expected diagnosis:
+//   1. dsh alpha.4 removed Session.events (the eagerly materialized array) and
+//      replaced it with on-demand read APIs: seq, eventAt(), snapshotEvents().
+//      The plugin reads session.events (42 references) -> undefined -> not iterable.
+//   2. npm peer check passes because ^0.1.2-alpha.2 is satisfied by 0.1.2-alpha.5
+//      in semver ordering. Peer range satisfaction is a STATIC package-metadata
+//      check: it verifies version bounds, not API presence.
+//   3. Peer range satisfaction checks: version ordering (semver), package
+//      co-installability. It does NOT check: API surface (removed/renamed
+//      methods), behavioral changes (sync to async, return type changes),
+//      feature flags. Two categories that pass peers but crash at runtime:
+//      (a) API removal (Session.events deleted, method renamed),
+//      (b) behavioral/contract change (sync call now async, argument order changed).
+//   4. Author should: test against the actual target version (not just the peer
+//      floor), and either tighten the peer range to exclude incompatible
+//      versions (e.g. <alpha.4) or add a runtime feature-detection guard
+//      (typeof session.snapshotEvents === 'function').
+//   5. User pre-install check: read the target dsh changelog between the peer
+//      floor and the installed version, or grep the plugin source for API
+//      surface usage against the target version's type definitions.
+import { emit, fixtureChanges, readAgentText } from './judge-utils.mjs'
+
+const TASK = 'S13-peer-range-vs-runtime'
+
+const ASPECTS = [
+  { key: 'Session.events removed at alpha.4, replaced by seq/eventAt()/snapshotEvents()',
+    pattern: /Session\.events|snapshotEvents|eventAt|alpha\.4/i, points: 20 },
+  { key: 'peer range satisfaction is static version-bound check, not API compatibility',
+    pattern: /(semver|version.{0,30}(bound|order|range)).{0,200}(API|runtime|compat)|(API|runtime).{0,200}(semver|version.{0,30}(bound|range))/i, points: 20 },
+  { key: 'two categories that pass peers but crash: API removal + behavioral/contract change',
+    pattern: /(remov|delet|renam).{0,100}(API|method|function)|(behavio|contract|sync|async|argument|return).{0,100}(chang|break)/i, points: 20 },
+  { key: 'author should: test against actual target version AND add runtime feature detection or tighten peer range',
+    pattern: /(test|verify).{0,60}(actual|target|real).{0,30}version|(feature.?detect|runtime.?guard|typeof|tighten|narrow).{0,60}(peer|range)/i, points: 20 },
+  { key: 'user pre-install check: read changelog between peer floor and installed version, or grep plugin source against target API',
+    pattern: /(changelog|release.?note).{0,80}(between|from|alpha)|(grep|scan|search|check).{0,60}(source|code|API|type)/i, points: 20 },
+]
+
+main().catch((error) => emit(0, [`judge error: ${error.message}`]))
+
+async function main() {
+  const reasons = []
+
+  const gate = await fixtureChanges('fixture')
+  if (gate.changed === true) {
+    emit(0, [`fixture was modified, 0 points for this task (read-only discipline): ${gate.detail}`])
+  }
+  if (gate.changed === null) reasons.push(`warning: ${gate.detail}`)
+  else reasons.push('fixture unchanged (read-only discipline passed)')
+
+  const { text, files } = readAgentText('', TASK)
+  if (!text.trim()) {
+    emit(0, [...reasons, `no report found under /app/agent-output/${TASK}/, treated as 0 points`])
+  }
+  reasons.push(`read agent report: ${files.join(', ')}`)
+
+  let score = 0
+  for (const aspect of ASPECTS) {
+    if (aspect.pattern.test(text)) {
+      score += aspect.points
+      reasons.push(`hit aspect: ${aspect.key} (+${aspect.points})`)
+    } else {
+      reasons.push(`missing aspect: ${aspect.key} (-${aspect.points})`)
+    }
+  }
+
+  emit(score, reasons)
+}

--- a/benchmark/tasks/S13-peer-range-vs-runtime/tests/test.sh
+++ b/benchmark/tasks/S13-peer-range-vs-runtime/tests/test.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Harbor verifier: run judge.mjs (its last line outputs a 0-100 score JSON), normalized to a 0~1 reward.
+# judge itself always exits 0; when no JSON can be parsed, treat the score as 0 (error-tolerant principle).
+mkdir -p /logs/verifier
+node /tests/judge.mjs > /tmp/judge.out 2>&1
+cat /tmp/judge.out
+node -e '
+const fs = require("node:fs");
+const lines = fs.readFileSync("/tmp/judge.out", "utf8").trim().split("\n").filter(Boolean);
+let score = 0;
+for (let i = lines.length - 1; i >= 0; i -= 1) {
+  try {
+    const j = JSON.parse(lines[i]);
+    if (typeof j.score === "number" && typeof j.max === "number") { score = j.score; break }
+  } catch {}
+}
+const reward = Math.max(0, Math.min(1, score / 100));
+fs.writeFileSync("/logs/verifier/reward.txt", String(reward) + "\n")
+'


### PR DESCRIPTION
## Summary

Two new **static read-only** diagnosis tasks (43-44) from real 2026-09-02 incidents.

### S12-global-upgrade-ebusy-trap — the dsh upgrade operational trap

A user upgrades dsh from alpha.5 to alpha.6 and fails twice:
1. **EBUSY on koffi.node** — the running dsh host process loaded a native addon; the OS holds a
   file lock that a browser page refresh cannot release. The agent must recognize that only a
   full process stop frees the lock.
2. **Silent downgrade to rc.2** — a plugin README's combined install command
   (`npm install -g @deepseek-ai/dsh ...`) without a version pin resolves to the `latest`
   dist-tag (= rc.2), silently replacing the installed alpha.5.

The agent must diagnose both, provide the safe stop-pin-version-restart sequence, and identify
the prevention (plugin READMEs must pin versions in install commands).

### S13-peer-range-vs-runtime — peerDependencies satisfaction is not runtime compatibility

A TUI plugin's peerDependencies declare `^0.1.2-alpha.2` (npm installs without warnings,
semver says alpha.5 > alpha.2 so the range is satisfied), but it crashes at startup because
dsh **alpha.4 removed `Session.events`** and the plugin reads it in 42 places. The agent must:
- identify the exact API removal from the changelog
- explain WHY the peer check passes (it's a static version-bounds check, not an API check)
- name two categories of breakage that pass peers but crash at runtime
- state what the author should have done (test target version + feature detection / tightened range)
- give the user's pre-install check (changelog diff + source grep)

### What makes these non-trivial

- **S12** tests that the agent understands OS-level native-module file locks (not a browser
  concept) and npm dist-tag resolution (not semver latest-version). Without the skill's
  upgrade-safety guidance, an agent might suggest `--force` or a page refresh.
- **S13** tests the meta-principle that **package metadata validation is not runtime compatibility**.
  Without the skill, agents trust peerDependencies as a compatibility contract and don't look
  at the actual API surface delta between the peer floor and the installed version.

### Registration (all four spots)

- `validate-execution-contract.mjs` expectedModes: S12, S13 -> readonly
- `benchmark/README.md`: counts 42->44, written split 14->16, two task table rows
- `docs/scoring.md`: total 4200->4400, two score-breakdown rows
- validators pass: `OK: 44 tasks`

## Provenance

Both from the author's own 2026-09-02 session: S12 from the dsh alpha.4->alpha.5 upgrade
(EBUSY + dsh-tui install downgrade), S13 from the dsh-tui beta.4 crash on dsh alpha.5
(Session.events removal). First-hand, reproducible, with full evidence packs.