### PR TITLE
docs(plugin-release): baked version constants — rebuild before tagging (pdm section 11)

### DIFF
--- a/skills/plugin-release/references/profile-dependency-management.md
+++ b/skills/plugin-release/references/profile-dependency-management.md
@@ -164,3 +164,38 @@ Keep one prompt template across a plugin family (only the package spec and repo 
 fix to the routing wording ships once and every plugin's next release carries it. This is a
 documentation-in-code contract: treat prompt wording changes like behavior changes — bump, release,
 and let the chip distribute them.
+
+## 11. Version constants baked at build time: rebuild before tagging, or the tag lies about itself
+
+**Symptom**: right after publishing `vX.Y.Z+1`, a consumer on the *latest* install clicks the
+plugin's update chip, installs the new tag, and the chip **still** offers an update to
+`vX.Y.Z+1`. The README matrix, the git tag, and `package.json` all say the new version; only the
+running plugin disagrees. (Real case: dsh-file-trace v0.3.1, 2026-09-04 — the update chip kept
+prompting immediately after the release was pushed.)
+
+**Root cause**: the plugin reads its version via `import pkg from '../../package.json'` in
+**source**, but what ships is the **built bundle** (`lib/client.js`): the bundler replaces the
+import at build time and bakes the then-current version string into the artifact. Bumping
+`package.json` and tagging **without rebuilding** publishes a tag whose manifest says
+`X.Y.Z+1` while its artifact still carries `X.Y.Z` — a self-inconsistent tag. Every
+version-comparison surface that reads the artifact (update chip, about panel, diagnostics) now
+compares old-against-new and reports an update forever. This bites hardest for repos that commit
+build outputs (`lib/` tracked in git) precisely because "just bump the manifest" *looks* like a
+complete doc-only release.
+
+**Fix** — make the artifact part of the release, not an afterthought:
+
+1. **Bump → rebuild → commit together**: change `package.json`, run the full build, and commit
+   manifest + rebuilt artifacts in the same commit before tagging. For a doc-only release the
+   rebuilt bundle is the *only* functional change — it is the release.
+2. **Gate**: grep the built artifact for the new version string before tagging
+   (`grep -o 'X\.Y\.Z' lib/client.js` or equivalent). No match → no tag.
+3. **Recovery for an already-pushed inconsistent tag**: rebuild, amend the release commit (or add
+   a fix commit), re-point the tag, and force-push **branch and tag with an explicit lease**
+   (`--force-with-lease=refs/heads/<branch>:<old-sha>`, `git push -f <remote> vX.Y.Z`) to every
+   mirror, then verify each mirror's tag target SHA. Acceptable only while the tag is fresh enough
+   that consumers pinning it are known; otherwise cut `X.Y.Z+2`.
+
+Related: Section 9 (the re-pointed tag must land on **every** mirror) and Section 10 (the update
+chip is the surface where this bug becomes user-visible — a chip that never clears is this section's
+signature symptom, not a prompt-wording problem).

--- a/skills/plugin-release/references/profile-dependency-management.md
+++ b/skills/plugin-release/references/profile-dependency-management.md
@@ -188,13 +188,27 @@ complete doc-only release.
 1. **Bump → rebuild → commit together**: change `package.json`, run the full build, and commit
    manifest + rebuilt artifacts in the same commit before tagging. For a doc-only release the
    rebuilt bundle is the *only* functional change — it is the release.
-2. **Gate**: grep the built artifact for the new version string before tagging
-   (`grep -o 'X\.Y\.Z' lib/client.js` or equivalent). No match → no tag.
-3. **Recovery for an already-pushed inconsistent tag**: rebuild, amend the release commit (or add
-   a fix commit), re-point the tag, and force-push **branch and tag with an explicit lease**
-   (`--force-with-lease=refs/heads/<branch>:<old-sha>`, `git push -f <remote> vX.Y.Z`) to every
-   mirror, then verify each mirror's tag target SHA. Acceptable only while the tag is fresh enough
-   that consumers pinning it are known; otherwise cut `X.Y.Z+2`.
+2. **Gate**: extract the version constant actually consumed by the update check from the built
+   artifact (or read it by executing the bundle in an isolated test harness), and require exact
+   string equality with `package.json.version`, including prerelease and build metadata. A missing,
+   ambiguous, or mismatched value blocks tagging. A whole-bundle grep is insufficient: `0.3.1`
+   also matches `0.3.1-rc.1`, and a dependency's version does not identify the plugin's version.
+3. **Recovery for an already-pushed inconsistent tag**: record each mirror's current branch and
+   tag ref OIDs before the repair. Rebuild, amend the release commit (or add a fix commit), and
+   re-point the tag. Push the intended branch and tag together with **separate explicit leases**:
+
+   ```sh
+   git push --atomic \
+     --force-with-lease=refs/heads/<branch>:<old-branch-oid> \
+     --force-with-lease=refs/tags/<tag>:<old-tag-oid> \
+     <remote> refs/heads/<branch>:refs/heads/<branch> refs/tags/<tag>:refs/tags/<tag>
+   ```
+
+   Use the OIDs recorded for that mirror; for an annotated tag, the lease needs the tag object's
+   OID, not its peeled commit SHA. If a lease fails, stop and inspect the concurrent change; do
+   not retry with `-f`. Repeat for every mirror, then verify each mirror's branch and tag target
+   SHAs. Acceptable only while the tag is fresh enough that consumers pinning it are known;
+   otherwise cut `X.Y.Z+2`.
 
 Related: Section 9 (the re-pointed tag must land on **every** mirror) and Section 10 (the update
 chip is the surface where this bug becomes user-visible — a chip that never clears is this section's


### PR DESCRIPTION
## Summary

Adds **Section 11** to `plugin-release/references/profile-dependency-management.md`: version constants baked at build time require a rebuild before tagging.

- **Symptom**: the in-plugin update chip keeps offering an update even on the just-installed latest tag (real case: dsh-file-trace v0.3.1, 2026-09-04).
- **Root cause**: `import pkg from '../../package.json'` is resolved at **build time** — the published bundle (`lib/client.js`) carries the version string from the last build. Tagging after a manifest-only bump ships a self-inconsistent tag: manifest says new, artifact says old. Worst for repos that commit build outputs, because a "doc-only" bump *looks* complete.
- **Fix**: bump → rebuild → commit manifest+artifacts together; grep the built artifact for the new version as a pre-tag gate; recovery recipe for an already-pushed inconsistent tag (amend, re-point tag, explicit-lease force-push to every mirror, verify each mirror's tag SHA).
- Cross-links Sections 9 (tag exists on every mirror) and 10 (the never-clearing update chip is this bug's signature symptom, not a prompt-wording problem).

Found while riding the six-plugin 0.1.2 train to rc.1 (see #156, which references this entry).
