### PR TITLE
feat(benchmark): S14 link-install lock trap + S15 slot error-boundary crash (tasks 45-46)

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,7 +1,7 @@
 # dsh plugin upgrade tasks (benchmark v2.4 · Harbor format)
 
-The 49 plugin-upgrade tasks measure one thing: **once an AI has our upgrade skill
-installed, will it actually upgrade the plugin**. The first 16 are written exams (read
+The 51 plugin-upgrade tasks measure one thing: **once an AI has our upgrade skill
+installed, will it actually upgrade the plugin**. The first 18 are written exams (read
 the code, produce the answer); the last 33 are hands-on (actually install dsh and run
 the plugin — whether it is alive is obvious at a glance). Every task ships with
 auto-grading, so no human marking is involved.
@@ -46,6 +46,8 @@ honestly instead of quietly fixing it and pretending nothing happened).
 | S11-mermaid-lazyload-trap | Static | A lazy-loaded mermaid chunk rollout fails three ways: split-chunk sibling imports 404, a Windows-only 403 from a case-sensitive containment guard, and a Ctrl+scroll double-fire under the zoom modal — can it derive each mechanism from the evidence |
 | S12-global-upgrade-ebusy-trap | Static | A user upgrades dsh and fails twice: EBUSY on koffi.node (running process holds a native-module lock) then a silent downgrade to rc.2 (unpinned npm install follows the latest dist-tag) — can it diagnose both and give the safe upgrade sequence |
 | S13-peer-range-vs-runtime | Static | A TUI plugin's peerDependencies claim ^0.1.2-alpha.2 (npm installs without warnings) but it crashes on dsh alpha.5 because alpha.4 removed Session.events — can it distinguish peer range satisfaction from runtime API compatibility |
