### PR TITLE
fix(audit): attribute shared-root sibling skill reads

### DIFF
--- a/benchmark/docs/skill-activation-audit.md
+++ b/benchmark/docs/skill-activation-audit.md
@@ -26,7 +26,7 @@ be the observed content-bearing access to the target `SKILL.md`, not reward.
 | **skill discovered** | The agent observed the skill's existence — an `ls`/`find`/`stat`/`test`/`glob` operand or any tool output text naming the target. Discovery is not use. |
 | **skill opened** | At least one content-bearing access to the target `SKILL.md` (the **primary activation metric**). |
 | **reference accessed** | Content access to a file under the target skill's `references/`. Reading a reference does **not** upgrade `opened`. |
-| **other skill accessed** | Content access to files under other skill roots from the same catalog. Reported observationally (`observed_other_skill_access`); never a causal verdict. |
+| **other skill accessed** | Content access to files under other skill roots from the same catalog. Reported observationally (`observed_other_skill_access`); never a causal verdict. Sibling skill accesses count even when they share the target's catalog root. Nested catalog roots use the most specific matching root. |
 | **activation rate** | `opened` trials divided by `supplied` (eligible) trials. Eligibility is always stated in the output. |
 
 Prose mentions never count: the assistant writing "I should read

--- a/benchmark/scripts/audit-skill-activation.mjs
+++ b/benchmark/scripts/audit-skill-activation.mjs
@@ -448,17 +448,21 @@ export function auditTrial({ trialDir, targetName, targetPaths, condition, basel
           }
           continue
         }
-        // Other skill roots from the same catalog (excluding the target root).
+        // Catalog roots may contain both the target and sibling skills.
         const resolved = candidate.startsWith('/') ? normalizePath(candidate) : joinLexical(item.workdir ?? '/', candidate)
-        for (const [rootId, rootPath] of parsedSkills.roots) {
+        let matchingRoot = null
+        for (const rootPath of parsedSkills.roots.values()) {
           const normalizedRoot = normalizePath(rootPath)
-          const isTargetRoot = targetRoots.some((root) => root.path === normalizedRoot || normalizedRoot.startsWith(root.path + '/') || root.path.startsWith(normalizedRoot + '/'))
-          if (isTargetRoot) continue
-          if (resolved.startsWith(normalizedRoot + '/')) {
-            const name = resolved.slice(normalizedRoot.length + 1).split('/')[0]
-            if (!otherSkillFiles.has(name)) otherSkillFiles.set(name, new Set())
-            otherSkillFiles.get(name).add(resolved.slice(normalizedRoot.length + 1))
+          if (resolved.startsWith(normalizedRoot + '/') &&
+              (matchingRoot === null || normalizedRoot.length > matchingRoot.length)) {
+            matchingRoot = normalizedRoot
           }
+        }
+        if (matchingRoot !== null) {
+          const relativePath = resolved.slice(matchingRoot.length + 1)
+          const name = relativePath.split('/')[0]
+          if (!otherSkillFiles.has(name)) otherSkillFiles.set(name, new Set())
+          otherSkillFiles.get(name).add(relativePath)
         }
       }
     } else if (item.kind === 'discovery') {

--- a/benchmark/scripts/audit-skill-activation.test.mjs
+++ b/benchmark/scripts/audit-skill-activation.test.mjs
@@ -325,6 +325,102 @@ test('baseline other-skill access is observational, reported only under the base
   assert.equal(withSkill.baselineHasOtherSkillAccess, false)
 })
 
