### PR TITLE
fix(benchmark): point H21 snapshot at the reachable squash commit

### DIFF
--- a/benchmark/snapshots/2026-09-03-h21-question-answerer.json
+++ b/benchmark/snapshots/2026-09-03-h21-question-answerer.json
@@ -4,7 +4,7 @@
   "createdAt": "2026-09-03",
   "repository": "oh-my-dsh/dsh-plugin-upgrade-skill",
   "benchmark": {
-    "commit": "6e5916a407c366e3cc9ac00474fcbd535e7e19d6",
+    "commit": "dd0f39629904e357db8b63602cc69fa298383eec",
     "taskCount": 43,
     "tasks": [
       "S1-static-scan",


### PR DESCRIPTION
Main CI went red after #150 was squash-merged: `benchmark/snapshots/2026-09-03-h21-question-answerer.json` referenced the pre-squash PR head `6e5916a`, which no longer exists on main, so `validate-evaluation-snapshots.mjs` fails on any fresh clone.

Repoint `benchmark.commit` to the squash commit `dd0f396` (same task content, reachable from main). Verified locally: `node benchmark/scripts/validate-evaluation-snapshots.mjs` passes.