+| S14-link-install-lock-trap | Static | Repo edits to a link-installed plugin never reach the GUI, Copy-Item into the profile hits EBUSY, and a rename-aside recovery leaves both "directories" with no entry files — can it recognize the junction install (repo tree IS the installed copy), attribute the two locks (running host + browser cache), and derive the activation procedure |
+| S15-slot-error-boundary-crash | Static | After a feature release the pending-attachment dock vanishes entirely: a dangling `busy` identifier (another component's state) throws only when a chip renders and the phase guard short-circuits open — can it find the pre-existing line behind the misleading new diff and design a data-present render regression |
 | M2-optional-dep-trap | Hands-on | The plugin declares an optional dependency but imports it unconditionally at top level (the comment says optional is harmless): does it fix the dependency contract instead of wrapping the import, and prove it with a cold boot |
 | M3-session-projection | Hands-on | A self-assembled profile mounts dsh-tool-todo without the sessionProjections service: does it fix the composition (never edit shipped packages) so the tree activates while the todo tool survives in the final composition |
 | M4-peer-prerelease-range | Hands-on | A peer lower bound written as ^0.1.0-rc.8 does not match 0.1.2-alpha.2 under npm semver's prerelease rule: does it rewrite the bound to the target cohort instead of widening it into a meaningless range |
@@ -233,7 +235,7 @@ harbor run -p benchmark/tasks/S1-static-scan -a oracle
 # evaluate a single task with an agent
 harbor run -p benchmark/tasks/M1-host-migration -a claude-code -m anthropic/claude-opus-4-1
 
-# all 49 tasks: pointing -p at the tasks/ directory runs them as a dataset batch
+# all 51 tasks: pointing -p at the tasks/ directory runs them as a dataset batch
 harbor run -p benchmark/tasks -a claude-code -m anthropic/claude-opus-4-1
 ```
 
@@ -245,7 +247,7 @@ the judge's per-item reasons are in the verifier log.
 
 ### Unattended authorization
 
-All 49 `instruction.md` files carry the `BENCHMARK-AUTH-v1` marker: the task prompt
+All 51 `instruction.md` files carry the `BENCHMARK-AUTH-v1` marker: the task prompt
 itself is the user's confirmation of the plan and the execution within the stated
 scope. The agent should complete the necessary analysis/planning and then proceed — it
 must not stop just because Harbor will not send a second round of "confirmation". The
@@ -422,7 +424,7 @@ numbers cannot be compared across models or against later runs.
   adding ordinary fixture tasks** — the point is to stop anyone from accidentally
   publishing fake plugins to npm.
 - When adding a task, scaffold it with `harbor task init`, then fill in
-  judge / solve.sh following the layout of the existing 49 tasks, and verify the
+  judge / solve.sh following the layout of the existing 51 tasks, and verify the
   reference answer scores 1.0 with `harbor run -p <task> -a oracle`.
 - After adding or modifying prompts, run
   `node benchmark/scripts/validate-execution-contract.mjs` to make sure the

--- a/benchmark/docs/scoring.md
+++ b/benchmark/docs/scoring.md
@@ -1,6 +1,6 @@
 # Scoring rules and checkpoint mapping
 
-Total 4900 (49 tasks × 100; the Harbor reward is 0–1, normalized as score/100).
+Total 5100 (51 tasks × 100; the Harbor reward is 0–1, normalized as score/100).
 Every judge: exit 0, with the last stdout line
 `{"score": 0-100, "max": 100, "reasons": [...]}`; `tests/test.sh` parses that last
 line as JSON and writes score/100 to `/logs/verifier/reward.txt`.
@@ -41,6 +41,8 @@ line as JSON and writes score/100 to `/logs/verifier/reward.txt`.
 | S11-mermaid-lazyload-trap | skills/plugin-heavy-dep (heavy-dependency lazy-load checklist; real 2026-09-01 dsh-file-trace mermaid integration, v0.2.3/v0.2.4) | Five diagnosis aspects × 20: split-chunk relative resolution + single-file fix, realpath drive-letter case → 403 mechanism, path.relative containment + JS MIME, modal wheel ownership, regression coverage; fixture modified → flat 0 (read-only discipline) |
 | S12-global-upgrade-ebusy-trap | real 2026-09-02 dsh alpha upgrade incident | Five × 20: koffi lock / stop process / dist-tag downgrade / pin version / README prevention |
 | S13-peer-range-vs-runtime | real 2026-09-02 dsh-tui crash | Five × 20: Session.events→snapshotEvents / peer=static not API / pass-peer-crash categories / author feature detect / user changelog check |
+| S14-link-install-lock-trap | skills/plugin-runtime-debug (link-install activation family; real 2026-09-03 dsh-paste-input v0.1.17 session) | Five × 20: junction semantics (repo tree IS the install) / lock owners (running host + browser cache) / rename-aside same-directory recovery / ordered activation (stop host → restart → hard refresh) / pre-flight install-mode check |
+| S15-slot-error-boundary-crash | skills/plugin-runtime-debug (silent slot-unmount family; same 2026-09-03 session's dangling-busy crash) | Five × 20: free identifier + || short-circuit + chip-present latency / error-boundary whole-entry unmount (console-only) / attribution vs the newest diff (rollback or minimal render mount) / fix + hardening (?? [], closest?.()) / data-present render smoke + no-undef |
 | M6-sleep-tool | DSH-0.1.2-A2-03 peer hygiene (bare cordis contract, ContentBlock → dsh-llm); real @huanlin/dsh-plugin-sleep e25a4a9 | Static 50 (bare cordis gone 12 + @deepseek-ai/cordis 10 + dsh-tools floor 12 + dsh-llm peer 10 + meta optional 6) + headless activation 25 + diagnose 15 (exists 5, names 5, A2-03 3, R-01 2) + release 10; memo bait (keep bare cordis) caps at 60, changed-but-unfixed caps at 40 (M4 precedent) |
 | M7-d399-overlay | DSH-0.1.2-A1-25 client-runtime removal; DSH-0.1.2-A1-19 roster anchor | Static 50 (runtimeGone 10 + inject recomposed 10 + ISessions annotation 10 + cohort 12 + scoped cordis 8) + deploy 25 + diagnose 15 (exists 5, names 5, A1-25 3, R-01 2) + release 10; runtime retained caps at 20 |
 | M8-brand-text | DSH-0.1.2-A1-25 (store engine → dsh-client-store); rollup R-06 baseline attribution (H2 precedent) | Static 50 (runtimeGone + storeTypeSource + inject recomposed + cordis ^4.0.1 without -rc + cohort, 10 each) + deploy 25 + diagnose 15 incl. pre-existing-red-test honesty item + release 10; runtime retained caps at 20, store-bait retained caps at 60 |

--- a/benchmark/scripts/validate-execution-contract.mjs
+++ b/benchmark/scripts/validate-execution-contract.mjs
@@ -39,6 +39,8 @@ const expectedModes = new Map([
   ['S11-mermaid-lazyload-trap', 'readonly'],
   ['S12-global-upgrade-ebusy-trap', 'readonly'],
   ['S13-peer-range-vs-runtime', 'readonly'],
+  ['S14-link-install-lock-trap', 'readonly'],
+  ['S15-slot-error-boundary-crash', 'readonly'],
   ['H12-remote-result-boundary-trap', 'readonly'],
   ['M2-optional-dep-trap', 'mutable'],
   ['M3-session-projection', 'mutable'],

--- a/benchmark/tasks/S14-link-install-lock-trap/README.md
+++ b/benchmark/tasks/S14-link-install-lock-trap/README.md
@@ -1,0 +1,15 @@
+# S14 · Link-Install File-Lock Trap
+
+Static, read-only. A link-installed (junction) lib-only Web plugin is edited in its repo;
+the maintainer then (a) refreshes only the browser and sees stale code, (b) tries to
+Copy-Item the new files into the profile's node_modules and hits EBUSY, (c) attempts a
+rename-aside recovery that leaves BOTH the repo and the profile with no entry files
+(both paths resolve to the same directory through the junction).
+
+Derived from a real 2026-09-03 dsh-paste-input v0.1.17 verification session
+(hover-preview feature rollout).
+
+- Type: static / read-only report
+- Score: 5 aspects × 20 points, fixture-modification gate → 0
+- **Oracle**: `harbor run -p benchmark/tasks/S14-link-install-lock-trap -a oracle`, expected 1.0.
+- See `instruction.md` for the brief, `solution/SOLUTION.md` for the reference answer

--- a/benchmark/tasks/S14-link-install-lock-trap/environment/Dockerfile
+++ b/benchmark/tasks/S14-link-install-lock-trap/environment/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:24-bookworm
+
+# git 供 judge 检测 fixture 是否被改动（只读纪律门禁）
+RUN apt-get update && apt-get install -y --no-install-recommends git     && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY fixture /app/fixture
+
+# 基线提交：judge 用 `git status --porcelain -- fixture` 判定 agent 是否守只读纪律
+RUN git init -q && git add -A && git -c user.email=bench@local -c user.name=bench commit -q -m "baseline"

--- a/benchmark/tasks/S14-link-install-lock-trap/environment/fixture/README.md
+++ b/benchmark/tasks/S14-link-install-lock-trap/environment/fixture/README.md
@@ -1,0 +1,11 @@
+# S14 fixture · Link-install activation evidence pack (static)
+
+Evidence for the S14-link-install-lock-trap task: a PowerShell session transcript showing a
+failed Copy-Item into the plugin's profile node_modules, the filesystem introspection that
+reveals what that profile entry actually is, and the maintainer's thread describing what
+they changed and what the user saw. **Read-only fixture — do not execute or publish
+anything here**; the task grading requires this directory to be unchanged relative to git HEAD.
+
+- `copy-session.txt` — the EBUSY Copy-Item attempts (including one "rename aside then copy" recovery that made things worse)
+- `profile-introspection.txt` — Get-Item LinkType/Target on the profile entry and the repo directory
+- `maintainer-thread.md` — what was changed, where, and what the user reported after each step

--- a/benchmark/tasks/S14-link-install-lock-trap/environment/fixture/copy-session.txt
+++ b/benchmark/tasks/S14-link-install-lock-trap/environment/fixture/copy-session.txt
@@ -1,0 +1,22 @@
+PS E:\dev> Copy-Item E:\dev\dsh-attach-input\lib\*.js C:\Users\me\.dsh\profiles\web\node_modules\@org\dsh-attach-input\lib\ -Force
+Copy-Item : The file "C:\Users\me\.dsh\profiles\web\node_modules\@org\dsh-attach-input\lib\client.js"
+is being used by another process, so the process cannot access this file.
++ CategoryInfo          : NotSpecified: (:) [ ], IOException, Microsoft.PowerShell.Commands.CopyItemCommand
+
+# maintainer closes the browser tab, waits, retries:
+PS E:\dev> Copy-Item E:\dev\dsh-attach-input\lib\*.js C:\Users\me\.dsh\profiles\web\node_modules\@org\dsh-attach-input\lib\ -Force
+Copy-Item : ... same IOException for client.js, index.js, package.json
+
+# maintainer tries the rename-aside trick (rename the locked file, then copy the new one in):
+PS E:\dev> $dst = 'C:\Users\me\.dsh\profiles\web\node_modules\@org\dsh-attach-input\lib'
+PS E:\dev> Rename-Item ($dst + '\client.js') 'client.js.old2'
+PS E:\dev> Rename-Item ($dst + '\index.js') 'index.js.old2'
+PS E:\dev> Copy-Item 'E:\dev\dsh-attach-input\lib\client.js' ($dst + '\client.js')
+Copy-Item : Cannot find path "E:\dev\dsh-attach-input\lib\client.js" because it does not exist.
+PS E:\dev> Get-ChildItem E:\dev\dsh-attach-input\lib
+client.js.old2
+index.js.old2
+PS E:\dev> Get-ChildItem $dst
+client.js.old2
+index.js.old2
+# ^ both directories now show ONLY the renamed files, and the plugin has no entry files at all

--- a/benchmark/tasks/S14-link-install-lock-trap/environment/fixture/maintainer-thread.md
+++ b/benchmark/tasks/S14-link-install-lock-trap/environment/fixture/maintainer-thread.md
@@ -1,0 +1,31 @@
+# Maintainer thread — @org/dsh-attach-input v0.2.11 verification
+
+I maintain a lib-only Web plugin (no build step; `lib/client.js` + `lib/index.js` are the
+shipped files). Today I:
+
+1. Edited `lib/client.js` and `lib/index.js` directly in the repo at `E:\dev\dsh-attach-input`
+   (a hover-preview feature for image attachments, plus a new read-only host route).
+2. Told the user "restart dsh web and hard-refresh the browser to verify".
+3. The user refreshed the browser tab only — nothing changed (old behavior, no preview).
+4. I assumed the profile must be running an installed COPY of the plugin, so I tried to
+   Copy-Item the new lib files into the profile's node_modules (see copy-session.txt) —
+   EBUSY on every attempt, even after the browser tab was closed.
+5. I tried renaming the locked files aside and copying replacements in; the copy failed
+   with "source does not exist" and BOTH directories ended up with only the renamed
+   .old2 files (the plugin is now completely broken — no entry files at all).
+6. profile-introspection.txt shows what I found when I finally looked at what the profile
+   entry actually IS.
+
+Questions I need answered in the report:
+
+- Why did the browser refresh show nothing new, and why were the lib files "in use" even
+  with no browser tab open?
+- What does the Junction + Target actually mean for "deploying" my repo edits to the
+  profile — was step 4 (Copy-Item into node_modules) ever necessary for THIS install?
+- Why did the rename-aside trick in step 5 make the SOURCE directory lose its files too,
+  and what is the correct recovery from the current broken state (only .old2 files exist)?
+- What is the correct, complete activation procedure for a link-installed lib-only Web
+  plugin after editing its repo files — which processes must restart, in what order, and
+  what does the browser need (and why can it still show stale code after the host
+  restarted)?
+- How should I have determined the install mode BEFORE touching any files?

--- a/benchmark/tasks/S14-link-install-lock-trap/environment/fixture/profile-introspection.txt
+++ b/benchmark/tasks/S14-link-install-lock-trap/environment/fixture/profile-introspection.txt
@@ -1,0 +1,14 @@
+PS E:\dev> Get-Item C:\Users\me\.dsh\profiles\web\node_modules\@org\dsh-attach-input | Select-Object FullName, LinkType, Target
+
+FullName : C:\Users\me\.dsh\profiles\web\node_modules\@org\dsh-attach-input
+LinkType : Junction
+Target   : {E:\dev\dsh-attach-input}
+
+PS E:\dev> Get-Item E:\dev\dsh-attach-input | Select-Object FullName, LinkType, Target
+
+FullName : E:\dev\dsh-attach-input
+LinkType :
+Target   : {}
+
+PS E:\dev> Get-Content C:\Users\me\.dsh\profiles\web\cordis.patch.yml | Select-String dsh-attach-input
+  - node_modules/@org/dsh-attach-input  # link:E:\dev\dsh-attach-input (installed 2026-08-30)

--- a/benchmark/tasks/S14-link-install-lock-trap/instruction.md
+++ b/benchmark/tasks/S14-link-install-lock-trap/instruction.md
@@ -1,0 +1,50 @@
+# S14 · Link-Install File-Lock Trap (Read-Only)
+
+## Unattended Evaluation Authorization (BENCHMARK-AUTH-v1)
+
+This is an unattended evaluation running in a disposable, isolated container; there will be
+no follow-up user messages. This task brief is itself the user's explicit authorization and
+confirmation for the approach and execution needed to complete the task: complete the
+necessary analysis and planning on your own, and keep executing as soon as the plan is
+formed — do not pause to wait for "confirmation", and do not ask the user follow-up
+questions. That confirmation continues to apply to the concrete plans you produce under the
+applicable skill, but only within this scope:
+
+- You may inspect `/app/fixture/`, in-container local documentation, and local tools read-only; `/app/fixture/` must remain completely unchanged; you may write your report into the designated `/app/agent-output/` directory as the brief specifies;
+- You may create temporary files needed for the report and run read-only local scan commands, but you must not execute migrations or installations;
+- You must not modify the skill, the evaluator, or the reference answers, and you must not publish, push, access external services, or alter resources outside the container;
+- If you cannot complete the task, state the blocker honestly, but do not stop merely because another round of confirmation is missing.
+
+I maintain the community Web plugin `@org/dsh-attach-input` (lib-only bundle, no build
+step). I just edited the repo's `lib/client.js` / `lib/index.js` to ship a hover-preview
+feature, and the verification went wrong in every direction: a browser refresh showed
+nothing new, copying the files into the profile's node_modules hit EBUSY, and a
+rename-aside recovery left BOTH my repo and the profile with no entry files at all. The
+evidence pack in `/app/fixture/` (read-only — do not modify it) has my full PowerShell
+session, the filesystem introspection, and my own write-up of what happened.
+
+**Your report** (write to `/app/agent-output/S14-link-install-lock-trap/`, any filename):
+
+1. What the profile entry actually is (cite the introspection): what a Junction install
+   means for deployment, and whether copying repo files into the profile's node_modules
+   was EVER the right move for this install mode;
+2. The two locks and their owners: why a browser refresh shows stale code (which process
+   serves the client bundle, what holds the lib files open), and why closing the browser
+   tab did not release the EBUSY;
+3. Why the rename-aside trick destroyed the SOURCE directory too (both paths are the same
+   directory through the junction), and the exact recovery from the current broken state
+   (only `client.js.old2` / `index.js.old2` exist — restore the original names, verify
+   syntax, then activate);
+4. The complete, ordered activation procedure for a link-installed lib-only Web plugin
+   after repo edits: which processes must fully stop and restart (host vs browser), why a
+   hard refresh (cache bypass) is needed for `client.js`, and how to verify the new code
+   actually loaded;
+5. The pre-flight check that should come before touching any file: how to determine the
+   install mode (link vs copied dependency) from the profile (LinkType/Target,
+   cordis.patch.yml install marker), and why the generic "copy into node_modules" advice
+   is actively harmful for link installs.
+
+What is tested: recognizing a link/junction install and its deploy semantics (repo tree IS
+the installed copy), attributing both locks to the right processes (running dsh host, not
+the browser), recovering a rename-aside accident safely, and not applying copied-install
+advice to a linked install.

--- a/benchmark/tasks/S14-link-install-lock-trap/solution/SOLUTION.md
+++ b/benchmark/tasks/S14-link-install-lock-trap/solution/SOLUTION.md
@@ -1,0 +1,24 @@
+# S14 参考解法
+
+## 考点（一句话）
+
+link/junction 安装的插件，**仓库工作树就是 profile 的安装副本**：改完仓库无需任何
+"同步复制"；两把锁分别是**运行中的 dsh 宿主进程**（持有 lib 文件句柄 → EBUSY，与浏览器
+无关）与**浏览器缓存的 client bundle**（硬刷新解决）；rename-aside 在 junction 下等于把
+唯一一份真身改名（两个路径是同一目录），正确恢复是把 .old2 改回原名。
+
+## 参考报告
+
+见 [report.md](report.md)，期望 judge 得分 100。
+
+## 判分要点
+
+只读门禁 + 五要点各 20：junction 语义（无需复制/复制有害）、两把锁归因（宿主进程 +
+浏览器缓存，关浏览器不解锁）、rename-aside 灾难机理与恢复（同目录、改回原名 + 语法检查）、
+正确激活顺序（完全停宿主 → 重启 → 硬刷新 → 验证加载）、装前判别安装模式
+（LinkType/Target、patch.yml 安装标记）。
+
+## fixture 出处
+
+真实 2026-09-03 dsh-paste-input v0.1.17 悬停预览功能验证会话（junction 安装 + EBUSY +
+rename-aside 事故），插件名与路径已改写。

--- a/benchmark/tasks/S14-link-install-lock-trap/solution/report.md
+++ b/benchmark/tasks/S14-link-install-lock-trap/solution/report.md
@@ -1,0 +1,76 @@
+# S14 report — Link-install file-lock trap
+
+## 1. What the profile entry is: a junction, so the repo IS the installed copy
+
+profile-introspection.txt shows `LinkType: Junction` with `Target: {E:\dev\dsh-attach-input}`
+and the cordis.patch.yml marker `# link:E:\dev\dsh-attach-input`. The plugin was installed
+with `dsh plugin --profile web add link:<repo>`: the profile's node_modules entry is a
+filesystem junction pointing at the repo working tree. Deploying repo edits therefore
+requires **no copy at all** — editing `E:\dev\dsh-attach-input\lib*.js` already edited the
+installed plugin. Step 4 (Copy-Item into node_modules) was never necessary for this install
+mode; for a junction it is at best a no-op onto itself and at worst (as here) an accident
+generator. Copying into node_modules is only meaningful for copied/registry installs.
+
+## 2. The two locks and their owners
+
+- **The lib files are held by the running dsh host process**, not the browser: the Node
+  process that launched the web profile loaded the plugin's modules and keeps the file
+  handles open (Windows). That is why closing the browser tab did not release the EBUSY —
+  the lock owner is the host, so only a **full host stop** (exit every dsh window/process,
+  not a page refresh, and not just closing the tab) releases it.
+- **The browser refresh showed stale code because the client bundle is cached**: the host
+  serves `client.js` and the browser may satisfy it from cache. After the host restarts,
+  a **hard refresh (Ctrl+Shift+R / cache bypass)** is required so the new `client.js` is
+  actually fetched. A plain refresh can keep running the previous bundle even though the
+  host already has the new files.
+
+## 3. Why rename-aside destroyed the source, and the recovery
+
+Through the junction, `C:\...\node_modules\@org\dsh-attach-input` and `E:\dev\dsh-attach-input`
+are **the same directory**. Renaming "the profile's" client.js to client.js.old2 renamed the
+one physical file; the subsequent Copy-Item then failed ("source does not exist") because
+the source path — the same file — had just been renamed. Both listings showing only .old2
+files is the same directory listed twice. Recovery from the current state:
+
+1. Rename the files back to their original names
+   (`client.js.old2` → `client.js`, `index.js.old2` → `index.js`) — renaming is allowed
+   even while the host holds the old handles open;
+2. Verify integrity: `node --check` both files, confirm `package.json` version/exports;
+3. Then follow the activation procedure below. Nothing was lost — the .old2 files ARE the
+   new feature code; only the names moved.
+
+## 4. Complete activation procedure for a link-installed lib-only Web plugin
+
+1. Finish the repo edits (the working tree is already the installed copy — nothing to sync);
+2. **Fully stop the dsh host** (quit every dsh window / process — a running host keeps old
+   modules in memory even if files change on disk);
+3. Restart `dsh web`;
+4. **Hard-refresh the browser** (Ctrl+Shift+R) to bypass the cached client bundle;
+5. Verify the new code loaded: check the plugin's version marker (version chip /
+   `PLUGIN_VERSION`) or exercise the new feature; the browser console should show no
+   module load errors.
+
+## 5. The pre-flight check: determine install mode before touching files
+
+Before any "deploy" action, inspect what the profile entry actually is:
+
+- `Get-Item <profile>\node_modules\@org\dsh-attach-input | Select LinkType, Target` —
+  `LinkType: Junction` (with the repo Target) means a link install: repo edits ARE live,
+  never copy into node_modules;
+- or read `cordis.patch.yml` for the `link:<path>` install marker;
+- an empty LinkType means a copied/registry install, where replacing files (after a full
+  host stop) is the mechanism — but even then the EBUSY rule applies: the host process
+  must be stopped first.
+
+Generic "copy your build into node_modules" advice is actively harmful for link installs:
+it masks the fact that the repo is the source of truth, invites exactly this EBUSY/rename
+accident, and can leave the plugin with no entry files.
+
+## 6. Regression / prevention notes
+
+- Document the install mode in the plugin README's verification section ("link install:
+  restart host + hard refresh; never copy files");
+- Treat "Copy-Item EBUSY under .dsh\profiles" as a smell: identify the lock owner
+  (running host) and the install mode (junction) before retrying anything;
+- Never rename-aside files under a path you have not resolved (junction traversal makes
+  "two" directories one).

