### PR TITLE
docs(paper): add Tongtao Wang as co-author

### DIFF
--- a/paper/latex/acl_latex.tex
+++ b/paper/latex/acl_latex.tex
@@ -86,7 +86,11 @@
   \And
   Yucheng Xia \\
   Harbin Engineering University \\
-  \texttt{Fisfzy@qq.com} \\}
+  \texttt{Fisfzy@qq.com} \\
+  \And
+  Tongtao Wang \\
+  Independent Researcher \\
+  \texttt{tongtao.wang@gmail.com} \\}
 
 \begin{document}
 \maketitle


### PR DESCRIPTION
## Summary

Adds an author entry to the ACL author block in `paper/latex/acl_latex.tex`, following the maintainer's request that contributors submit their names. Appended after the existing entries with the same `\And` separator; single file, five added lines, no other change.

- **Tongtao Wang** — Independent Researcher — `tongtao.wang@gmail.com`

Contribution context (`@TT-Wang`):

- #92 — pre-flight step 1.5 (ghost host: an in-place upgrade leaves the running process on the old wire while the disk reports the new version) and the raw-client field note on `DSH-0.1.2-A1-08`.
- #94 — `scripts/ghost-host-check.mjs`, the executable form of that step (process start time vs checkout change, argv resolution through symlinks, unauthenticated-probe classification), wired into `scripts/validate.mjs` with its own check file.
- #95 — plugin-test: same-payload in-place re-verification section.
- #101 — benchmark task H13-ghost-host-trap: a real ghost built inside the container (rc.2 process + in-place npm upgrade to alpha.2), judge with git-based ops integrity check, oracle/naive/tamper controls.
- #116 — the alpha.3 → alpha.4 corridor: six cards (`DSH-0.1.2-A4-01…06`) and the three-host verification record that the alpha.4 Windows fleet evidence was later added to.
- #146 (open) — the alpha.4 → alpha.5 and alpha.5 → rc.1 corridors, with real-host records.

Note: as with #117, the document builds with `\usepackage[review]{acl}`, under which the author block renders as "Anonymous ACL submission"; the entry appears once the option is switched to `final` or `preprint`.

## Scope Checklist

- [x] I checked existing Issues and PRs for overlap and coordinated any related work (the other open co-author PRs each append their own entry; this one appends after the currently merged entries).
- [x] The change is limited to the `\author{}` block; no version-specific claims.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