+// ── shared-root regression: target and sibling under the same catalog root ────
+
+function withSharedRootSkills() {
+  return skillsText({
+    roots: { r0: '/root/.agents/skills' },
+    skills: [
+      { name: 'plugin-upgrade', rootId: 'r0', rel: 'plugin-upgrade/SKILL.md', desc: 'Inspect or upgrade installed DSH plugins' },
+      { name: 'imagegen', rootId: 'r0', rel: 'imagegen/SKILL.md', desc: 'Generate images' },
+    ],
+  })
+}
+
+test('shared-root sibling skill read: otherSkills.opened with the sibling name, target untouched', () => {
+  const { trialDir } = initTrial()
+  writeTrialWithEvents(trialDir, {
+    skills: withSharedRootSkills(),
+    events: [execLine(3, 'cat /root/.agents/skills/imagegen/SKILL.md', '/app')],
+  })
+  const result = runAudit(trialDir)
+  assert.equal(result.targetSkill.opened, false)
+  assert.equal(result.otherSkills.opened, true)
+  assert.deepEqual(result.otherSkills.skills, ['imagegen'])
+})
+
+test('shared-root exact target not mis-attributed as other: opened remains true, otherSkills stays false', () => {
+  const { trialDir } = initTrial()
+  writeTrialWithEvents(trialDir, {
+    skills: withSharedRootSkills(),
+    events: [execLine(2, 'cat /root/.agents/skills/plugin-upgrade/SKILL.md', '/app')],
+  })
+  const result = runAudit(trialDir)
+  assert.equal(result.targetSkill.opened, true)
+  assert.equal(result.otherSkills.opened, false)
+})
+
+test('shared-root path-prefix sibling name does not match target', () => {
+  const { trialDir } = initTrial()
+  writeTrialWithEvents(trialDir, {
+    skills: skillsText({
+      roots: { r0: '/root/.agents/skills' },
+      skills: [
+        { name: 'plugin-upgrade', rootId: 'r0', rel: 'plugin-upgrade/SKILL.md', desc: 'Inspect or upgrade installed DSH plugins' },
+        { name: 'plugin-upgrade-extra', rootId: 'r0', rel: 'plugin-upgrade-extra/SKILL.md', desc: 'Extra plugin tools' },
+      ],
+    }),
+    events: [execLine(3, 'cat /root/.agents/skills/plugin-upgrade-extra/SKILL.md', '/app')],
+  })
+  const result = runAudit(trialDir)
+  assert.equal(result.targetSkill.opened, false, 'plugin-upgrade-extra should not match target plugin-upgrade')
+  assert.equal(result.otherSkills.opened, true)
+  assert.deepEqual(result.otherSkills.skills, ['plugin-upgrade-extra'])
+})
+
+test('shared-root baseline other-skill is observational', () => {
+  const { trialDir } = initTrial()
+  writeTrialWithEvents(trialDir, {
+    skills: withSharedRootSkills(),
+    events: [execLine(3, 'cat /root/.agents/skills/imagegen/SKILL.md', '/app')],
+  })
+  const baseline = runAudit(trialDir, { condition: 'no-target-skill' })
+  assert.equal(baseline.baselineHasOtherSkillAccess, true)
+  assert.equal(baseline.targetSkill.opened, false)
+  const withSkill = runAudit(trialDir, { condition: 'with-skill' })
+  assert.equal(withSkill.baselineHasOtherSkillAccess, false)
+})
+
+test('shared-root relative operand with explicit target-path: sibling still detected', () => {
+  const { trialDir } = initTrial()
+  writeTrialWithEvents(trialDir, {
+    skills: withSharedRootSkills(),
+    events: [execLine(3, 'cat imagegen/SKILL.md', '/root/.agents/skills')],
+  })
+  const result = runAudit(trialDir, { targetPaths: ['plugin-upgrade'] })
+  assert.equal(result.targetSkill.opened, false)
+  assert.equal(result.otherSkills.opened, true)
+  assert.deepEqual(result.otherSkills.skills, ['imagegen'])
+})
+
+
+test('nested catalog roots attribute a sibling only to its most specific root', () => {
+  const { trialDir } = initTrial()
+  writeTrialWithEvents(trialDir, {
+    skills: skillsText({
+      roots: { r0: '/root/.agents/skills', r1: '/root/.agents/skills/.system' },
+      skills: [
+        { name: 'plugin-upgrade', rootId: 'r0', rel: 'plugin-upgrade/SKILL.md' },
+        { name: 'imagegen', rootId: 'r1', rel: 'imagegen/SKILL.md' },
+      ],
+    }),
+    events: [execLine(3, 'cat /root/.agents/skills/.system/imagegen/SKILL.md', '/app')],
+  })
+  const result = runAudit(trialDir)
+  assert.equal(result.targetSkill.opened, false)
+  assert.deepEqual(result.otherSkills.skills, ['imagegen'])
+})
+
 test('unrelated SKILL.md with the same basename never counts', () => {
   const { trialDir } = initTrial()
   writeTrialWithEvents(trialDir, { events: [execLine(2, 'cat /app/other/SKILL.md', '/app')] })


### PR DESCRIPTION
The skill-activation auditor excludes an entire catalog root when that root contains the target skill. If a sibling skill shares the root, reading its files is consequently omitted from `otherSkills` and the baseline observation.

Keep target-file classification first, then attribute other reads to the most specific matching catalog root. This detects sibling accesses under a shared root and avoids reporting an intermediate directory such as `.system` as an extra skill when catalog roots are nested.

Regression coverage includes shared-root siblings, exact target exclusion, prefix-similar names, baseline observation, relative operands, and nested roots. Documentation keeps these results as content-access observations, not evidence of skill-following or causal improvement.

Validation:
- Four shared-root regressions fail against the original auditor.
- The nested-root case fails against the initial candidate and passes after selecting the most specific root.
- `node --test benchmark/scripts/audit-skill-activation.test.mjs`: 50 tests pass.
- `node scripts/validate.mjs` and `node scripts/validate-manifests.mjs`: pass.
- `npm test`: pass.
- `git diff --check`: pass.

Tests use synthetic trajectories matching the supported format; no real-model run or experimental-result recalculation is claimed.