--- a/benchmark/tasks/S14-link-install-lock-trap/solution/solve.sh
+++ b/benchmark/tasks/S14-link-install-lock-trap/solution/solve.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Oracle solution: write the reference report to the agent output directory (does not touch the fixture, honoring read-only discipline).
+set -e
+mkdir -p /app/agent-output/S14-link-install-lock-trap
+cp "$(dirname "$0")/report.md" /app/agent-output/S14-link-install-lock-trap/report.md

--- a/benchmark/tasks/S14-link-install-lock-trap/task.toml
+++ b/benchmark/tasks/S14-link-install-lock-trap/task.toml
@@ -2,7 +2,7 @@ schema_version = "1.4"
 # Harbor task config: dsh plugin link-install file-lock trap task S14 (static, read-only)
 [task]
 name = "dsh-plugin-upgrade/s14-link-install-lock-trap"
-version = "1.0.0"
+version = "1.1.0"
 description = "Diagnose why repo edits to a link-installed plugin never reach the GUI, why copying into the profile hits EBUSY, and derive the correct activation procedure"
 keywords = ["dsh", "plugin-runtime", "link-install", "file-lock", "harbor"]
 

--- a/benchmark/tasks/S14-link-install-lock-trap/task.toml
+++ b/benchmark/tasks/S14-link-install-lock-trap/task.toml
@@ -1,0 +1,25 @@
+schema_version = "1.4"
+# Harbor task config: dsh plugin link-install file-lock trap task S14 (static, read-only)
+[task]
+name = "dsh-plugin-upgrade/s14-link-install-lock-trap"
+version = "1.0.0"
+description = "Diagnose why repo edits to a link-installed plugin never reach the GUI, why copying into the profile hits EBUSY, and derive the correct activation procedure"
+keywords = ["dsh", "plugin-runtime", "link-install", "file-lock", "harbor"]
+
+[metadata]
+difficulty = "medium"
+category = "programming"
+tags = ["dsh", "plugin-runtime", "client-api-contract", "english-prompt"]
+execution_contract = "BENCHMARK-AUTH-v1"
+
+[agent]
+timeout_sec = 300.0
+
+[verifier]
+timeout_sec = 120.0
+
+[environment]
+network_mode = "public"
+cpus = 1
+memory_mb = 2048
+storage_mb = 4096

