### PR TITLE
fix(judge): M11/M12 cohort check wrongly includes cordis — perfect migrations capped at 40

### DIFF
--- a/benchmark/tasks/M11-sidebar-spur/tests/judge.mjs
+++ b/benchmark/tasks/M11-sidebar-spur/tests/judge.mjs
@@ -240,7 +240,7 @@ function scoreStatic() {
 
   // (e) the peer cohort.
   const peers = pkg.peerDependencies ?? {}
-  const dshPeers = Object.entries(peers).filter(([k]) => k.startsWith('@deepseek-ai/'))
+  const dshPeers = Object.entries(peers).filter(([k]) => k.startsWith('@deepseek-ai/dsh-'))
   const offCohort = dshPeers.filter(([, v]) => !ALPHA_COHORT.test(String(v)))
   if (dshPeers.length > 0 && offCohort.length === 0) {
     score += 8

--- a/benchmark/tasks/M12-interpreters-card/tests/judge.mjs
+++ b/benchmark/tasks/M12-interpreters-card/tests/judge.mjs
@@ -235,7 +235,7 @@ function scoreStatic() {
 
   // (e) the peer cohort.
   const peers = pkg.peerDependencies ?? {}
-  const dshPeers = Object.entries(peers).filter(([k]) => k.startsWith('@deepseek-ai/'))
+  const dshPeers = Object.entries(peers).filter(([k]) => k.startsWith('@deepseek-ai/dsh-'))
   const offCohort = dshPeers.filter(([, v]) => !ALPHA_COHORT.test(String(v)))
   if (dshPeers.length > 0 && offCohort.length === 0) {
     score += 10


### PR DESCRIPTION
The peers filter in M11/M12 matched every `@deepseek-ai/*` package. cordis sits at `^4.0.1` — a 4.x semver — so it never matches the `0.1.2-alpha` cohort regex, and both tasks get capped at 40 forever via `Math.min(score, 40)`.

The reference solution hits the same cap: run the oracle package set through this check and cordis is the only "off-cohort" entry. In other words, **even a perfect migration cannot score above 0.4 on these two tasks**.

Fix: filter on `@deepseek-ai/dsh-`, exactly what M9 and the other tasks already do.

Verified in-container with the oracle `package.json`: after the fix the cohort check passes — the only remaining score deltas are agent-side, not judge-side.