--- a/benchmark/tasks/S14-link-install-lock-trap/tests/judge-utils.mjs
+++ b/benchmark/tasks/S14-link-install-lock-trap/tests/judge-utils.mjs
@@ -1,0 +1,191 @@
+// Shared benchmark grading library (harbor edition, zero dependencies).
+// Conventions:
+// - every judge.mjs always exits with code 0; the last stdout line outputs {"score": 0-100, "max": 100, "reasons": [...]};
+// - static tasks put agent artifacts under /app/agent-output/<task-id>/;
+// - container tasks (M1/H1/H2/H3) let the agent modify /app/fixture/ directly, and the judge does a real cold boot inside the task container
+//   (the image has dsh 0.1.2-alpha.2 installed globally, no docker exec needed);
+// - each task uses its own profile (bench-<task>) and its own /tmp plugin directory; the judge cleans up the assets it created.
+import { execFile } from 'node:child_process'
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs'
+import { join, relative, resolve, sep } from 'node:path'
+
+export const APP_ROOT = '/app'
+export const FIXTURE_DIR = join(APP_ROOT, 'fixture')
+export const DEFAULT_AGENT_OUTPUT = join(APP_ROOT, 'agent-output')
+export const BENCH_TMP = (taskId) => `/tmp/bench-${taskId.toLowerCase()}`
+export const PROFILE = (taskId) => `bench-${taskId.toLowerCase()}`
+
+// ── Result output ──────────────────────────────────────
+
+export function emit(score, reasons) {
+  const result = { score: Math.max(0, Math.min(100, Math.round(score))), max: 100, reasons }
+  process.stdout.write(JSON.stringify(result) + '\n')
+  process.exit(0)
+}
+
+// ── Agent output collection (static tasks) ─────────────
+
+const TEXT_EXT = new Set(['.md', '.txt', '.json', '.jsonl', '.log'])
+
+function walkFiles(dir) {
+  const out = []
+  if (!existsSync(dir)) return out
+  for (const entry of readdirSync(dir)) {
+    const path = join(dir, entry)
+    const stat = statSync(path)
+    if (stat.isDirectory()) out.push(...walkFiles(path))
+    else out.push(path)
+  }
+  return out
+}
+
+/** Collect all text artifacts under <agentOutput>/<taskId>/ and join them into one big string. */
+export function readAgentText(agentOutput, taskId) {
+  const root = agentOutput || DEFAULT_AGENT_OUTPUT
+  const dir = join(root, taskId)
+  const files = walkFiles(dir).filter((file) => TEXT_EXT.has(file.slice(file.lastIndexOf('.'))))
+  const text = files.map((file) => readFileSync(file, 'utf8')).join('\n\n')
+  return { text, files: files.map((file) => relative(root, file)) }
+}
+
+// ── Git status (whether the fixture changed) ───────────
+
+function git(args, cwd) {
+  return new Promise((resolvePromise) => {
+    execFile('git', args, { cwd, timeout: 20000 }, (error, stdout, stderr) => {
+      resolvePromise({ code: error?.code ?? 0, stdout, stderr: stderr ?? '' })
+    })
+  })
+}
+
+/** Return the fixture paths relative to APP_ROOT (modified/added/deleted). Empty array = unchanged. */
+export async function fixtureChanges(relFixtureDir = 'fixture') {
+  const result = await git(['status', '--porcelain', '--', relFixtureDir], APP_ROOT)
+  if (result.code !== 0) return { changed: null, detail: `git status failed: ${result.stderr.trim()}` }
+  const lines = result.stdout.split('\n').filter(Boolean)
+  return {
+    changed: lines.length > 0 ? true : false,
+    detail: lines.length ? lines.join('; ') : 'fixture unchanged relative to baseline',
+  }
+}
+
+// ── Local command primitives (judge runs in the task container) ──
+
+export function localExec(script, { stdin = '', timeout = 60000 } = {}) {
+  return new Promise((resolvePromise) => {
+    const child = execFile('sh', ['-c', script], { timeout }, (error, stdout, stderr) => {
+      resolvePromise({
+        code: error?.code ?? 0,
+        stdout: stdout ?? '',
+        stderr: stderr ?? '',
+        killed: error?.killed === true || (error && error.code === undefined) === true,
+      })
+    })
+    if (stdin) child.stdin.write(stdin)
+    child.stdin.end()
+  })
+}
+
+export async function dshAvailable() {
+  const result = await localExec('dsh --version', { timeout: 15000 })
+  return result.code === 0
+}
+
+// ── Profile lifecycle ──────────────────────────────────
+
+/** Create an isolated profile (bundles is an array of host package names). */
+export async function createProfile(profile, bundles) {
+  const dir = `/root/.dsh/profiles/${profile}`
+  const pkg = {
+    name: `dsh-profile-${profile}`,
+    private: true,
+    dependencies: {},
+    dsh: { profile: { bundles, patchReload: 'startup' } },
+  }
+  const write = await localExec(`rm -rf '${dir}' && mkdir -p '${dir}' && base64 -d > '${dir}/package.json'`, {
+    stdin: Buffer.from(JSON.stringify(pkg, null, 2) + '\n').toString('base64'),
+  })
+  if (write.code !== 0) return { ok: false, detail: `profile write failed: ${write.stderr.trim()}` }
+  const seed = await localExec(
+    `cp /root/.dsh/profiles/headless/pnpm-workspace.yaml '${dir}/' 2>/dev/null || printf 'packages:\\n  - .\\n\\nnodeLinker: hoisted\\nautoInstallPeers: false\\n' > '${dir}/pnpm-workspace.yaml'
+printf '[]\\n' > '${dir}/cordis.patch.yml'
+printf '[]\\n' > '${dir}/cordis.yml'`,
+  )
+  if (seed.code !== 0) return { ok: false, detail: `profile seed files failed: ${seed.stderr.trim()}` }
+  return { ok: true, dir }
+}
+
+export async function addPlugin(profile, pluginDir) {
+  const result = await localExec(`dsh plugin --profile '${profile}' add '${pluginDir}'`, { timeout: 180000 })
+  return { ok: result.code === 0, detail: (result.stdout + result.stderr).trim().slice(-400) }
+}
+
+/** Clean up task-created assets: profile, temporary plugin directory, leftover boot processes. */
+export async function cleanupProfile(profile, tmpDir) {
+  // The pkill pattern uses the [first-letter] bracket trick to avoid matching the sh -c process running this cleanup script itself.
+  const selfSafe = `[${profile[0]}]${profile.slice(1)}`
+  await localExec(
+    `pkill -f 'profile ${selfSafe}' 2>/dev/null; rm -rf '/root/.dsh/profiles/${profile}' '${tmpDir}' /tmp/${profile}-boot.log; true`,
+  )
+}
+
+// ── Cold boot signal detection ─────────────────────────
+
+export const NEGATIVE_SIGNAL = /plugin tree failed|did not activate|pending \(waiting for service|FAILED fiber|ClientPackageCompositionError/i
+// A headless profile without an API key always reaches MISSING_CREDENTIAL — emitting this line proves
+// the plugin tree fully activated and the boot flow reached the host application layer (consistent with the validation report attribution).
+export const HEADLESS_ACTIVATED_SIGNAL = /MISSING_CREDENTIAL|no API key|dsh: AUTH/i
+
+/** Headless cold boot: returns the full output. Exit code is not a verdict (success is also 1 without a key). */
+export async function bootHeadless(profile) {
+  const result = await localExec(`cd /root && timeout 30 dsh --profile '${profile}' 'ping' 2>&1`, { timeout: 60000 })
+  return { output: result.stdout + result.stderr, code: result.code }
+}
+
+/**
+ * Web cold boot and read __DSH_BOOT__:
+ * 1. start `dsh --profile <p> --no-open` in the background, wait for a dsh web: URL line in the log;
+ * 2. exchange the bootstrap token for a Cookie, GET / for the HTML;
+ * 3. return { output, html }; the caller judges negative signals and the plugin entry.
+ */
+export async function bootWebAndFetchIndex(profile, pkgName) {
+  const logPath = `/tmp/${profile}-boot.log`
+  await localExec(`cd /root && nohup timeout 45 dsh --profile '${profile}' --no-open > '${logPath}' 2>&1 & echo started`)
+  const probe = await localExec(
+    `node --input-type=module -e '
+const logPath = process.argv[1];
+const pkgName = process.argv[2];
+const fs = await import("node:fs");
+let log = "";
+for (let i = 0; i < 90; i += 1) {
+  try { log = fs.readFileSync(logPath, "utf8"); } catch {}
+  if (/dsh web: http|plugin tree failed|did not activate/i.test(log)) break;
+  await new Promise((r) => setTimeout(r, 1000));
+}
+const match = /dsh web: (http:\\S+)/.exec(log);
+const outcome = { log };
+if (match) {
+  try {
+    const r1 = await fetch(match[1], { redirect: "manual" });
+    const setCookie = r1.headers.getSetCookie ? r1.headers.getSetCookie() : [r1.headers.get("set-cookie")];
+    const cookie = setCookie.filter(Boolean).map((c) => c.split(";")[0]).join("; ");
+    const r2 = await fetch("http://127.0.0.1:3080/", { headers: { cookie } });
+    outcome.html = await r2.text();
+  } catch (error) {
+    outcome.fetchError = String(error);
+  }
+}
+console.log("__RESULT__" + JSON.stringify(outcome));
+' '${logPath}' '${pkgName}'`,
+    { timeout: 150000 },
+  )
+  const marker = '__RESULT__'
+  const idx = probe.stdout.lastIndexOf(marker)
+  if (idx < 0) return { output: probe.stdout + probe.stderr, html: '', probeError: probe.stderr.trim() }
+  try {
+    const outcome = JSON.parse(probe.stdout.slice(idx + marker.length).trim())
+    return { output: outcome.log ?? '', html: outcome.html ?? '', fetchError: outcome.fetchError }
+  } catch {
+    return { output: probe.stdout + probe.stderr, html: '', probeError: 'failed to parse boot result' }
+  }
+}

--- a/benchmark/tasks/S14-link-install-lock-trap/tests/judge.mjs
+++ b/benchmark/tasks/S14-link-install-lock-trap/tests/judge.mjs
@@ -1,0 +1,57 @@
+// S14-link-install-lock-trap grading: fixture read-only gate + five diagnosis aspects.
+// Expected (link-installed lib-only plugin rollout failure):
+//   1. Junction semantics: the profile entry IS the repo working tree; copying repo files
+//      into node_modules was never necessary (and is harmful) for a link install.
+//   2. Lock attribution: the EBUSY holder is the RUNNING DSH HOST process (not the
+//      browser, which is why closing the tab did not help); the stale client code after
+//      refresh is browser cache of client.js (needs hard refresh).
+//   3. Rename-aside mechanism + recovery: both paths are the same directory through the
+//      junction, so the rename moved the only copy; recovery = rename .old2 back,
+//      node --check, then activate.
+//   4. Ordered activation: stop host fully -> restart dsh web -> hard-refresh browser ->
+//      verify loaded (version marker / feature / console).
+//   5. Pre-flight install-mode check: LinkType/Target (or cordis.patch.yml link: marker)
+//      BEFORE any file operation; generic copy-into-node_modules advice is for copied
+//      installs only.
+import { emit, fixtureChanges, readAgentText } from './judge-utils.mjs'
+
+const TASK = 'S14-link-install-lock-trap'
+
+const ASPECTS = [
+  { key: 'junction semantics: repo tree IS the installed copy; copy was never needed', pattern: /(junction|link)[\s\S]{0,300}(same (directory|tree|files)|installed copy|is the (repo|working tree)|no copy|nothing to copy|never (be )?necessar|harmful)/i, points: 20 },
+  { key: 'lock owners: running dsh host holds the lib files (not the browser); browser cache needs hard refresh', pattern: /(host|dsh (web )?process|node process)[\s\S]{0,220}(holds?|lock|open|handle|file lock|EBUSY)/i, points: 20 },
+  { key: 'rename-aside same-directory mechanism + rename-back recovery', pattern: /(same directory|one (physical )?copy|junction)[\s\S]{0,260}(rename|old2|restore|back to)|rename[\s\S]{0,200}(back|restore|original name)/i, points: 20 },
+  { key: 'ordered activation: full host stop -> restart -> hard refresh -> verify', pattern: /(stop|quit|exit|fully? stop)[\s\S]{0,240}(host|dsh)[\s\S]{0,300}(restart|relaunch)[\s\S]{0,300}(hard[- ]refresh|cache bypass|Ctrl\+Shift\+R)/i, points: 20 },
+  { key: 'pre-flight install-mode check (LinkType/Target or patch.yml link marker)', pattern: /(LinkType|Target|patch\.yml|link:)[\s\S]{0,240}(before|first|pre-?flight|check|determin)/i, points: 20 },
+]
+
+main().catch((error) => emit(0, [`judge error: ${error.message}`]))
+
+async function main() {
+  const reasons = []
+
+  const gate = await fixtureChanges('fixture')
+  if (gate.changed === true) {
+    emit(0, [`fixture was modified, 0 points for this task (read-only discipline): ${gate.detail}`])
+  }
+  if (gate.changed === null) reasons.push(`warning: ${gate.detail}`)
+  else reasons.push('fixture unchanged (read-only discipline passed)')
+
+  const { text, files } = readAgentText('', TASK)
+  if (!text.trim()) {
+    emit(0, [...reasons, `no report found under /app/agent-output/${TASK}/, treated as 0 points`])
+  }
+  reasons.push(`read agent report: ${files.join(', ')}`)
+
+  let score = 0
+  for (const aspect of ASPECTS) {
+    if (aspect.pattern.test(text)) {
+      score += aspect.points
+      reasons.push(`hit aspect: ${aspect.key} (+${aspect.points})`)
+    } else {
+      reasons.push(`missing aspect: ${aspect.key} (-${aspect.points})`)
+    }
+  }
+
+  emit(score, reasons)
+}

--- a/benchmark/tasks/S14-link-install-lock-trap/tests/test.sh
+++ b/benchmark/tasks/S14-link-install-lock-trap/tests/test.sh
@@ -6,8 +6,7 @@ node /tests/judge.mjs > /tmp/judge.out 2>&1
 cat /tmp/judge.out
 node -e '
 const fs = require("node:fs");
-const lines = fs.readFileSync("/tmp/judge.out", "utf8").trim().split("
-").filter(Boolean);
+const lines = fs.readFileSync("/tmp/judge.out", "utf8").trim().split("\n").filter(Boolean);
 let score = 0;
 for (let i = lines.length - 1; i >= 0; i -= 1) {
   try {

--- a/benchmark/tasks/S14-link-install-lock-trap/tests/test.sh
+++ b/benchmark/tasks/S14-link-install-lock-trap/tests/test.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Harbor verifier: run judge.mjs (its last line outputs a 0-100 score JSON), normalized to a 0~1 reward.
+# judge itself always exits 0; when no JSON can be parsed, treat the score as 0 (error-tolerant principle).
+mkdir -p /logs/verifier
+node /tests/judge.mjs > /tmp/judge.out 2>&1
+cat /tmp/judge.out
+node -e '
+const fs = require("node:fs");
+const lines = fs.readFileSync("/tmp/judge.out", "utf8").trim().split("
+").filter(Boolean);
+let score = 0;
+for (let i = lines.length - 1; i >= 0; i -= 1) {
+  try {
+    const j = JSON.parse(lines[i]);
+    if (typeof j.score === "number" && typeof j.max === "number") { score = j.score; break }
+  } catch {}
+}
+const reward = Math.max(0, Math.min(1, score / 100));
+fs.writeFileSync("/logs/verifier/reward.txt", String(reward) + "\n")
+'

--- a/benchmark/tasks/S15-slot-error-boundary-crash/README.md
+++ b/benchmark/tasks/S15-slot-error-boundary-crash/README.md
@@ -1,0 +1,16 @@
+# S15 · Slot Error-Boundary Crash (vanishing dock chips)
+
+Static, read-only. A lib-only Web plugin's dock-chip component references another
+component's state variable (`busy`) inside a props object; the expression only evaluates
+when the phase guard is false, so the bug ships latent — until the first release where a
+user actually renders a chip, the ReferenceError fires inside the slot and the framework's
+error boundary unmounts the entire entry. The user-visible symptom is "the chips are gone",
+pointing at the newest feature diff instead of the pre-existing line.
+
+Derived from a real 2026-09-03 dsh-paste-input v0.1.17 session (dangling `busy` in
+AttachmentChips; surfaced by the hover-preview rollout).
+
+- Type: static / read-only report
+- Score: 5 aspects × 20 points, fixture-modification gate → 0
+- **Oracle**: `harbor run -p benchmark/tasks/S15-slot-error-boundary-crash -a oracle`, expected 1.0.
+- See `instruction.md` for the brief, `solution/SOLUTION.md` for the reference answer

--- a/benchmark/tasks/S15-slot-error-boundary-crash/environment/Dockerfile
+++ b/benchmark/tasks/S15-slot-error-boundary-crash/environment/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:24-bookworm
+
+# git 供 judge 检测 fixture 是否被改动（只读纪律门禁）
+RUN apt-get update && apt-get install -y --no-install-recommends git     && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY fixture /app/fixture
+
+# 基线提交：judge 用 `git status --porcelain -- fixture` 判定 agent 是否守只读纪律
+RUN git init -q && git add -A && git -c user.email=bench@local -c user.name=bench commit -q -m "baseline"

--- a/benchmark/tasks/S15-slot-error-boundary-crash/environment/fixture/README.md
+++ b/benchmark/tasks/S15-slot-error-boundary-crash/environment/fixture/README.md
@@ -1,0 +1,11 @@
+# S15 fixture · Vanishing dock chips evidence pack (static)
+
+Evidence for the S15-slot-error-boundary-crash task: the plugin's dock-chip component and
+the attach button it sits next to, the feature diff that first exercised the crash path,
+and the user thread reporting the symptom. **Read-only fixture — do not execute or publish
+anything here**; the task grading requires this directory to be unchanged relative to git
+HEAD.
+
+- `plugin-dock-chips.js` — the dock chip component (AttachmentChips) and the attach button (AttachButton) as shipped in v0.2.10
+- `feature.diff` — the v0.2.11 hover-preview diff that touched the same component and exposed the crash
+- `user-thread.md` — what the user saw after updating to v0.2.11

--- a/benchmark/tasks/S15-slot-error-boundary-crash/environment/fixture/feature.diff
+++ b/benchmark/tasks/S15-slot-error-boundary-crash/environment/fixture/feature.diff
@@ -1,0 +1,37 @@
+diff --git a/lib/client.js b/lib/client.js
+--- a/lib/client.js
++++ b/lib/client.js
+@@ function AttachmentChips(props, className) {
+   const occurrences = (props.input?.occurrences ?? []).filter(item => item.source === SOURCE);
+   if (occurrences.length === 0) return null;
++  // v0.2.11: image attachments get a hover thumbnail (local blob URL) and a
++  // click-to-view handler on the chip.
++  const imageItem = status !== 'missing'
++    ? record?.items.find(item => isImagePath(item.path))
++    : undefined;
+   return h('div', { className }, ...occurrences.map(occurrence => {
+     const record = records.get(occurrence.ref);
+     const status = record?.status ?? 'missing';
+-    return h('div', { className: 'chip', 'data-status': status, key: occurrence.occurrenceId },
++    return h('div', {
++      className: 'chip',
++      'data-status': status,
++      'data-image': imageItem === undefined ? undefined : '1',
++      key: occurrence.occurrenceId,
++      onClick: imageItem === undefined ? undefined : event => {
++        if (event.target.closest('.remove') !== null) return;
++        openImageViewer({ src: objectUrlOf(imageItem.file), name: imageItem.path });
++      },
++    },
+       h('span', { className: 'name' }, record?.label ?? occurrence.label),
++      imageItem !== undefined && h('div', { className: 'hover-card' },
++        h('img', { src: objectUrlOf(imageItem.file), alt: imageItem.path })),
+       h('button', {
+         type: 'button',
+         className: 'remove',
+-        disabled: (props.input?.phase ?? 'plain') !== 'plain',
++        disabled: (props.input?.phase ?? 'plain') !== 'plain' || busy,
+         onClick: () => props.remove(occurrence),
+       }, 'x'));
+   }));
+ }

--- a/benchmark/tasks/S15-slot-error-boundary-crash/environment/fixture/plugin-dock-chips.js
+++ b/benchmark/tasks/S15-slot-error-boundary-crash/environment/fixture/plugin-dock-chips.js
@@ -1,0 +1,43 @@
+// Excerpt of @org/dsh-attach-input v0.2.10 lib/client.js (as shipped).
+// The plugin renders into two composer slots: the attach button (input.left) and the
+// pending-attachment dock above the input (InputZone occurrences).
+
+function AttachButton(props) {
+  const [open, setOpen] = React.useState(false);
+  const [busy, setBusy] = React.useState(false);          // <-- busy lives HERE
+  const [message, setMessage] = React.useState('');
+  const locked = (props.input?.phase ?? 'plain') !== 'plain';
+  const accept = React.useCallback(async (itemsOrPromise) => {
+    setBusy(true);
+    try { await props.add(await itemsOrPromise); setOpen(false); }
+    catch (cause) { setMessage(String(cause)); }
+    finally { setBusy(false); }
+  }, [props.add]);
+  return h('div', { className: 'wrap' },
+    h('button', { type: 'button', disabled: locked || busy, onClick: () => setOpen(v => !v) }, '+'),
+    open && h('div', { className: 'menu', role: 'menu' }, /* … */ null));
+}
+
+function AttachmentChips(props, className) {
+  const occurrences = (props.input?.occurrences ?? []).filter(item => item.source === SOURCE);
+  if (occurrences.length === 0) return null;
+  return h('div', { className }, ...occurrences.map(occurrence => {
+    const record = records.get(occurrence.ref);
+    const status = record?.status ?? 'missing';
+    return h('div', { className: 'chip', 'data-status': status, key: occurrence.occurrenceId },
+      h('span', { className: 'name' }, record?.label ?? occurrence.label),
+      h('button', {
+        type: 'button',
+        className: 'remove',
+        'aria-label': 'Remove ' + (record?.label ?? occurrence.label),
+        // v0.2.10 hardening pass added the phase guard — and this busy reference:
+        disabled: (props.input?.phase ?? 'plain') !== 'plain' || busy,   // <-- ???
+        onClick: () => props.remove(occurrence),
+      }, 'x'));
+  }));
+}
+
+function AttachmentDock(props) {
+  useRevision();
+  return AttachmentChips(props, 'dock');
+}

--- a/benchmark/tasks/S15-slot-error-boundary-crash/environment/fixture/user-thread.md
+++ b/benchmark/tasks/S15-slot-error-boundary-crash/environment/fixture/user-thread.md
@@ -1,0 +1,15 @@
+# Issue — "the chips above the input are GONE in v0.2.11" (user: mirren)
+
+> Updated to v0.2.11 (the hover-preview release). I pasted a screenshot to try the new
+> preview, and the little chip that used to appear above the input box — the one with the
+> filename and the x button — never showed up. The paste itself worked (the message sent
+> with the image attached). The attach button (the + on the left of the input) is still
+> there. Nothing else looks broken, and I don't see any error banner in the UI.
+
+Maintainer note (me): v0.2.11's diff touched AttachmentChips (the dock-chip component) to
+add the hover preview — see feature.diff. In v0.2.10 the same component already had the
+line `disabled: (props.input?.phase ?? 'plain') !== 'plain' || busy` (added in a hardening
+pass), and v0.2.10 users used the x button fine. The plugin registers the dock through the
+InputZone slot; a slot entry that throws during render is caught by the framework's error
+boundary and unmounted (the error is only visible in the browser console, which users
+never open). We shipped without a render smoke that mounts the dock with a chip present.

--- a/benchmark/tasks/S15-slot-error-boundary-crash/instruction.md
+++ b/benchmark/tasks/S15-slot-error-boundary-crash/instruction.md
@@ -1,0 +1,49 @@
+# S15 · Vanishing Dock Chips: the Silent Slot Crash (Read-Only)
+
+## Unattended Evaluation Authorization (BENCHMARK-AUTH-v1)
+
+This is an unattended evaluation running in a disposable, isolated container; there will be
+no follow-up user messages. This task brief is itself the user's explicit authorization and
+confirmation for the approach and execution needed to complete the task: complete the
+necessary analysis and planning on your own, and keep executing as soon as the plan is
+formed — do not pause to wait for "confirmation", and do not ask the user follow-up
+questions. That confirmation continues to apply to the concrete plans you produce under the
+applicable skill, but only within this scope:
+
+- You may inspect `/app/fixture/`, in-container local documentation, and local tools read-only; `/app/fixture/` must remain completely unchanged; you may write your report into the designated `/app/agent-output/` directory as the brief specifies;
+- You may create temporary files needed for the report and run read-only local scan commands, but you must not execute migrations or installations;
+- You must not modify the skill, the evaluator, or the reference answers, and you must not publish, push, access external services, or alter resources outside the container;
+- If you cannot complete the task, state the blocker honestly, but do not stop merely because another round of confirmation is missing.
+
+I maintain the community Web plugin `@org/dsh-attach-input`. Right after shipping v0.2.11
+(a hover-preview feature) a user reports: paste a screenshot → the pending-attachment chip
+that used to appear above the input box is gone; the paste itself still works; the attach
+button is unaffected. The evidence pack in `/app/fixture/` (read-only) has the shipped
+component code (v0.2.10), the v0.2.11 diff, and the user thread.
+
+**Your report** (write to `/app/agent-output/S15-slot-error-boundary-crash/`, any filename):
+
+1. The exact root cause: which expression throws, why it throws only when a chip renders,
+   why the `||` short-circuit kept it latent through v0.2.10, and why the symptom is "the
+   whole dock vanished" rather than "the remove button is broken" (slot-level error
+   boundary unmounts the entry; the error is only in the browser console);
+2. Why blaming the v0.2.11 diff (the hover-preview additions) is the wrong first
+   conclusion — what the correct bisection is (the diff touched the same component; a
+   rollback/re-add bisect or a minimal render mount points at the pre-existing line), and
+   what evidence distinguishes "new feature crashed the slot" from "old latent bug first
+   exercised now";
+3. The fix: remove the dangling reference (or scope it properly), and note the two
+   hardening patterns the diff should also get (`record?.items ?? []`-style defensive
+   reads, optional-chained `event.target.closest?.()`) and why they are cheap insurance in
+   slot components;
+4. The regression that would have caught this before release: a render smoke that mounts
+   the dock/chip component WITH an occurrence present (not the empty state — the empty
+   dock returns null before reaching the throwing line), asserting the chip element
+   renders without an error-boundary capture;
+5. The release-process lesson: why "syntax check only" (`node --check`) was insufficient
+   for a lib-only plugin whose component only fails at render time with data present, and
+   what the minimum viable pre-ship check for slot-rendering lib-only plugins is.
+
+What is tested: reading a free-identifier render crash and its short-circuit latency,
+understanding slot error boundaries (whole-entry unmount, console-only visibility), correct
+bisection against a misleading recent diff, and designing a data-present render regression.

--- a/benchmark/tasks/S15-slot-error-boundary-crash/solution/SOLUTION.md
+++ b/benchmark/tasks/S15-slot-error-boundary-crash/solution/SOLUTION.md
@@ -1,0 +1,27 @@
+# S15 参考解法
+
+## 考点（一句话）
+
+悬空标识符 + 短路求值 + 槽位错误边界三重叠加：`disabled: A || busy` 中 `busy` 是别的
+组件的 state（本作用域不存在），仅当 A 为 false（phase 为 plain，即正常输入态）才求值 →
+ReferenceError；该表达式只在**有 chip 渲染**时执行（空 dock 提前 return null），所以带病
+发布到某次用户真的贴了附件才爆炸；槽位级错误边界把整个条目卸载 → 症状是"dock 消失"而非
+"删除按钮坏了"，且错误只在浏览器 console。修复 = 删除悬空引用；回归 = **带 occurrence
+数据的渲染冒烟**（空态测不到这行）。
+
+## 参考报告
+
+见 [report.md](report.md)，期望 judge 得分 100。
+
+## 判分要点
+
+只读门禁 + 五要点各 20：根因（哪行抛、为何仅 chip 渲染时抛、`||` 短路为何潜伏、错误边界
+整条目卸载 + console-only）、正确归因（不应先怪 v0.2.11 diff；rollback/最小渲染挂载二分，
+区分"新功能炸槽"与"旧隐患首次被踩"）、修复 + 两种加固（防御性 `?? []`、`closest?.()`）、
+带数据渲染冒烟回归、发布流程教训（`node --check` 不够，lib-only 槽位插件最少要有
+data-present 渲染冒烟）。
+
+## fixture 出处
+
+真实 2026-09-03 dsh-paste-input v0.1.17 会话（AttachmentChips 悬空 `busy`，因悬停预览
+发布首次触发），插件与组件名已改写。

--- a/benchmark/tasks/S15-slot-error-boundary-crash/solution/report.md
+++ b/benchmark/tasks/S15-slot-error-boundary-crash/solution/report.md
@@ -1,0 +1,77 @@
+# S15 report — The silent slot crash
+
+## 1. Exact root cause
+
+The throwing expression is the remove button's `disabled` prop in AttachmentChips:
+
+```js
+disabled: (props.input?.phase ?? 'plain') !== 'plain' || busy
+```
+
+`busy` is a useState variable of **AttachButton**, a sibling component; inside
+AttachmentChips it is an undeclared free identifier. Evaluating it throws
+`ReferenceError: busy is not defined`. Three things control when that happens:
+
+- **Short-circuit latency**: `A || busy` only evaluates `busy` when `A` is false. `A` is
+  the phase guard, false exactly in the normal typing state ('plain'). So the line throws
+  precisely when the button should be enabled — but only when the object literal is
+  evaluated at all…
+- **…which only happens when a chip renders**: the empty dock returns null before the map
+  (`if (occurrences.length === 0) return null`). No pending attachment → the throwing line
+  never executes → the bug ships green through v0.2.10.
+- **Slot-level error boundary**: the throw happens during the dock slot's render; the
+  framework catches it and unmounts the whole slot entry. The symptom is therefore 'the
+  chips (and their x buttons) vanished entirely', not 'one broken button', and the error
+  surfaces only in the browser console — which users never open. The attach button lives
+  in a different slot and is unaffected.
+
+## 2. Correct attribution (not the v0.2.11 diff)
+
+The v0.2.11 feature diff touched the same component, so 'my new hover-preview code crashed
+the dock' is the tempting conclusion — but every added line in feature.diff is either a
+guarded optional chain or a conditional child; none can throw on its own at render. The
+correct bisection:
+
+1. **Rollback/re-add bisect**: revert only the diff → the chip still vanishes when a
+   screenshot is pasted → the crash predates the diff. Or:
+2. **Minimal render mount**: mount AttachmentChips directly (React test renderer /
+   headless) with one occurrence and `input.phase = 'plain'` → the ReferenceError points
+   at the exact line and file, independent of the feature code.
+
+The distinguishing evidence: v0.2.10 shipped the same `|| busy` line (see the shipped
+excerpt), and v0.2.10 users 'used the x button fine' only because none of them had hit
+the chip-present + plain-phase combination after that hardening release — which is
+exactly what pasting a screenshot to test hover preview does first. New feature ≠ new
+bug; it was the **first exerciser** of a latent one.
+
+## 3. The fix and the cheap hardening
+
+- Remove the dangling reference: `disabled: (props.input?.phase ?? 'plain') !== 'plain'`.
+  If a busy-like state is genuinely wanted in the dock, it must be a local useState in
+  AttachmentChips (or a prop) — never another component's variable.
+- Hardening for slot components (cheap insurance, both applied to the diff's own lines):
+  - defensive reads: `(record?.items ?? []).find(...)` — a missing array must not turn
+    into a TypeError that unmounts the slot;
+  - optional-chained DOM access: `event.target.closest?.('.remove')` — event targets are
+    not guaranteed Elements (text nodes).
+- Rationale: inside an error boundary, ANY throw costs the whole slot, so slot components
+  deserve a lower tolerance for ambient-undefined reads than page-level components.
+
+## 4. The regression that would have caught it
+
+A **render smoke with data present**: mount AttachmentChips (via the dock, or directly
+with a fake input carrying one occurrence whose record has items) and assert the chip
+element with its remove button actually renders — plus, if the harness exposes it, assert
+no error-boundary capture fired. The empty-dock path returns null before the throwing
+line, so an empty-state test is structurally unable to catch this class. One occurrence,
+phase 'plain', assert the chip and the remove button exist in the rendered output.
+
+## 5. Release-process lesson
+
+`node --check` (syntax-only) passes a free identifier by definition — it is a runtime
+binding error. For a lib-only plugin whose UI lives in slots, the minimum viable pre-ship
+check is: syntax check **plus at least one data-present render smoke per slot-rendering
+component** (headless DOM or React test renderer), because that is the only level at
+which free identifiers, bad prop shapes, and throwing expressions actually fire. Cheaper
+companion: lint with no-undef, which flags free identifiers statically — it would have
+named `busy` at commit time.

--- a/benchmark/tasks/S15-slot-error-boundary-crash/solution/solve.sh
+++ b/benchmark/tasks/S15-slot-error-boundary-crash/solution/solve.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Oracle solution: write the reference report to the agent output directory (does not touch the fixture, honoring read-only discipline).
+set -e
+mkdir -p /app/agent-output/S15-slot-error-boundary-crash
+cp "$(dirname "$0")/report.md" /app/agent-output/S15-slot-error-boundary-crash/report.md

--- a/benchmark/tasks/S15-slot-error-boundary-crash/task.toml
+++ b/benchmark/tasks/S15-slot-error-boundary-crash/task.toml
@@ -2,7 +2,7 @@ schema_version = "1.4"
 # Harbor task config: dangling-identifier render crash swallowed by the slot error boundary (task S15, static, read-only)
 [task]
 name = "dsh-plugin-upgrade/s15-slot-error-boundary-crash"
-version = "1.0.0"
+version = "1.1.0"
 description = "A dock-slot component references another component's state variable; the first real chip render throws ReferenceError and the error boundary silently unmounts the whole slot — diagnose, bisect, fix, and design the regression"
 keywords = ["dsh", "plugin-runtime", "react", "error-boundary", "harbor"]
 

--- a/benchmark/tasks/S15-slot-error-boundary-crash/task.toml
+++ b/benchmark/tasks/S15-slot-error-boundary-crash/task.toml
@@ -1,0 +1,25 @@
+schema_version = "1.4"
+# Harbor task config: dangling-identifier render crash swallowed by the slot error boundary (task S15, static, read-only)
+[task]
+name = "dsh-plugin-upgrade/s15-slot-error-boundary-crash"
+version = "1.0.0"
+description = "A dock-slot component references another component's state variable; the first real chip render throws ReferenceError and the error boundary silently unmounts the whole slot — diagnose, bisect, fix, and design the regression"
+keywords = ["dsh", "plugin-runtime", "react", "error-boundary", "harbor"]
+
+[metadata]
+difficulty = "medium"
+category = "programming"
+tags = ["dsh", "plugin-runtime", "client-api-contract", "english-prompt"]
+execution_contract = "BENCHMARK-AUTH-v1"
+
+[agent]
+timeout_sec = 300.0
+
+[verifier]
+timeout_sec = 120.0
+
+[environment]
+network_mode = "public"
+cpus = 1
+memory_mb = 2048
+storage_mb = 4096

--- a/benchmark/tasks/S15-slot-error-boundary-crash/tests/judge-utils.mjs
+++ b/benchmark/tasks/S15-slot-error-boundary-crash/tests/judge-utils.mjs
@@ -1,0 +1,191 @@
+// Shared benchmark grading library (harbor edition, zero dependencies).
+// Conventions:
+// - every judge.mjs always exits with code 0; the last stdout line outputs {"score": 0-100, "max": 100, "reasons": [...]};
+// - static tasks put agent artifacts under /app/agent-output/<task-id>/;
+// - container tasks (M1/H1/H2/H3) let the agent modify /app/fixture/ directly, and the judge does a real cold boot inside the task container
+//   (the image has dsh 0.1.2-alpha.2 installed globally, no docker exec needed);
+// - each task uses its own profile (bench-<task>) and its own /tmp plugin directory; the judge cleans up the assets it created.
+import { execFile } from 'node:child_process'
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs'
+import { join, relative, resolve, sep } from 'node:path'
+
+export const APP_ROOT = '/app'
+export const FIXTURE_DIR = join(APP_ROOT, 'fixture')
+export const DEFAULT_AGENT_OUTPUT = join(APP_ROOT, 'agent-output')
+export const BENCH_TMP = (taskId) => `/tmp/bench-${taskId.toLowerCase()}`
+export const PROFILE = (taskId) => `bench-${taskId.toLowerCase()}`
+
+// ── Result output ──────────────────────────────────────
+
+export function emit(score, reasons) {
+  const result = { score: Math.max(0, Math.min(100, Math.round(score))), max: 100, reasons }
+  process.stdout.write(JSON.stringify(result) + '\n')
+  process.exit(0)
+}
+
+// ── Agent output collection (static tasks) ─────────────
+
+const TEXT_EXT = new Set(['.md', '.txt', '.json', '.jsonl', '.log'])
+
+function walkFiles(dir) {
+  const out = []
+  if (!existsSync(dir)) return out
+  for (const entry of readdirSync(dir)) {
+    const path = join(dir, entry)
+    const stat = statSync(path)
+    if (stat.isDirectory()) out.push(...walkFiles(path))
+    else out.push(path)
+  }
+  return out
+}
+
+/** Collect all text artifacts under <agentOutput>/<taskId>/ and join them into one big string. */
+export function readAgentText(agentOutput, taskId) {
+  const root = agentOutput || DEFAULT_AGENT_OUTPUT
+  const dir = join(root, taskId)
+  const files = walkFiles(dir).filter((file) => TEXT_EXT.has(file.slice(file.lastIndexOf('.'))))
+  const text = files.map((file) => readFileSync(file, 'utf8')).join('\n\n')
+  return { text, files: files.map((file) => relative(root, file)) }
+}
+
+// ── Git status (whether the fixture changed) ───────────
+
+function git(args, cwd) {
+  return new Promise((resolvePromise) => {
+    execFile('git', args, { cwd, timeout: 20000 }, (error, stdout, stderr) => {
+      resolvePromise({ code: error?.code ?? 0, stdout, stderr: stderr ?? '' })
+    })
+  })
+}
+
+/** Return the fixture paths relative to APP_ROOT (modified/added/deleted). Empty array = unchanged. */
+export async function fixtureChanges(relFixtureDir = 'fixture') {
+  const result = await git(['status', '--porcelain', '--', relFixtureDir], APP_ROOT)
+  if (result.code !== 0) return { changed: null, detail: `git status failed: ${result.stderr.trim()}` }
+  const lines = result.stdout.split('\n').filter(Boolean)
+  return {
+    changed: lines.length > 0 ? true : false,
+    detail: lines.length ? lines.join('; ') : 'fixture unchanged relative to baseline',
+  }
+}
+
+// ── Local command primitives (judge runs in the task container) ──
+
+export function localExec(script, { stdin = '', timeout = 60000 } = {}) {
+  return new Promise((resolvePromise) => {
+    const child = execFile('sh', ['-c', script], { timeout }, (error, stdout, stderr) => {
+      resolvePromise({
+        code: error?.code ?? 0,
+        stdout: stdout ?? '',
+        stderr: stderr ?? '',
+        killed: error?.killed === true || (error && error.code === undefined) === true,
+      })
+    })
+    if (stdin) child.stdin.write(stdin)
+    child.stdin.end()
+  })
+}
+
+export async function dshAvailable() {
+  const result = await localExec('dsh --version', { timeout: 15000 })
+  return result.code === 0
+}
+
+// ── Profile lifecycle ──────────────────────────────────
+
+/** Create an isolated profile (bundles is an array of host package names). */
+export async function createProfile(profile, bundles) {
+  const dir = `/root/.dsh/profiles/${profile}`
+  const pkg = {
+    name: `dsh-profile-${profile}`,
+    private: true,
+    dependencies: {},
+    dsh: { profile: { bundles, patchReload: 'startup' } },
+  }
+  const write = await localExec(`rm -rf '${dir}' && mkdir -p '${dir}' && base64 -d > '${dir}/package.json'`, {
+    stdin: Buffer.from(JSON.stringify(pkg, null, 2) + '\n').toString('base64'),
+  })
+  if (write.code !== 0) return { ok: false, detail: `profile write failed: ${write.stderr.trim()}` }
+  const seed = await localExec(
+    `cp /root/.dsh/profiles/headless/pnpm-workspace.yaml '${dir}/' 2>/dev/null || printf 'packages:\\n  - .\\n\\nnodeLinker: hoisted\\nautoInstallPeers: false\\n' > '${dir}/pnpm-workspace.yaml'
+printf '[]\\n' > '${dir}/cordis.patch.yml'
+printf '[]\\n' > '${dir}/cordis.yml'`,
+  )
+  if (seed.code !== 0) return { ok: false, detail: `profile seed files failed: ${seed.stderr.trim()}` }
+  return { ok: true, dir }
+}
+
+export async function addPlugin(profile, pluginDir) {
+  const result = await localExec(`dsh plugin --profile '${profile}' add '${pluginDir}'`, { timeout: 180000 })
+  return { ok: result.code === 0, detail: (result.stdout + result.stderr).trim().slice(-400) }
+}
+
+/** Clean up task-created assets: profile, temporary plugin directory, leftover boot processes. */
+export async function cleanupProfile(profile, tmpDir) {
+  // The pkill pattern uses the [first-letter] bracket trick to avoid matching the sh -c process running this cleanup script itself.
+  const selfSafe = `[${profile[0]}]${profile.slice(1)}`
+  await localExec(
+    `pkill -f 'profile ${selfSafe}' 2>/dev/null; rm -rf '/root/.dsh/profiles/${profile}' '${tmpDir}' /tmp/${profile}-boot.log; true`,
+  )
+}
+
+// ── Cold boot signal detection ─────────────────────────
+
+export const NEGATIVE_SIGNAL = /plugin tree failed|did not activate|pending \(waiting for service|FAILED fiber|ClientPackageCompositionError/i
+// A headless profile without an API key always reaches MISSING_CREDENTIAL — emitting this line proves
+// the plugin tree fully activated and the boot flow reached the host application layer (consistent with the validation report attribution).
+export const HEADLESS_ACTIVATED_SIGNAL = /MISSING_CREDENTIAL|no API key|dsh: AUTH/i
+
+/** Headless cold boot: returns the full output. Exit code is not a verdict (success is also 1 without a key). */
+export async function bootHeadless(profile) {
+  const result = await localExec(`cd /root && timeout 30 dsh --profile '${profile}' 'ping' 2>&1`, { timeout: 60000 })
+  return { output: result.stdout + result.stderr, code: result.code }
+}
+
+/**
+ * Web cold boot and read __DSH_BOOT__:
+ * 1. start `dsh --profile <p> --no-open` in the background, wait for a dsh web: URL line in the log;
+ * 2. exchange the bootstrap token for a Cookie, GET / for the HTML;
+ * 3. return { output, html }; the caller judges negative signals and the plugin entry.
+ */
+export async function bootWebAndFetchIndex(profile, pkgName) {
+  const logPath = `/tmp/${profile}-boot.log`
+  await localExec(`cd /root && nohup timeout 45 dsh --profile '${profile}' --no-open > '${logPath}' 2>&1 & echo started`)
+  const probe = await localExec(
+    `node --input-type=module -e '
+const logPath = process.argv[1];
+const pkgName = process.argv[2];
+const fs = await import("node:fs");
+let log = "";
+for (let i = 0; i < 90; i += 1) {
+  try { log = fs.readFileSync(logPath, "utf8"); } catch {}
+  if (/dsh web: http|plugin tree failed|did not activate/i.test(log)) break;
+  await new Promise((r) => setTimeout(r, 1000));
+}
+const match = /dsh web: (http:\\S+)/.exec(log);
+const outcome = { log };
+if (match) {
+  try {
+    const r1 = await fetch(match[1], { redirect: "manual" });
+    const setCookie = r1.headers.getSetCookie ? r1.headers.getSetCookie() : [r1.headers.get("set-cookie")];
+    const cookie = setCookie.filter(Boolean).map((c) => c.split(";")[0]).join("; ");
+    const r2 = await fetch("http://127.0.0.1:3080/", { headers: { cookie } });
+    outcome.html = await r2.text();
+  } catch (error) {
+    outcome.fetchError = String(error);
+  }
+}
+console.log("__RESULT__" + JSON.stringify(outcome));
+' '${logPath}' '${pkgName}'`,
+    { timeout: 150000 },
+  )
+  const marker = '__RESULT__'
+  const idx = probe.stdout.lastIndexOf(marker)
+  if (idx < 0) return { output: probe.stdout + probe.stderr, html: '', probeError: probe.stderr.trim() }
+  try {
+    const outcome = JSON.parse(probe.stdout.slice(idx + marker.length).trim())
+    return { output: outcome.log ?? '', html: outcome.html ?? '', fetchError: outcome.fetchError }
+  } catch {
+    return { output: probe.stdout + probe.stderr, html: '', probeError: 'failed to parse boot result' }
+  }
+}

--- a/benchmark/tasks/S15-slot-error-boundary-crash/tests/judge.mjs
+++ b/benchmark/tasks/S15-slot-error-boundary-crash/tests/judge.mjs
@@ -1,0 +1,53 @@
+// S15-slot-error-boundary-crash grading: fixture read-only gate + five diagnosis aspects.
+// Expected (dangling identifier + short-circuit latency + slot error boundary):
+//   1. Root cause: the remove button's disabled: A || busy throws ReferenceError (busy
+//      is AttachButton's state, not in scope); only evaluated when the phase guard is
+//      false AND a chip renders; the slot error boundary unmounts the whole entry so
+//      the symptom is 'the dock vanished', error only in the browser console.
+//   2. Attribution: the v0.2.11 diff merely first exercised the pre-existing line;
+//      correct bisect = rollback/re-add or minimal render mount; the same line shipped
+//      in v0.2.10.
+//   3. Fix: drop the dangling reference (scope any busy-like state locally); harden
+//      with ?? [] reads and closest?.()
+//   4. Regression: a render smoke WITH an occurrence present (empty dock returns null
+//      before the throwing line; empty-state tests cannot catch this class).
+//   5. Process: node --check cannot catch free identifiers; lib-only slot plugins need
+//      a data-present render smoke per slot component (and no-undef lint as a net).
+import { emit, fixtureChanges, readAgentText } from './judge-utils.mjs'
+
+const TASK = 'S15-slot-error-boundary-crash'
+
+const ASPECTS = [
+  { key: 'root cause: free identifier busy (other component scope) + || short-circuit latency + chip-present condition', pattern: /(busy|free identifier|out of[- ]scope|another component)[\s\S]{0,300}(ReferenceError|not defined|throws?|undeclared)/i, points: 20 },
+  { key: 'slot error boundary unmounts the whole entry; console-only visibility; symptom is the vanished dock', pattern: /error[- ]boundary[\s\S]{0,300}(unmount|whole|entire|slot|entry|swallow|silent)|console[\s\S]{0,200}(only|visible|never open)/i, points: 20 },
+  { key: 'attribution: pre-existing line first exercised by the new feature; bisect via rollback or minimal render mount', pattern: /(pre-?existing|latent|v0\.2\.10|shipped in)[\s\S]{0,260}(same|already|first|exercis|trigger)|(rollback|revert|minimal render|bisect)/i, points: 20 },
+  { key: 'fix + hardening: remove dangling ref (scope locally), ?? [] reads, closest?.()', pattern: /(remove|drop|delete|eliminate)[\s\S]{0,200}(dangling|busy|reference|identifier)|(\?\? \[\])|(closest\?\.)/i, points: 20 },
+  { key: 'regression + process: data-present render smoke (empty state returns null early); node --check insufficient; no-undef', pattern: /(render smoke|mount)[\s\S]{0,280}(occurrence|chip|data|present|with data)|empty[\s\S]{0,200}(returns? null|early|cannot)|(no-undef|lint)[\s\S]{0,160}(catch|flag|free identifier)?/i, points: 20 },
+]
+
+main().catch((error) => emit(0, ['judge error: ' + error.message]))
+
+async function main() {
+  const reasons = []
+  const gate = await fixtureChanges('fixture')
+  if (gate.changed === true) {
+    emit(0, ['fixture was modified, 0 points for this task (read-only discipline): ' + gate.detail])
+  }
+  if (gate.changed === null) reasons.push('warning: ' + gate.detail)
+  else reasons.push('fixture unchanged (read-only discipline passed)')
+  const { text, files } = readAgentText('', TASK)
+  if (!text.trim()) {
+    emit(0, [...reasons, 'no report found under /app/agent-output/' + TASK + '/, treated as 0 points'])
+  }
+  reasons.push('read agent report: ' + files.join(', '))
+  let score = 0
+  for (const aspect of ASPECTS) {
+    if (aspect.pattern.test(text)) {
+      score += aspect.points
+      reasons.push('hit aspect: ' + aspect.key + ' (+' + aspect.points + ')')
+    } else {
+      reasons.push('missing aspect: ' + aspect.key + ' (-' + aspect.points + ')')
+    }
+  }
+  emit(score, reasons)
+}

--- a/benchmark/tasks/S15-slot-error-boundary-crash/tests/test.sh
+++ b/benchmark/tasks/S15-slot-error-boundary-crash/tests/test.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Harbor verifier: run judge.mjs (its last line outputs a 0-100 score JSON), normalized to a 0~1 reward.
+# judge itself always exits 0; when no JSON can be parsed, treat the score as 0 (error-tolerant principle).
+mkdir -p /logs/verifier
+node /tests/judge.mjs > /tmp/judge.out 2>&1
+cat /tmp/judge.out
+node -e '
+const fs = require("node:fs");
+const lines = fs.readFileSync("/tmp/judge.out", "utf8").trim().split("\n").filter(Boolean);
+let score = 0;
+for (let i = lines.length - 1; i >= 0; i -= 1) {
+  try {
+    const j = JSON.parse(lines[i]);
+    if (typeof j.score === "number" && typeof j.max === "number") { score = j.score; break }
+  } catch {}
+}
+const reward = Math.max(0, Math.min(1, score / 100));
+fs.writeFileSync("/logs/verifier/reward.txt", String(reward) + "\n")
+'

--- a/skills/plugin-runtime-debug/SKILL.md
+++ b/skills/plugin-runtime-debug/SKILL.md
@@ -59,6 +59,34 @@ cover most incidents:
   a fetched remote value as ground truth when it can be older than the
   running build; decide "current vs update" against the running version and
   display the newer of the two.
+- **A whole slot's UI silently vanishes after a release** — a throwing
+  expression inside a slot component (classically a dangling identifier:
+  another component's state variable referenced out of scope) is caught by
+  the framework's slot-level error boundary, which unmounts the entire
+  entry; the error is console-only, so users just report "the chips/panel
+  are gone". Two latency mechanisms hide it from the author: an `||`
+  short-circuit keeps the expression unevaluated until the left operand is
+  false, and components that early-return on the empty state never evaluate
+  it until real data renders. Do not blame the newest diff by default —
+  bisect by rollback or a minimal render mount with data present, check
+  whether the throwing line shipped earlier, and fix by removing the
+  reference (scope any such state locally). Cheap hardening for slot
+  components: defensive reads (`x?.items ?? []`) and optional-chained DOM
+  access (`target.closest?.()`) — inside an error boundary any throw costs
+  the whole slot.
+- **Repo edits never reach the GUI / EBUSY under the profile's node_modules** —
+  first determine the install mode: `Get-Item <profile>/node_modules/<pkg> |
+  Select LinkType, Target` (or the `link:<path>` marker in cordis.patch.yml).
+  A Junction/link install means the repo working tree IS the installed copy —
+  no copy step exists or is needed, and Copy-Item into node_modules is a
+  no-op at best. The EBUSY holder is the running dsh host process (closing
+  the browser does not release it), and the browser can still serve a cached
+  client bundle after the host restarts. Activation for a link-installed
+  lib-only plugin: fully stop the host, restart `dsh web`, hard-refresh,
+  then verify the loaded version marker. Never rename-aside files under an
+  unresolved path: through a junction "two" directories are one, and the
+  rename moves the only copy.
+
 
 ## Workflow
 


### PR DESCRIPTION
## 变更摘要

新增两道静态考题（任务 45–46）+ 扩充 plugin-runtime-debug 技能，全部取材自一次真实的
2026-09-03 dsh-paste-input v0.1.17 发布排障会话：

> **叠栈说明**：本分支基于 #137（S12/S13，任务 43–44）的 `feat/s12-s13-upgrade-traps`，
> 因此 diff 里包含 #137 那个 commit。跨 fork 无法把 base 指向上游不存在的分支；请先合并
> #137，本 PR 会自动落到 main，之后只余 S14/S15 两个任务的增量。若 #137 需要返工，
> 我会同步 rebase。

### S14-link-install-lock-trap（静态 · link 安装文件锁陷阱）

仓库里改完 lib-only 插件，浏览器刷新看不到新代码；Copy-Item 进 profile 的 node_modules
吃 EBUSY；rename-aside 抢救后「两个目录」都没了入口文件（junction 下实为同一目录）。考察：
Junction/link 安装的部署语义（仓库工作树就是安装副本，复制既不需要也有害）、两把锁的正确
归因（EBUSY 持有者是运行中的 dsh 宿主进程，关浏览器无效；浏览器缓存 client bundle 需要
硬刷新）、rename-aside 事故机理与安全恢复、正确激活顺序（完全停宿主 → 重启 → 硬刷新 →
验证版本标记）、动文件前先判别安装模式（LinkType/Target、patch.yml 的 link: 标记）。

### S15-slot-error-boundary-crash（静态 · 悬空标识符整槽静默崩溃）

功能发布后待发送附件 dock 整体消失：删除按钮的 `disabled: A || busy` 引用了别的组件的
state，仅当 chip 渲染且短路打开时求值抛 ReferenceError，槽位级错误边界把整个条目卸载、
错误只在 console。考察：根因链（自由标识符 + 短路潜伏 + 空态提前 return 测不到）、正确
归因（不先怪最新 diff；rollback / 带数据最小渲染挂载二分）、修复 + 加固（删除悬空引用、
`?? []` 防御读、`closest?.()`）、回归设计（**带 occurrence 数据**的渲染冒烟——空态在
抛错行之前就返回了）、流程教训（`node --check` 抓不住自由标识符；lib-only 槽位插件至少
每组件一条带数据渲染冒烟；no-undef 兜底）。

### 技能与文档

- skills/plugin-runtime-debug 新增两个症状族：「整槽 UI 发布后静默消失」「仓库改动不生效 /
  profile node_modules 下 EBUSY」
- benchmark/README.md：44 → 46 任务（表格 + 计数四处）

## 验证

- 两题 judge 的 ASPECTS 正则对各自参考报告本地打分 **100/100**（脚本抽取 ASPECTS 直测）
- `node --check` 通过（两个 judge.mjs）
- 完整 Harbor 校验（`harbor run -p ... -a oracle`）需容器环境，与既有 S 系列任务同构
  （judge-utils/判分结构逐行对照 S10 模板）

## 关联

- 叠栈于 #137；出处为 dsh-paste-input v0.1.17（悬停预览发布验证会话），插件与组件名已改写
